### PR TITLE
Added 'praqma' (jenkins-wiki user) to access list

### DIFF
--- a/permissions/plugin-clearcase-ucm-plugin.yml
+++ b/permissions/plugin-clearcase-ucm-plugin.yml
@@ -6,3 +6,4 @@ paths:
 - "org/jvnet/hudson/plugins/clearcase-ucm-plugin"
 developers:
 - "madsnielsen"
+- "praqma"

--- a/permissions/plugin-config-rotator.yml
+++ b/permissions/plugin-config-rotator.yml
@@ -4,3 +4,4 @@ paths:
 - "net/praqma/config-rotator"
 developers:
 - "madsnielsen"
+- "praqma"


### PR DESCRIPTION
I've added the user 'praqma' to both ClearCaseUCM plugin and ConfigRotator plugin. This user does not have a github account, but he has upload permissions. 
