### PR TITLE
Remove obsolete paths as workaround for INFRA-905

### DIFF
--- a/permissions/component-deployment-sphere.yml
+++ b/permissions/component-deployment-sphere.yml
@@ -1,8 +1,6 @@
 ---
 name: "deployment-sphere"
 paths:
-- "com/epam/jenkins/deployment-sphere/deployment-sphere"
-- "org/jenkins/plugins/deployment-sphere"
 - "org/jenkins-ci/plugins/deployment-sphere"
 developers:
 - "webdizz"

--- a/permissions/component-maven-agent.yml
+++ b/permissions/component-maven-agent.yml
@@ -2,8 +2,6 @@
 name: "maven-agent"
 paths:
 - "org/jenkins-ci/main/maven/maven-agent"
-- "org/jenkins-ci/main/maven-agent"
-- "org/jvnet/hudson/main/maven-agent"
 developers:
 - "kutzi"
 - "ndeloof"

--- a/permissions/component-maven-interceptor.yml
+++ b/permissions/component-maven-interceptor.yml
@@ -2,8 +2,6 @@
 name: "maven-interceptor"
 paths:
 - "org/jenkins-ci/main/maven/maven-interceptor"
-- "org/jenkins-ci/main/maven-interceptor"
-- "org/jvnet/hudson/main/maven-interceptor"
 developers:
 - "kutzi"
 - "ndeloof"

--- a/permissions/component-maven3-agent.yml
+++ b/permissions/component-maven3-agent.yml
@@ -2,8 +2,6 @@
 name: "maven3-agent"
 paths:
 - "org/jenkins-ci/main/maven/maven3-agent"
-- "org/jenkins-ci/main/maven3-agent"
-- "org/jvnet/hudson/main/maven3-agent"
 developers:
 - "kutzi"
 - "ndeloof"

--- a/permissions/component-maven3-interceptor.yml
+++ b/permissions/component-maven3-interceptor.yml
@@ -2,8 +2,6 @@
 name: "maven3-interceptor"
 paths:
 - "org/jenkins-ci/main/maven/maven3-interceptor"
-- "org/jenkins-ci/main/maven3-interceptor"
-- "org/jvnet/hudson/main/maven3-interceptor"
 developers:
 - "kutzi"
 - "ndeloof"

--- a/permissions/plugin-DotCi-Plugins-Starter-Pack.yml
+++ b/permissions/plugin-DotCi-Plugins-Starter-Pack.yml
@@ -1,7 +1,6 @@
 ---
 name: "DotCi-Plugins-Starter-Pack"
 paths:
-- "com/groupon/jenkins/plugins/DotCi-Plugins-Starter-Pack"
 - "com/groupon/jenkins-ci/plugins/DotCi-Plugins-Starter-Pack"
 developers:
 - "surya548"

--- a/permissions/plugin-JiraTestResultReporter.yml
+++ b/permissions/plugin-JiraTestResultReporter.yml
@@ -1,7 +1,6 @@
 ---
 name: "JiraTestResultReporter"
 paths:
-- "com/maplesteve/jenkins-ci/plugins/JiraTestResultReporter"
 - "org/jenkins-ci/plugins/JiraTestResultReporter"
 developers:
 - "andreituicu"

--- a/permissions/plugin-Office-365-Connector.yml
+++ b/permissions/plugin-Office-365-Connector.yml
@@ -1,7 +1,6 @@
 ---
 name: "Office-365-Connector"
 paths:
-- "jenkins/plugins/office365connector/Office-365-Connector"
 - "org/jenkins-ci/plugins/Office-365-Connector"
 developers:
 - "outconn"

--- a/permissions/plugin-build-monitor-plugin.yml
+++ b/permissions/plugin-build-monitor-plugin.yml
@@ -1,7 +1,6 @@
 ---
 name: "build-monitor-plugin"
 paths:
-- "com/smartcodeltd/jenkins-ci/plugins/build-monitor-plugin"
 - "org/jenkins-ci/plugins/build-monitor-plugin"
 developers:
 - "janmolak"

--- a/permissions/plugin-build-pipeline-plugin.yml
+++ b/permissions/plugin-build-pipeline-plugin.yml
@@ -1,9 +1,7 @@
 ---
 name: "build-pipeline-plugin"
 paths:
-- "au/com/centrumsystems/build-pipeline-plugin"
 - "org/jenkins-ci/plugins/build-pipeline-plugin"
-- "org/jvnet/hudson/plugins/build-pipeline-plugin"
 developers:
 - "dalvizu"
 - "geoffbullen"

--- a/permissions/plugin-clearcase-ucm-plugin.yml
+++ b/permissions/plugin-clearcase-ucm-plugin.yml
@@ -1,8 +1,6 @@
 ---
 name: "clearcase-ucm-plugin"
 paths:
-- "net/praqma/clearcase-ucm-plugin"
 - "org/jenkins-ci/plugins/clearcase-ucm-plugin"
-- "org/jvnet/hudson/plugins/clearcase-ucm-plugin"
 developers:
 - "madsnielsen"

--- a/permissions/plugin-collapsing-console-sections.yml
+++ b/permissions/plugin-collapsing-console-sections.yml
@@ -2,6 +2,5 @@
 name: "collapsing-console-sections"
 paths:
 - "org/jenkins-ci/plugins/collapsing-console-sections"
-- "org/jvnet/hudson/plugins/collapsing-console-sections"
 developers:
 - "oleg_nenashev"

--- a/permissions/plugin-contrast-continuous-application-security.yml
+++ b/permissions/plugin-contrast-continuous-application-security.yml
@@ -1,7 +1,6 @@
 ---
 name: "contrast-continuous-application-security"
 paths:
-- "com/contrastsecurity/contrast-continuous-application-security"
 - "org/jenkins-ci/plugins/contrast-continuous-application-security"
 developers:
 - "mgelman08"

--- a/permissions/plugin-dependency-check-jenkins-plugin.yml
+++ b/permissions/plugin-dependency-check-jenkins-plugin.yml
@@ -2,6 +2,5 @@
 name: "dependency-check-jenkins-plugin"
 paths:
 - "org/jenkins-ci/plugins/dependency-check-jenkins-plugin"
-- "org/owasp/dependency-check/dependency-check-jenkins-plugin"
 developers:
 - "sspringett"

--- a/permissions/plugin-dropdown-viewstabbar-plugin.yml
+++ b/permissions/plugin-dropdown-viewstabbar-plugin.yml
@@ -2,6 +2,5 @@
 name: "dropdown-viewstabbar-plugin"
 paths:
 - "org/jenkins-ci/plugins/dropdown-viewstabbar-plugin"
-- "org/jvnet/hudson/plugins/dropdown-viewstabbar-plugin"
 developers:
 - "michael1010"

--- a/permissions/plugin-extended-choice-parameter.yml
+++ b/permissions/plugin-extended-choice-parameter.yml
@@ -2,6 +2,5 @@
 name: "extended-choice-parameter"
 paths:
 - "org/jenkins-ci/plugins/extended-choice-parameter"
-- "org/jvnet/hudson/plugins/extended-choice-parameter"
 developers:
 - "vimil"

--- a/permissions/plugin-hp-application-automation-tools-plugin.yml
+++ b/permissions/plugin-hp-application-automation-tools-plugin.yml
@@ -1,7 +1,6 @@
 ---
 name: "hp-application-automation-tools-plugin"
 paths:
-- "hp-application-automation-tools-plugin/hp-application-automation-tools-plugin"
 - "org/jenkins-ci/plugins/hp-application-automation-tools-plugin"
 developers:
 - "mrman"

--- a/permissions/plugin-job-dsl.yml
+++ b/permissions/plugin-job-dsl.yml
@@ -1,8 +1,6 @@
 ---
 name: "job-dsl"
 paths:
-- "job-dsl-plugin-root/job-dsl"
 - "org/jenkins-ci/plugins/job-dsl"
-- "org/jenkinsci/plugins/job-dsl"
 developers:
 - "daspilker"

--- a/permissions/plugin-jobrevision.yml
+++ b/permissions/plugin-jobrevision.yml
@@ -1,7 +1,5 @@
 ---
 name: "jobrevision"
 paths:
-- "com/thalesgroup/jenkins-ci/plugins/jobrevision"
 - "org/jenkins-ci/plugins/jobrevision"
-- "org/jvnet/hudson/plugins/jobrevision"
 developers: []

--- a/permissions/plugin-validating-string-parameter.yml
+++ b/permissions/plugin-validating-string-parameter.yml
@@ -2,6 +2,5 @@
 name: "validating-string-parameter"
 paths:
 - "org/jenkins-ci/plugins/validating-string-parameter"
-- "org/jvnet/hudson/plugins/validating-string-parameter"
 developers:
 - "vlatombe"


### PR DESCRIPTION
Artifactory appears to have a limit of probably (undocumented) 1024 chars (Office-365-Connector had 1026 chars in its `includePattern`, the other affected ones were all longer than that).

Keeps the most recently used path/groupId for a given artifact.

To be merged only if JFrog support has no better solution. Or maybe even then. Do we want to prune obsolete paths?