### PR TITLE
Add MadsNielsen and Praqma to post build task plugin

### DIFF
--- a/permissions/plugin-postbuild-task.yml
+++ b/permissions/plugin-postbuild-task.yml
@@ -2,4 +2,6 @@
 name: "postbuild-task"
 paths:
 - "org/jvnet/hudson/plugins/postbuild-task"
-developers: []
+developers:
+- "madsnielsen"
+- "praqma" 


### PR DESCRIPTION
Im adding this request to adopt the plugin "Hudson Post Build Task" plugin. 

I've added my user MadsNielsen and our automation user Praqma to commit acces.