### PR TITLE
Add oleg_nenashev to release-plugin

### DIFF
--- a/permissions/plugin-release.yml
+++ b/permissions/plugin-release.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jvnet/hudson/plugins/release"
 developers:
 - "avalanche123"
+- "oleg_nenashev"


### PR DESCRIPTION
I'm not a maintainer, but I want to release the version with SECURITY-170 fix (https://github.com/jenkinsci/release-plugin/pull/17) and several other pretty important fixes. Using my Jenkins Core and Security team membership as a justification