### PR TITLE
Allow deployment of blueocean-display-url-plugin

### DIFF
--- a/permissions/plugin-blueocean-display-url.yml
+++ b/permissions/plugin-blueocean-display-url.yml
@@ -1,0 +1,11 @@
+---
+name: "blueocean-display-url"
+paths:
+- "org/jenkins-ci/plugins/blueocean-display-url"
+developers:
+- "michaelneale"
+- "vivek"
+- "tfennelly"
+- "kzantow"
+- "tscherler"
+- "imeredith"


### PR DESCRIPTION
This is to allow the deployment of a the display-url-provider plugin for blueocean by @imeredith

Hopefully I have the details right. 

The plugin: 
https://github.com/jenkinsci/blueocean-display-url-plugin