### PR TITLE
Work around the artifactory length limitation for docker-slaves

### DIFF
--- a/permissions/plugin-docker-slaves.yml
+++ b/permissions/plugin-docker-slaves.yml
@@ -1,8 +1,6 @@
 ---
 name: "docker-slaves"
 paths:
-- "xyz/quoidneufdocker/docker-slaves"
-- "it/dockins/docker-slaves"
 - "io/jenkins/plugins/docker-slaves"
 developers:
 - "ndeloof"


### PR DESCRIPTION
Artifactory restricts the length of certain fields in permission targets (and JFrog rejected my bug), and the current version of docker-slaves hits that limit, therefore the permissions update gets rejected. We need to remove at least one of the paths to make this work again.

@ndeloof Does this work for you like this, or want to retain one of the old paths?

@orrc @batmat @oleg-nenashev 