### PR TITLE
Adding new pipeline-model-api plugin and pipeline-model-parent.

### DIFF
--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-model-api"
+paths:
+- "org/jenkinsci/plugins/pipeline-model-api"
+developers:
+- "abayer"
+- "stephenconnolly"

--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -4,4 +4,5 @@ paths:
 - "org/jenkinsci/plugins/pipeline-model-api"
 developers:
 - "abayer"
+- "oleg_nenashev"
 - "stephenconnolly"

--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
+- "stephenconnolly"

--- a/permissions/pom-pipeline-model-parent.yml
+++ b/permissions/pom-pipeline-model-parent.yml
@@ -4,4 +4,5 @@ paths:
 - "org/jenkinsci/plugins/pipeline-model-parent"
 developers:
 - "abayer"
+- "oleg_nenashev"
 - "stephenconnolly"

--- a/permissions/pom-pipeline-model-parent.yml
+++ b/permissions/pom-pipeline-model-parent.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-model-parent"
+paths:
+- "org/jenkinsci/plugins/pipeline-model-parent"
+developers:
+- "abayer"
+- "stephenconnolly"


### PR DESCRIPTION
We're going to split pipeline-model-definition up into two plugins, so
we need to be able to push the new plugin and its parent.