### PR TITLE
Adding belltimo and bank @amazon.com to CodePipeline plugin maintainers

### DIFF
--- a/permissions/plugin-aws-codepipeline.yml
+++ b/permissions/plugin-aws-codepipeline.yml
@@ -4,3 +4,5 @@ paths:
 - "com/amazonaws/aws-codepipeline"
 developers:
 - "biagic"
+- "belltimo"
+- "bank"


### PR DESCRIPTION
Adding belltimo and bank to CodePipeline plugin maintainers.

See: https://issues.jenkins-ci.org/browse/HOSTING-210

https://github.com/jenkinsci/aws-codepipeline-plugin/commits/master