### PR TITLE
add permissions to scaleway-cloud-plugin

### DIFF
--- a/permissions/plugin-scaleway-cloud-plugin.yml
+++ b/permissions/plugin-scaleway-cloud-plugin.yml
@@ -1,6 +1,6 @@
 ---
-name: "scaleway-cloud-plugin"
+name: "scaleway-cloud"
 paths:
-- "com/github/segator/jenkins/scaleway-cloud-plugin"
+- "com/github/segator/jenkins/scaleway-cloud"
 developers:
 - "segator"

--- a/permissions/plugin-scaleway-cloud-plugin.yml
+++ b/permissions/plugin-scaleway-cloud-plugin.yml
@@ -1,0 +1,6 @@
+---
+name: "scaleway-cloud-plugin"
+paths:
+- "com/github/segator/jenkins/scaleway-cloud-plugin"
+developers:
+- "segator"

--- a/permissions/plugin-scaleway-plugin.yml
+++ b/permissions/plugin-scaleway-plugin.yml
@@ -1,6 +1,0 @@
----
-name: "scaleway-plugin"
-paths:
-- "com/github/segator/jenkins/scaleway-cloud"
-developers:
-- "segator"

--- a/permissions/plugin-scaleway-plugin.yml
+++ b/permissions/plugin-scaleway-plugin.yml
@@ -1,0 +1,6 @@
+---
+name: "scaleway-plugin"
+paths:
+- "com/github/segator/jenkins/scaleway-cloud"
+developers:
+- "segator"


### PR DESCRIPTION
Hi I wanted to contribuite to jenkins and created this plugin "scaleway-cloud-plugin"
This plugin allow to create slave's on demand using  [Scaleway](https://scaleway.com)

I readed your documentation you need a prove  that i have write permissions in the oficial forked jenkins repo of this plugin [Scaleway Jenkins Plugin](https://github.com/jenkinsci/scaleway-cloud-plugin)
check I did some commit's today.

Let me know if you need something more.
