### PR TITLE
Adding pipeline-stage-tags-metadata plugin

### DIFF
--- a/permissions/plugin-pipeline-stage-tags-metadata.yml
+++ b/permissions/plugin-pipeline-stage-tags-metadata.yml
@@ -1,0 +1,9 @@
+---
+name: "pipeline-stage-tags-metadata"
+paths:
+- "org/jenkinsci/plugins/pipeline-stage-tags-metadata"
+developers:
+- "abayer"
+- "oleg_nenashev"
+- "stephenconnolly"
+- "rsandell"


### PR DESCRIPTION
Yup, another Declarative-related plugin. This one is an attempt to
again minimize dependencies for something that may be used by other
plugins (such as pipeline-graph-analysis and Blue Ocean).

See
https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/47
for the addition of the plugin. And yes, the POM needs to be updated
with a real wiki page etc.