### PR TITLE
Extend lifx-notifier plugin developers list

### DIFF
--- a/permissions/plugin-lifx-notifier.yml
+++ b/permissions/plugin-lifx-notifier.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/lifx-notifier"
 developers:
 - "michaelneale"
+- "vgaidarji"


### PR DESCRIPTION
I've worked on new version of [`lifx-notifier`](https://github.com/vgaidarji/lifx-notifier-plugin) plugin. I'm on the way of publishing it and want to extend list of developers of this plugin.
I was added to the repo [list of collaborators](https://github.com/jenkinsci/lifx-notifier-plugin/settings/collaboration) by plugin author as well.
<img width="996" alt="screen shot 2016-11-25 at 11 46 19 am" src="https://cloud.githubusercontent.com/assets/3036347/20620927/32149b52-b30d-11e6-9888-684ded597965.png">
