### PR TITLE
Add pipeline-githubnotify-step plugin

### DIFF
--- a/permissions/plugin-pipeline-githubnotify-step.yml
+++ b/permissions/plugin-pipeline-githubnotify-step.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-githubnotify-step"
+paths:
+- "org/jenkins-ci/plugins/pipeline-githubnotify-step"
+developers:
+- "rarabaolaza"
+- "recena"


### PR DESCRIPTION
Request permission to deploy newly created plugin pipeline-githubnotify-step plugin

[Plugin Location](https://github.com/jenkinsci/pipeline-githubnotify-step-plugin)

See [here](https://github.com/jenkinsci/pipeline-githubnotify-step-plugin/graphs/contributors) to check that I am a contirbutor