### PR TITLE
Add batmat to support-core releasers

### DIFF
--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -8,3 +8,5 @@ developers:
 - "schristou"
 - "schristou88"
 - "stephenconnolly"
+- "batmat"
+


### PR DESCRIPTION
# Description

Add myself to the list of people allowed to release the [support-core plugin](https://github.com/jenkinsci/support-core-plugin). 

@jglick advised me to do so in https://github.com/jenkinsci/support-core-plugin/pull/89#issuecomment-264034017 and @christ66 did the same in private.

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)