### PR TITLE
Add new plugin: fluentd

### DIFF
--- a/permissions/plugin-fluentd.yml
+++ b/permissions/plugin-fluentd.yml
@@ -1,0 +1,7 @@
+---
+name: "fluentd"
+paths:
+- "org/jenkins-ci/plugins/fluentd"
+developers:
+- "jimilian"
+- "sschuberth"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

Fluentd Plugin: https://github.com/jenkinsci/fluentd-plugin
HOSTING issue:
https://issues.jenkins-ci.org/browse/HOSTING-220

Fails with:
`Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project fluentd: Failed to deploy artifacts: Could not transfer artifact org.jenkins-ci.plugins:fluentd:hpi:0.1.1 from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): Access denied to: https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/fluentd/0.1.1/fluentd-0.1.1.hpi, ReasonPhrase: Forbidden. -> [Help 1]
`

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
