### PR TITLE
Add new plugin: buildrotator

### DIFF
--- a/permissions/plugin-buildrotator.yml
+++ b/permissions/plugin-buildrotator.yml
@@ -1,7 +1,7 @@
 ---
 name: "buildrotator"
 paths:
-- "org/jenkins-ci/plugins/BuildRotator"
+- "org/jenkins-ci/plugins/buildrotator"
 developers:
 - "jimilian"
 - "sschuberth"

--- a/permissions/plugin-buildrotator.yml
+++ b/permissions/plugin-buildrotator.yml
@@ -1,0 +1,7 @@
+---
+name: "buildrorator"
+paths:
+- "org/jenkins-ci/plugins/BuildRotator"
+developers:
+- "jimilian"
+- "sschuberth"

--- a/permissions/plugin-buildrotator.yml
+++ b/permissions/plugin-buildrotator.yml
@@ -1,5 +1,5 @@
 ---
-name: "buildrorator"
+name: "buildrotator"
 paths:
 - "org/jenkins-ci/plugins/BuildRotator"
 developers:


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

https://issues.jenkins-ci.org/browse/HOSTING-219
https://github.com/jenkinsci/buildrotator-plugin

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
