### PR TITLE
Adding BlackDuck hub plugin permission

### DIFF
--- a/permissions/plugin-blackduck-hub.yml
+++ b/permissions/plugin-blackduck-hub.yml
@@ -1,0 +1,8 @@
+---
+name: "blackduck-hub"
+paths:
+- "com/blackducksoftware/integration/blackduck-hub"
+developers:
+- "jrichard"
+- "akamen"
+- "bdsoss"


### PR DESCRIPTION
# Description

This is a Jenkins plugin that allows Users to run BlackDuck Hub scans in Jenkins.

https://github.com/jenkinsci/blackduck-hub-plugin

https://issues.jenkins-ci.org/browse/HOSTING-215

### When adding new uploaders (this includes newly created permissions files)
@daniel-beck 