### PR TITLE
Add colinmsphere to Marathon Plugin Developers

### DIFF
--- a/permissions/plugin-marathon.yml
+++ b/permissions/plugin-marathon.yml
@@ -4,3 +4,4 @@ paths:
 - "com/mesosphere/velocity/marathon"
 developers:
 - "titosand"
+- "colinmsphere"


### PR DESCRIPTION
# Description

Add "colinmsphere" (jenkins-ci username) to the list of developers with release permissions for the Marathon plugin (`permissions/plugin-marathon.yaml`).

Plugin Repository: https://github.com/jenkinsci/marathon-plugin

