### PR TITLE
[INFRA-1005] Allow contributors to deploy -SNAPSHOTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target/
 *.iml
 out/
 lib/
+
+# Work
+json/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node('java') {
         stage 'Run'
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactoryAdmin',
                           usernameVariable: 'ARTIFACTORY_USERNAME', passwordVariable: 'ARTIFACTORY_PASSWORD']]) {
-            sh 'target/appassembler/bin/repository-permissions-updater -d $PWD/permissions -w $PWD/json'
+            sh 'target/appassembler/bin/repository-permissions-updater --definitionDir $PWD/permissions --workDir $PWD/json'
         }
     } finally {
         stage 'Archive'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,11 +30,7 @@ node('java') {
         stage 'Run'
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactoryAdmin',
                           usernameVariable: 'ARTIFACTORY_USERNAME', passwordVariable: 'ARTIFACTORY_PASSWORD']]) {
-            sh '${JAVA_HOME}/bin/java' +
-                    ' -DdefinitionsDir=$PWD/permissions' +
-                    ' -DartifactoryApiTempDir=$PWD/json' +
-                    ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
-                    ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
+            sh 'target/appassembler/bin/repository-permissions-updater -d $PWD/permissions -w $PWD/json'
         }
     } finally {
         stage 'Archive'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This repository contains both the definitions for Artifactory upload permissions
 
 **Note:** These permissions are specifically for _uploading_ artifacts to the Jenkins project's Maven repository. It is independent of GitHub repository permissions. You may have one without the other. Typically, you'll either have both, or just the GitHub repository access.
 
+**Note:** There are two levels of permission. Developers have permission to deploy both releases and snapshots. Contributors have permission to deploy snapshots.
+
 Requesting Permissions
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Create a new YAML file similar to existing files.
 
 Edit the `developers` list in the YAML file for the plugin.
 
+### Adding a `-SNAPSHOT` only uploader to an existing plugin
+
+Create or edit the `contributors` list in the YAML file for the plugin.
+
 ### Deprecating a plugin
 
 Remove the YAML file. The next synchronization will remove permissions for the plugin.

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -8,3 +8,5 @@ developers:
 - "jglick"
 - "markewaite"
 - "ndeloof"
+contributors:
+- "stephenconnolly"

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -8,5 +8,4 @@ developers:
 - "jglick"
 - "markewaite"
 - "ndeloof"
-contributors:
 - "stephenconnolly"

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -5,3 +5,5 @@ paths:
 - "org/jvnet/hudson/plugins/mercurial"
 developers:
 - "jglick"
+contributors:
+- "stephenconnnolly"

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,27 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>appassembler-maven-plugin</artifactId>
+                <version>1.10</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>assemble</goal>
+                        </goals>
+                        <configuration>
+                            <programs>
+                                <program>
+                                    <id>${project.artifactId}</id>i
+                                    <mainClass>${main.class}</mainClass>
+                                </program>
+                            </programs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin> <!-- TODO remove once Jenkinsfile changes accepted -->
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
@@ -88,6 +109,11 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.7</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
See [INFRA-1005](https://issues.jenkins-ci.org/browse/INFRA-1005)

- Also tidy up the updater and allow for dry runs and off-line testing

- Also adds "stephenconnolly" as a contributor to [git](https://github.com/jenkinsci/git-plugin) and [mercurial](https://github.com/jenkinsci/mercurial-plugin) plugins @jglick @MarkEWaite
