### PR TITLE
kanboard-publisher plugin renamed to kanboard.

### DIFF
--- a/permissions/plugin-kanboard-publisher.yml
+++ b/permissions/plugin-kanboard-publisher.yml
@@ -1,6 +1,0 @@
----
-name: "kanboard-publisher"
-paths:
-- "org/jenkins-ci/plugins/kanboard-publisher"
-developers:
-- "mably"

--- a/permissions/plugin-kanboard.yml
+++ b/permissions/plugin-kanboard.yml
@@ -1,0 +1,6 @@
+---
+name: "kanboard"
+paths:
+- "org/jenkins-ci/plugins/kanboard"
+developers:
+- "mably"


### PR DESCRIPTION
Upload permission request for the Kanboard Plugin previously called Kanboard Publisher Plugin.

Repository have been renamed and pom.xml updated accordingly:
https://github.com/jenkinsci/kanboard-plugin/

Some discussion about the renaming:
https://issues.jenkins-ci.org/browse/HOSTING-241
