### PR TITLE
Adding maggiecopyaws to CodePipeline plugin maintainers

### DIFF
--- a/permissions/plugin-aws-codepipeline.yml
+++ b/permissions/plugin-aws-codepipeline.yml
@@ -6,3 +6,4 @@ developers:
 - "biagic"
 - "belltimo"
 - "bank"
+- "maggiecopyaws"


### PR DESCRIPTION
Adding maggiecopyaws to CodePipeline plugin maintainers.

see https://issues.jenkins-ci.org/browse/HOSTING-246

https://github.com/jenkinsci/aws-codepipeline-plugin

Original discussion https://github.com/jenkins-infra/repository-permissions-updater/pull/157