### PR TITLE
Added developers to coverity plugin

### DIFF
--- a/permissions/plugin-coverity.yml
+++ b/permissions/plugin-coverity.yml
@@ -5,4 +5,7 @@ paths:
 developers:
 - "frossi"
 - "kdang"
+- "shami"
+- "jbriggs"
+- "ahcho0819"
 - "oleg_nenashev"


### PR DESCRIPTION
# Description

Adding developers @shamiwillms, @jbriggs22, @ahcho0819 to [jenkinsci/coverity-plugin](https://github.com/jenkinsci/coverity-plugin)

Needs @coverity-kdang to confirm

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
