### PR TITLE
Bluocean git and github plugins deploy permission

### DIFF
--- a/permissions/plugin-blueocean-git-pipeline.yml
+++ b/permissions/plugin-blueocean-git-pipeline.yml
@@ -1,0 +1,10 @@
+---
+name: "blueocean-git-pipeline"
+paths:
+- "io/jenkins/blueocean/blueocean-git-pipeline"
+developers:
+- "michaelneale"
+- "vivek"
+- "tfennelly"
+- "kzantow"
+- "tscherler"

--- a/permissions/plugin-blueocean-github-pipeline.yml
+++ b/permissions/plugin-blueocean-github-pipeline.yml
@@ -1,0 +1,10 @@
+---
+name: "blueocean-github-pipeline"
+paths:
+- "io/jenkins/blueocean/blueocean-github-pipeline"
+developers:
+- "michaelneale"
+- "vivek"
+- "tfennelly"
+- "kzantow"
+- "tscherler"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

Permission to deploy blueocean-git-pipeline and blueocean-github-pipeline plugins.

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

https://github.com/jenkinsci/blueocean-plugin/tree/story/JENKINS-38847/blueocean-git-pipeline
https://github.com/jenkinsci/blueocean-plugin/tree/story/JENKINS-38847/blueocean-github-pipeline

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

@vivek

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)