### PR TITLE
Add janschaefer as developer to jgiven plugin

### DIFF
--- a/permissions/plugin-jgiven.yml
+++ b/permissions/plugin-jgiven.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/jgiven"
 developers:
 - "wolfs"
+- "janschaefer"


### PR DESCRIPTION
# Description

Add janschaefer as a developer to the jgiven plugin: https://github.com/jenkinsci/jgiven-plugin/

@wolfs

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
