### PR TITLE
Add component-lib-jenkins-maven-embedder to the permission list

### DIFF
--- a/permissions/component-lib-jenkins-maven-embedder.yml
+++ b/permissions/component-lib-jenkins-maven-embedder.yml
@@ -1,0 +1,13 @@
+---
+name: "lib-jenkins-maven-embedder"
+paths:
+- "org/jenkins-ci/lib/lib-jenkins-maven-embedder"
+developers:
+- "stephenc"
+- "danielbeck"
+- "jglick"
+- "abayer"
+- "oleg_nenashev"
+- "batmat"
+- "olivergondza"
+- "olamy"


### PR DESCRIPTION
Adds upload permissions for https://github.com/jenkinsci/lib-jenkins-maven-embedder. Since this component is not being widely maintained && there is no person who wanted to claim sole ownership, I've just added several people from the core team, who regularly do releases.

CC @daniel-beck, @stephenc , @olamy , @abayer , @oleg-nenashev, @batmat , @olivergondza, @jglick 

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins


