### PR TITLE
Added permissions for new Device Watcher Plugin

### DIFF
--- a/permissions/plugin-device-watcher.yml
+++ b/permissions/plugin-device-watcher.yml
@@ -1,0 +1,6 @@
+---
+name: "device-watcher-plugin"
+paths:
+- "org/jenkins-ci/plugins/device-watcher-plugin"
+developers:
+- "sonicwind"

--- a/permissions/plugin-device-watcher.yml
+++ b/permissions/plugin-device-watcher.yml
@@ -1,5 +1,5 @@
 ---
-name: "device-watcher-plugin"
+name: "device-watcher"
 paths:
 - "org/jenkins-ci/plugins/device-watcher"
 developers:

--- a/permissions/plugin-device-watcher.yml
+++ b/permissions/plugin-device-watcher.yml
@@ -1,6 +1,6 @@
 ---
 name: "device-watcher-plugin"
 paths:
-- "org/jenkins-ci/plugins/device-watcher-plugin"
+- "org/jenkins-ci/plugins/device-watcher"
 developers:
 - "sonicwind"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description
GitHub: https://github.com/jenkinsci/device-watcher-plugin
Hosting Issue: https://issues.jenkins-ci.org/browse/HOSTING-258

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
