### PR TITLE
Create plugin-aws-cloudwatch-logs-publisher.yml

### DIFF
--- a/permissions/plugin-aws-cloudwatch-logs-publisher.yml
+++ b/permissions/plugin-aws-cloudwatch-logs-publisher.yml
@@ -1,0 +1,6 @@
+---
+name: "aws-cloudwatch-logs-publisher"
+paths:
+- "org/jenkins-ci/plugins/aws-cloudwatch-logs-publisher"
+developers:
+- "elifarley"


### PR DESCRIPTION
# Description

Permission to upload new plugin aws-cloudwatch-logs-publisher

# Permissions pull request checklist

### Always

- I'm a committer at https://github.com/jenkinsci/aws-cloudwatch-logs-publisher-plugin

### For a newly hosted plugin only

- https://issues.jenkins-ci.org/browse/HOSTING-260

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkins-infra/repository-permissions-updater/185)
<!-- Reviewable:end -->
