### PR TITLE
Add batmat to allowed releasers

### DIFF
--- a/permissions/pom-plugin.yml
+++ b/permissions/pom-plugin.yml
@@ -10,3 +10,5 @@ developers:
 - "oleg_nenashev"
 - "stephenconnolly"
 - "tfennelly"
+- "batmat"
+


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

_Would like to add myself to list of people allowed to release the Jenkins plugins parent pom: (https://github.com/jenkinsci/plugin-pom). Stephen Connolly [asked me to handle the release](https://github.com/jenkinsci/plugin-pom/pull/42#issuecomment-273716761)_

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- _N/A_

### For a new permissions file only

- _N/A_

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
    * actually, authorization given upstream, see https://github.com/jenkinsci/plugin-pom/pull/42#issuecomment-273713875
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
