### PR TITLE
Create plugin-github-pr-comment-build

### DIFF
--- a/permissions/plugin-github-pr-comment-build.yml
+++ b/permissions/plugin-github-pr-comment-build.yml
@@ -1,0 +1,6 @@
+---
+name: "github-pr-comment-build"
+paths:
+- "org/jenkins-ci/plugins/github-pr-comment-build"
+developers:
+- "bksaville"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

Add permissions for new github-pr-comment-build plugin.
Git repo: https://github.com/jenkinsci/github-pr-comment-build-plugin
Hosting issue: https://issues.jenkins-ci.org/browse/HOSTING-248

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [n/a] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
