### PR TITLE
[HOSTING-254] Requesting permission to release docker-fixtures

### DIFF
--- a/permissions/component-docker-fixtures.yml
+++ b/permissions/component-docker-fixtures.yml
@@ -1,0 +1,11 @@
+---
+name: "docker-fixtures"
+paths:
+- "org/jenkins-ci/test/docker-fixtures"
+developers:
+- "andresrc"
+- "jglick"
+- "kohsuke"
+- "olivergondza"
+- "rsandell"
+- "vlatombe"


### PR DESCRIPTION
[HOSTING-254](https://issues.jenkins-ci.org/browse/HOSTING-254)

Adding a new component, split off from `acceptance-test-harness`.

https://github.com/jglick/docker-fixtures/pull/1

@reviewbybees