### PR TITLE
Grant access to taoyong

### DIFF
--- a/permissions/plugin-aws-codebuild.yml
+++ b/permissions/plugin-aws-codebuild.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "subinataws"
 - "johnhankataw"
+- "taoyong"


### PR DESCRIPTION
I am a dev in AWS codebuild. I will need to release our plugin to Jenkins.

_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

_Grant permission to taoyong https://github.com/awslabs/aws-codebuild-jenkins-plugin_

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
