### PR TITLE
Added permission file enabling user dillense to upload maven artifact

### DIFF
--- a/permissions/plugin-clif-performance-testing.yml
+++ b/permissions/plugin-clif-performance-testing.yml
@@ -1,0 +1,6 @@
+---
+name: "clif-performance-testing"
+paths:
+- "org/jenkins-ci/plugins/clif-performance-testing"
+developers:
+- "dillense"


### PR DESCRIPTION
org.jenkins-ci.plugins:clif-performance-testing

_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

Added permission file enabling user dillense to upload maven artifact

# Permissions pull request checklist

### Always

https://github.com/jenkinsci/clif-performance-testing-plugin.git

### For a newly hosted plugin only

https://issues.jenkins-ci.org/browse/HOSTING-261

### For a new permissions file only

- [X ] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [N/A] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
