### PR TITLE
add permission for report-info-plugin

### DIFF
--- a/permissions/plugin-report-info.yml
+++ b/permissions/plugin-report-info.yml
@@ -1,0 +1,6 @@
+---
+name: "report-info"
+paths:
+- "org/jenkins-ci/plugins/report-info"
+developers:
+- "gcolin"


### PR DESCRIPTION
# Description

A view with some information from Surefire, PMD, Findbugs and Checkstyle reports.
Git repo: [https://github.com/jenkinsci/report-info-plugin](https://github.com/jenkinsci/report-info-plugin)
Hosting issue: [https://issues.jenkins-ci.org/browse/HOSTING-262](https://issues.jenkins-ci.org/browse/HOSTING-262)

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
