### PR TITLE
Create plugin-zanata.yml

### DIFF
--- a/permissions/plugin-zanata.yml
+++ b/permissions/plugin-zanata.yml
@@ -1,6 +1,6 @@
 ---
-name: "zanata-plugin"
+name: "zanata"
 paths:
-- "org/jenkins-ci/plugins/zanata-plugin"
+- "org/jenkins-ci/plugins/zanata"
 developers:
 - "yushao"

--- a/permissions/plugin-zanata.yml
+++ b/permissions/plugin-zanata.yml
@@ -1,0 +1,6 @@
+---
+name: "zanata-plugin"
+paths:
+- "org/jenkins-ci/plugins/zanata-plugin"
+developers:
+- "yushao"


### PR DESCRIPTION
This is adding permission to newly approved plugin zanata-plugin

# Description

user "yushao" is created on repo.jenkins-ci.org, but user yushao is not able to upload the plugin due to the permission.

Git repo: https://github.com/jenkinsci/zanata-plugin.git
Hosting request ticket just got approved: https://issues.jenkins-ci.org/browse/HOSTING-249

    artifactId = zanata
    groupId / artifactId  = org.jenkins-ci.plugins/zanata
    filename = plugin-zanata.yml

