### PR TITLE
rename groupId of pipeline-dependency-walker to default per @daniel-beck recommendation

### DIFF
--- a/permissions/plugin-pipeline-dependency-walker.yml
+++ b/permissions/plugin-pipeline-dependency-walker.yml
@@ -1,6 +1,6 @@
 ---
 name: "pipeline-dependency-walker"
 paths:
-- "org/jenkins-ci/plugins/workflow/pipeline-dependency-walker"
+- "org/jenkins-ci/plugins/pipeline-dependency-walker"
 developers:
 - "estarter"


### PR DESCRIPTION
rename groupId of pipeline-dependency-walker to default per @daniel-beck recommendation
original pr: https://github.com/jenkins-infra/repository-permissions-updater/pull/184

# Description

Adds the Pipeline step ‘walk’ to execute a pipeline task for the job and all its downstream jobs.

Git repo: https://github.com/jenkinsci/pipeline-dependency-walker-plugin
Hosting issue: https://issues.jenkins-ci.org/browse/HOSTING-256

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
