### PR TITLE
add isparkes to developers

### DIFF
--- a/permissions/plugin-jenkins-jira-issue-updater.yml
+++ b/permissions/plugin-jenkins-jira-issue-updater.yml
@@ -3,4 +3,5 @@ name: "jenkins-jira-issue-updater"
 paths:
 - "info/bluefloyd/jenkins/jenkins-jira-issue-updater"
 developers:
+- "isparkes"
 - "laszlomiklosik"


### PR DESCRIPTION
# Description

Please add isparkes to the list of developers for [https://github.com/jenkinsci/jira-issue-updater-plugin](url). Laszlo is not really active on this plugin any more (he doesn't use it currently), and I've taken over the maintenance.

I already have commit permissions: (see e.g. e5c33f711c72c2fdadf2ff0f0e24c9542643f8a2)

