### PR TITLE
Remove old permissions from Accurev plugin

### DIFF
--- a/permissions/plugin-accurev.yml
+++ b/permissions/plugin-accurev.yml
@@ -2,6 +2,5 @@
 name: "accurev"
 paths:
 - "org/jenkins-ci/plugins/accurev"
-- "org/jvnet/hudson/plugins/accurev"
 developers:
 - "casz"

--- a/permissions/plugin-accurev.yml
+++ b/permissions/plugin-accurev.yml
@@ -4,7 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/accurev"
 - "org/jvnet/hudson/plugins/accurev"
 developers:
-- "jsherwood_accurev"
-- "ndeloof"
-- "rym0021"
 - "casz"


### PR DESCRIPTION
As suggested in https://github.com/jenkins-infra/repository-permissions-updater/pull/15#issuecomment-242981574
Should we remove the old ones?

Also is `org/jvnet/hudson/plugins/accurev` still relevant?

https://github.com/jenkinsci/accurev-plugin