### PR TITLE
Add fgalmeida to AWS CodePipeline plugin maintainers

### DIFF
--- a/permissions/plugin-aws-codepipeline.yml
+++ b/permissions/plugin-aws-codepipeline.yml
@@ -3,7 +3,7 @@ name: "aws-codepipeline"
 paths:
 - "com/amazonaws/aws-codepipeline"
 developers:
-- "biagic"
 - "belltimo"
 - "bank"
 - "maggiecopyaws"
+- "fgalmeida"


### PR DESCRIPTION
Add fgalmeida, remove biagic from AWS CodePipeline plugin mauntainers
list

# Description

Add fgalmeida (galmeida on github) to list of AWS CodePipeline plugin maintainers, Remove biagic from the list

* https://github.com/awslabs/aws-codepipeline-plugin-for-jenkins
* https://github.com/jenkinsci/aws-codepipeline-plugin

@belltimo can you please confirm my permission request?

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
