### PR TITLE
Remove @stephenc from component-lib-jenkins-maven-embedder.yml

### DIFF
--- a/permissions/component-lib-jenkins-maven-embedder.yml
+++ b/permissions/component-lib-jenkins-maven-embedder.yml
@@ -3,7 +3,6 @@ name: "lib-jenkins-maven-embedder"
 paths:
 - "org/jenkins-ci/lib/lib-jenkins-maven-embedder"
 developers:
-- "stephenc"
 - "danielbeck"
 - "jglick"
 - "abayer"


### PR DESCRIPTION
Just a follow-up to #178

CC @daniel-beck @stephenc 
