### PR TITLE
add permission for openshift-sync plugin

### DIFF
--- a/permissions/plugin-openshift-sync.yml
+++ b/permissions/plugin-openshift-sync.yml
@@ -4,3 +4,5 @@ paths:
 - "io/fabric8/jenkins/plugins/openshift-sync"
 developers:
 - "jimmi"
+- "bparees"
+- "gmontero"


### PR DESCRIPTION
Adding bparees and gmontero to openshift sync plugin permissions
repo: https://github.com/jenkinsci/openshift-sync-plugin

@jimmidyson please confirm.
