### PR TITLE
Adding pipeline-metadata-utils library

### DIFF
--- a/permissions/component-pipeline-metadata-utils.yml
+++ b/permissions/component-pipeline-metadata-utils.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-metadata-utils"
+paths:
+- "org/jenkins-ci/infra/pipeline-metadata-utils"
+developers:
+- "abayer"
+- "kwhetstone"


### PR DESCRIPTION
This'll be deployed from https://github.com/jenkins-infra/pipeline-metadata-utils

_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

Infra utility library for common code in https://github.com/jenkins-infra/pipeline-steps-doc-generator and the upcoming tool for [INFRA-1053](https://issues.jenkins-ci.org/browse/INFRA-1053)

# Permissions pull request checklist

### Always

- [x] https://github.com/jenkins-infra/pipeline-metadata-utils

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
(note: not 100% sure @kwhetstone has logged into Artifactory)