### PR TITLE
add bparees to openshift plugins

### DIFF
--- a/permissions/plugin-openshift-login.yml
+++ b/permissions/plugin-openshift-login.yml
@@ -4,3 +4,4 @@ paths:
 - "org/openshift/jenkins/openshift-login"
 developers:
 - "gmontero"
+- "bparees"

--- a/permissions/plugin-openshift-pipeline.yml
+++ b/permissions/plugin-openshift-pipeline.yml
@@ -4,3 +4,4 @@ paths:
 - "com/openshift/jenkins/openshift-pipeline"
 developers:
 - "gmontero"
+- "bparees"


### PR DESCRIPTION
@jenkinsadmin or others PTAL

In addition to adding @bparees to openshift-login and openshift-pipeline, we noticed that at 
https://github.com/jenkinsci/openshift-pipeline-plugin/settings/collaboration "Everyone" seems to have write
access.

However, when we look at say https://github.com/jenkinsci/openshift-client-plugin/settings/collaboration or https://github.com/jenkinsci/openshift-login-plugin/settings/collaboration that is not the case.

Any idea how we can remove "Everyone" from having write access to openshift-pipeline?

thanks