### PR TITLE
Create component-lib-version-number.yml

### DIFF
--- a/permissions/component-lib-version-number.yml
+++ b/permissions/component-lib-version-number.yml
@@ -1,0 +1,8 @@
+---
+name: "version-number"
+paths:
+- "org/jenkins-ci/version-number"
+developers:
+- "jglick"
+- "stephenconnolly"
+- "kohsuke"


### PR DESCRIPTION
Found out that we have no permissions file for https://github.com/jenkinsci/lib-version-number

@jglick @daniel-beck @reviewbybees