### PR TITLE
Adding shaded JSON jar for Declarative

### DIFF
--- a/permissions/component-pipeline-model-json-shaded.yml
+++ b/permissions/component-pipeline-model-json-shaded.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-model-json-shaded"
+paths:
+- "org/jenkinsci/plugins/pipeline-model-json-shaded"
+developers:
+- "abayer"
+- "rsandell"

--- a/permissions/component-pipeline-model-json-shaded.yml
+++ b/permissions/component-pipeline-model-json-shaded.yml
@@ -1,7 +1,9 @@
 ---
 name: "pipeline-model-json-shaded"
 paths:
-- "org/jenkinsci/plugins/pipeline-model-json-shaded"
+- "org/jenkins-ci/lib/pipeline-model-json-shaded"
 developers:
 - "abayer"
+- "oleg_nenashev"
+- "stephenconnolly"
 - "rsandell"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

https://issues.jenkins-ci.org/browse/JENKINS-41911 - this isn't a
plugin, but I kept it in the same groupId as the rest of Declarative.

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
