### PR TITLE
pipeline-maven multi module

### DIFF
--- a/permissions/plugin-pipeline-maven.yml
+++ b/permissions/plugin-pipeline-maven.yml
@@ -2,5 +2,7 @@
 name: "pipeline-maven"
 paths:
 - "org/jenkins-ci/plugins/pipeline-maven"
+- "org/jenkins-ci/plugins/pipeline-maven-parent"
+- "org/jenkins-ci/plugins/pipeline-maven-spy"
 developers:
 - "alobato"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

The pipeline maven plugin is now multi-module so I need to add a couple os path for two new artifacts.

https://github.com/jenkinsci/pipeline-maven-plugin

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
