### PR TITLE
Correct pipeline maven plugin multi module permissions

### DIFF
--- a/permissions/component-pipeline-maven-spy.yml
+++ b/permissions/component-pipeline-maven-spy.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-maven-spy"
+paths:
+- "org/jenkins-ci/plugins/pipeline-maven-spy"
+developers:
+- "alobato"
+- "cleclerc"

--- a/permissions/plugin-pipeline-maven.yml
+++ b/permissions/plugin-pipeline-maven.yml
@@ -2,7 +2,6 @@
 name: "pipeline-maven"
 paths:
 - "org/jenkins-ci/plugins/pipeline-maven"
-- "org/jenkins-ci/plugins/pipeline-maven-parent"
-- "org/jenkins-ci/plugins/pipeline-maven-spy"
 developers:
 - "alobato"
+- "cleclerc"

--- a/permissions/pom-pipeline-maven-parent.yml
+++ b/permissions/pom-pipeline-maven-parent.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-maven-parent"
+paths:
+- "org/jenkins-ci/plugins/pipeline-maven-parent"
+developers:
+- "alobato"
+- "cleclerc"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

_Correct pipeline maven plugin multi module permissions and add cyrille-leclerc_
https://github.com/jenkinsci/pipeline-maven-plugin/

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
