### PR TITLE
Add components for Plugin Compatible Tester

### DIFF
--- a/permissions/component-plugins-compat-tester-aggregator.yml
+++ b/permissions/component-plugins-compat-tester-aggregator.yml
@@ -1,0 +1,9 @@
+---
+name: "plugins-compat-tester-aggregator"
+paths:
+- "org/jenkins-ci/tests/plugins-compat-tester-aggregator"
+developers:
+- "kwhetstone"
+- "jglick"
+- "andresrc"
+

--- a/permissions/component-plugins-compat-tester-cli.yml
+++ b/permissions/component-plugins-compat-tester-cli.yml
@@ -1,0 +1,9 @@
+---
+name: "plugins-compat-tester-cli"
+paths:
+- "org/jenkins-ci/tests/plugins-compat-tester-cli"
+developers:
+- "kwhetstone"
+- "jglick"
+- "andresrc"
+

--- a/permissions/component-plugins-compat-tester-gae-client.yml
+++ b/permissions/component-plugins-compat-tester-gae-client.yml
@@ -1,7 +1,7 @@
 ---
 name: "plugins-compat-tester-gae-client"
 paths:
-- "org/jenkins-ci/tests/plugins-compat-testeri-gae-client"
+- "org/jenkins-ci/tests/plugins-compat-tester-gae-client"
 developers:
 - "kwhetstone"
 - "jglick"

--- a/permissions/component-plugins-compat-tester-gae-client.yml
+++ b/permissions/component-plugins-compat-tester-gae-client.yml
@@ -1,0 +1,9 @@
+---
+name: "plugins-compat-tester-gae-client"
+paths:
+- "org/jenkins-ci/tests/plugins-compat-testeri-gae-client"
+developers:
+- "kwhetstone"
+- "jglick"
+- "andresrc"
+

--- a/permissions/component-plugins-compat-tester-gae.yml
+++ b/permissions/component-plugins-compat-tester-gae.yml
@@ -1,7 +1,7 @@
 ---
 name: "plugins-compat-tester-gae"
 paths:
-- "org/jenkins-ci/tests/plugins-compat-testeri-gae"
+- "org/jenkins-ci/tests/plugins-compat-tester-gae"
 developers:
 - "kwhetstone"
 - "jglick"

--- a/permissions/component-plugins-compat-tester-gae.yml
+++ b/permissions/component-plugins-compat-tester-gae.yml
@@ -1,0 +1,9 @@
+---
+name: "plugins-compat-tester-gae"
+paths:
+- "org/jenkins-ci/tests/plugins-compat-testeri-gae"
+developers:
+- "kwhetstone"
+- "jglick"
+- "andresrc"
+

--- a/permissions/component-plugins-compat-tester-model.yml
+++ b/permissions/component-plugins-compat-tester-model.yml
@@ -1,0 +1,9 @@
+---
+name: "plugins-compat-tester-model"
+paths:
+- "org/jenkins-ci/tests/plugins-compat-tester-model"
+developers:
+- "kwhetstone"
+- "jglick"
+- "andresrc"
+

--- a/permissions/component-plugins-compat-tester.yml
+++ b/permissions/component-plugins-compat-tester.yml
@@ -1,0 +1,9 @@
+---
+name: "plugins-compat-tester"
+paths:
+- "org/jenkins-ci/tests/plugins-compat-tester"
+developers:
+- "kwhetstone"
+- "jglick"
+- "andresrc"
+


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

Add permissions for [plugin compatibility tester](https://github.com/jenkinsci/plugin-compat-tester)

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

(we need access for `kwhetstone`)