### PR TITLE
Give permissions to kwhetstone

### DIFF
--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -4,6 +4,7 @@ paths:
 - "org/jenkins-ci/plugins/parameterized-trigger"
 developers:
 - "ikedam"
+- "kwhetstone"
 - "oleg_nenashev"
 - "olivergondza"
 - "svanoort"


### PR DESCRIPTION
@kwhetstone is listed as a maintainer of the plugin, but doesn't have release permissions for the plugin.

jenkins-ci.org account: kwhetstone

Plugin link: [jenkinsci/parameterized-trigger-plugin](https://github.com/jenkinsci/parameterized-trigger-plugin/)

Commit permissions: merged [PR99](https://github.com/jenkinsci/parameterized-trigger-plugin/commit/3acb3c2824ef7af5cec98cb0812c807921811510) into the project

Note: I'm having issues logging into Artifactory with my Jenkins account.  I don't know if this is a recent issue or if there's something with my account.

Review /cc @svanoort 
