### PR TITLE
Add @batmat to versioncolumn releasers

### DIFF
--- a/permissions/plugin-versioncolumn.yml
+++ b/permissions/plugin-versioncolumn.yml
@@ -2,4 +2,5 @@
 name: "versioncolumn"
 paths:
 - "org/jenkins-ci/plugins/versioncolumn"
-developers: []
+developers:
+- "batmat"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

_Add @batmat to people allowed to release https://github.com/jenkinsci/versioncolumn-plugin. I would like to take over maintenance as asked on https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/1RruU6DkBNs/K2AnrePUDQAJ_

Ping @ssogabe for possible feedback. Thanks!

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- ~~[ ] Add link to resolved HOSTING issue in description above~~

### For a new permissions file only

_N/A_ (already existing)

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
