### PR TITLE
Add @batmat to extended-read-permission releasers

### DIFF
--- a/permissions/plugin-extended-read-permission.yml
+++ b/permissions/plugin-extended-read-permission.yml
@@ -1,0 +1,6 @@
+---
+name: "extended-read-permission"
+paths:
+- "org/jvnet/hudson/plugins/extended-read-permission"
+developers:
+- "batmat"


### PR DESCRIPTION
As agreed with @dty

_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

_As discussed with @dty privately, I am taking over maintenance of https://github.com/jenkinsci/extended-read-permission-plugin/. So I need to be allowed to release for that purpose. (still waiting for public ack on https://groups.google.com/d/msg/jenkinsci-dev/bCvDTWciRz0/xxhjZ91RDQAJ though)._

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- N/A (already existing)

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
