### PR TITLE
Create plugin-rpi-build-status.yml

### DIFF
--- a/permissions/plugin-rpi-build-status.yml
+++ b/permissions/plugin-rpi-build-status.yml
@@ -1,0 +1,6 @@
+---
+name: "rpi-build-status"
+paths:
+- "net/sleepymouse/jenkins/plugins/rpi-build-status"
+developers:
+- "havelaptopwillcode"


### PR DESCRIPTION
Request permissions for initial deployment / upload

# Description

I am requesting permissions for initial plugin deployment

https://github.com/jenkinsci/rpi-build-status-plugin

# Permissions pull request checklist

### Always

- [ x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x ] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
