### PR TITLE
Agent installer modules

### DIFF
--- a/permissions/component-launchd-slave-installer.yml
+++ b/permissions/component-launchd-slave-installer.yml
@@ -1,0 +1,8 @@
+---
+name: "launchd-slave-installer"
+paths:
+- "org/jenkins-ci/modules/launchd-slave-installer"
+developers:
+- "kohsuke"
+- "jglick"
+- "oleg_nenashev"

--- a/permissions/component-slave-installer.yml
+++ b/permissions/component-slave-installer.yml
@@ -1,0 +1,8 @@
+---
+name: "slave-installer"
+paths:
+- "org/jenkins-ci/modules/slave-installer"
+developers:
+- "kohsuke"
+- "jglick"
+- "oleg_nenashev"

--- a/permissions/component-systemd-slave-installer.yml
+++ b/permissions/component-systemd-slave-installer.yml
@@ -1,0 +1,8 @@
+---
+name: "systemd-slave-installer"
+paths:
+- "org/jenkins-ci/modules/systemd-slave-installer"
+developers:
+- "kohsuke"
+- "jglick"
+- "oleg_nenashev"

--- a/permissions/component-upstart-slave-installer.yml
+++ b/permissions/component-upstart-slave-installer.yml
@@ -1,0 +1,8 @@
+---
+name: "upstart-slave-installer"
+paths:
+- "org/jenkins-ci/modules/upstart-slave-installer"
+developers:
+- "kohsuke"
+- "jglick"
+- "oleg_nenashev"

--- a/permissions/plugin-windows-slaves.yml
+++ b/permissions/plugin-windows-slaves.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "andresrc"
 - "jglick"
+- "oleg_nenashev"


### PR DESCRIPTION
_(This PR template only applies to permission changes -- ignore for changes to the tool)_

# Description

- [x] Provide @oleg-nenashev upload access to Windows Slaves plugin
- [x] Initialize permission plugins for old Jenkins core "*-slave-installer" modules, grant access to previous committers and to @oleg-nenashev since he maintains the remoting stuff

Components:
* https://wiki.jenkins-ci.org/display/JENKINS/Windows+Slaves+Plugin
* "Slave Installer" modules: https://github.com/jenkinsci?utf8=%E2%9C%93&q=slave-installer-module&type=&language=

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
