### PR TITLE
Let mbarrien + christ66 maintain cobertura-plugin

### DIFF
--- a/permissions/plugin-cobertura.yml
+++ b/permissions/plugin-cobertura.yml
@@ -7,3 +7,5 @@ developers:
 - "drulli"
 - "olivergondza"
 - "tamini"
+- "mbarrien"
+- "christ66"


### PR DESCRIPTION
# Description

Per the discussion in https://groups.google.com/forum/#!topic/jenkinsci-dev/J--7iWOEb00 adding permission for myself and Steven Christou @christ66 to the maintainers of cobertura-plugin.

Note that drulli and tamini have previously expressed that they no longer maintain the plugin. I don't know the procedure for removing maintainers if they want to be removed.

https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin
https://github.com/jenkinsci/cobertura-plugin

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding a new uploader (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions) (See email thread above)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)