### PR TITLE
Let mbarrien + schristou maintain cobertura-plugin

### DIFF
--- a/permissions/plugin-cobertura.yml
+++ b/permissions/plugin-cobertura.yml
@@ -7,3 +7,5 @@ developers:
 - "drulli"
 - "olivergondza"
 - "tamini"
+- "mbarrien"
+- "schristou"


### PR DESCRIPTION
Per the discussion in https://groups.google.com/forum/#!topic/jenkinsci-dev/J--7iWOEb00 adding permission for myself and Steven Christou schristou (@christ66) to the maintainers of cobertura-plugin. Soft approval is visible within the thread. Uncertain if it matters, but @christ66 is a CloudBees employee.

Attempts were made to contact the maintainers both privately 3 weeks ago, and cc-ed on the mailing list 2 weeks ago. All existing maintainers drulli (@uhafner), tamini (@tamini), ogondza (@olivergondza) have all expressed that they no longer maintain the plugin. I don't know the procedure for removing maintainers if they want to be removed.

It may complicate things, but the list of maintainers on the Wiki page is disjoint from the one maintained in this file. So also paging ssogabe (@ssogabe), manuel_carrasco (@manolo), and stephenconnolly (@stephenc) just in case.

https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin
https://github.com/jenkinsci/cobertura-plugin

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](#requesting-permissions)
