### PR TITLE
Release access for mc1arke to trilead-ssh2 library

### DIFF
--- a/permissions/component-trilead-ssh2.yml
+++ b/permissions/component-trilead-ssh2.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "kohsuke"
 - "stephenconnolly"
+- "mc1arke"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Release access to [trilead-ssh2](/jenkinsci/trilead-ssh2) for mc1arke. I seem to be the only one actively maintaining this plugin. @stephenc  and @kohsuke currently have access but don't seem to have any active involvement in the library.

# Permissions pull request checklist

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
