### PR TITLE
[JENKINS-43610] Trilead Plugin release permission

### DIFF
--- a/permissions/plugin-trilead-api.yml
+++ b/permissions/plugin-trilead-api.yml
@@ -1,0 +1,6 @@
+---
+name: "trilead-api"
+paths:
+- "org/jenkins-ci/plugins/trilead-api"
+developers:
+- "mc1arke"


### PR DESCRIPTION
# Description

Permission for the release of the new Trilead API plugin as part of the move to split Trilead out of Jenkins core.

Plugin is hosted at [/jenkinsci/trilead-api-plugin/](/jenkinsci/trilead-api-plugin) and was forked as part of [HOSTING-322](https://issues.jenkins-ci.org/browse/HOSTING-322). The only access is for me (@mc1arke) for now.

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
