### PR TITLE
Permissions for uploading ElectricFlow plugin

### DIFF
--- a/permissions/plugin-electricflow.yml
+++ b/permissions/plugin-electricflow.yml
@@ -1,0 +1,6 @@
+---
+name: "electricflow"
+paths:
+- "org/jenkins-ci/plugins/electricflow"
+developers:
+- "efpluginsdev"


### PR DESCRIPTION
# Description
Release permissions request for ElectricFlow plugin release.

Hosting request link:
https://issues.jenkins-ci.org/browse/HOSTING-326

Github repository link:
https://github.com/electric-cloud/electricflow-jenkins-plugin

Contributors:
@mcritic @vpalaiya @justnoxx @ec-plugins-dev @urvashisingh @imago-storm
