### PR TITLE
Add masterhard (the author) to Rich Text Publisher Plugin devs list

### DIFF
--- a/permissions/plugin-rich-text-publisher-plugin.yml
+++ b/permissions/plugin-rich-text-publisher-plugin.yml
@@ -2,4 +2,5 @@
 name: "rich-text-publisher-plugin"
 paths:
 - "org/jenkins-ci/plugins/rich-text-publisher-plugin"
-developers: []
+developers:
+- "masterhard"


### PR DESCRIPTION
# Description

Adding upload permissions to @masterhard, the owner/maintainer of https://github.com/jenkinsci/rich-text-publisher-plugin for the plugin.

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Permissions pull request checklist

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
