### PR TITLE
Grant @oleg-nenashev permissions to release Winstone

### DIFF
--- a/permissions/component-winstone.yml
+++ b/permissions/component-winstone.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
+- "oleg_nenashev"


### PR DESCRIPTION
I would like to get the release permissions in order to be able to spin Winstone releases (e.g. with this fix: https://github.com/jenkinsci/winstone/pull/32 )

Needs authorization from @kohsuke or @jglick 
