### PR TITLE
Permission to deploy autocomplete parameter

### DIFF
--- a/permissions/plugin-autocomplete-parameter.yml
+++ b/permissions/plugin-autocomplete-parameter.yml
@@ -1,0 +1,6 @@
+---
+name: "autocomplete-parameter"
+paths:
+- "org/jenkins-ci/plugins/autocomplete-parameter"
+developers:
+- "taksan"


### PR DESCRIPTION
# Description
https://github.com/jenkinsci/autocomplete-parameter-plugin

# Permissions pull request checklist
### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
