### PR TITLE
Add developer to matrix-auth plugin

### DIFF
--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
+- "mathias_nyman"


### PR DESCRIPTION
# Description

I contributed missing support for the Folder plugin to the matrix-auth-plugin (https://github.com/jenkinsci/matrix-auth-plugin), and wish to make a new release available through the official update channel.

There does not seem to exist a maintainer of this plugin, but @kohsuke and @jglick currently have commit and upload permissions. @orrc gave me commit rights.

Proof of commit rights:
* https://github.com/jenkinsci/matrix-auth-plugin/commit/63d6897dd0c6db10935c9638639e6da724dea011

My original request for commit rights is here:
* https://groups.google.com/forum/#!msg/jenkinsci-dev/8D4gyCrRbkc/q_LescD_DwAJ


### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
