### PR TITLE
Add justinharringa as dev for release process

### DIFF
--- a/permissions/plugin-chatter-notifier.yml
+++ b/permissions/plugin-chatter-notifier.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/chatter-notifier"
 developers:
 - "sfell"
+- "justinharringa"


### PR DESCRIPTION
# Description
Adding myself as a releaser/contributor for the [Chatter Notifier Plugin](https://github.com/jenkinsci/chatter-notifier-plugin/). I've also opened a [request to move this plugin to ci.jenkins.io](https://issues.jenkins-ci.org/browse/INFRA-1191). @superfell is the current release dev.

# Permissions pull request checklist

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
