### PR TITLE
Add abayer to releasers for pipeline-stage-step

### DIFF
--- a/permissions/plugin-pipeline-stage-step.yml
+++ b/permissions/plugin-pipeline-stage-step.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "jglick"
 - "svanoort"
+- "abayer"


### PR DESCRIPTION
# Description

Adding abayer to the existing releasers for https://github.com/jenkinsci/pipeline-stage-step-plugin. cc @jglick and @svanoort as existing maintainers for confirmation.

# Permissions pull request checklist

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
