### PR TITLE
Grant permissions to publish from my personal account

### DIFF
--- a/permissions/plugin-clover.yml
+++ b/permissions/plugin-clover.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/clover"
 developers:
 - "mparfianowicz"
+- "marekparf"


### PR DESCRIPTION
# Description

Atlassian open-sourced Atlassian Clover (https://www.atlassian.com/blog/announcements/atlassian-clover-open-source) and will no longer develop it.

For this reason I want to be able to publish new releases of Jenkins Clover Plugin:
  * https://github.com/jenkinsci/clover-plugin

using my personal account:
 * Jenkins ID is 'marekparf' (marek.parfianowicz@gmail.com)
 * GitHub ID is 'marek-parfianowicz' (marek.parfianowicz@gmail.com)

instead of my company one (@mparfianowicz = mparfianowicz@atlassian.com).

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
