### PR TITLE
add the maven interceptors parent path as well......

### DIFF
--- a/permissions/component-maven-modules.yml
+++ b/permissions/component-maven-modules.yml
@@ -1,0 +1,9 @@
+---
+name: "maven-modules"
+paths:
+- "org/jenkins-ci/main/maven/maven-modules"
+developers:
+- "kutzi"
+- "ndeloof"
+- "olamy"
+- "aheritier"


### PR DESCRIPTION
Trying to push a release for maven-interceptors and got this issue
```
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.6:deploy (default-deploy) on project maven-modules: Failed to deploy artifacts: Could not transfer artifact org.jenkins-ci.main.maven:maven-modules:pom:1.9 from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): Access denied to: https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/maven/maven-modules/1.9/maven-modules-1.9.pom, ReasonPhrase: Forbidden. -> [Help 1]
[INFO] [ERROR] 
```


