### PR TITLE
Request access to deploy HTML Publisher plugin

### DIFF
--- a/permissions/plugin-htmlpublisher.yml
+++ b/permissions/plugin-htmlpublisher.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jvnet/hudson/plugins/htmlpublisher"
 developers:
 - "mcrooney"
+- "r2b2_nz"


### PR DESCRIPTION
# Description

As I am slowly taking over as maintainer of the HTML Publisher plugin (https://github.com/jenkinsci/htmlpublisher-plugin) from @mrooney, this PR is to add myself with permission to deploy HTML Publisher plugin.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
