### PR TITLE
Revoke "angelman" from tinfoil-scan plugin

### DIFF
--- a/permissions/plugin-tinfoil-scan.yml
+++ b/permissions/plugin-tinfoil-scan.yml
@@ -3,6 +3,5 @@ name: "tinfoil-scan"
 paths:
 - "com/tinfoilsecurity/plugins/tinfoil-scan"
 developers:
-- "angelman"
 - "bsedat"
 - "shanewilton"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
This change is to revoke permissions from "angelman" for the tinfoil-scan plugin. @ShaneWilton to confirm this change.

Associated plugin repo: https://github.com/jenkinsci/tinfoil-security-plugin

We will also want to edit https://github.com/orgs/jenkinsci/teams/tinfoil-security-plugin-developers. I lack the permissions to make the changes myself.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

