### PR TITLE
[JENKINS-45349] - Remoting maintainers should be also able to release  Remoting Test Client

### DIFF
--- a/permissions/component-remoting.yml
+++ b/permissions/component-remoting.yml
@@ -3,6 +3,7 @@ name: "remoting"
 paths:
 - "org/jenkins-ci/main/remoting"
 - "org/jvnet/hudson/main/remoting"
+- "org/jenkins-ci/remoting-test-client"
 developers:
 - "kohsuke"
 - "oleg_nenashev"


### PR DESCRIPTION
https://repo.jenkins-ci.org/releases/org/jenkins-ci/remoting-test-client/

I need to respin the release in order to fix the issue with the fatal File Leak on Windows: https://issues.jenkins-ci.org/browse/JENKINS-45349 (CC @jtnord since it is a prerequisite for https://issues.jenkins-ci.org/browse/JENKINS-38696)

Currently the component sources are not available in GitHub, My plan is to retrieve sources from Maven and to put the code into the Remoting repository (e.g. to "src/it" or so)

@reviewbybees @daniel-beck @jtnord  @kohsuke 
