### PR TITLE
Added colourmeamused as release uploader for parameterized-scheduler plugin

### DIFF
--- a/permissions/plugin-parameterized-scheduler.yml
+++ b/permissions/plugin-parameterized-scheduler.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/parameterized-scheduler"
 developers:
 - "batmat"
+- "colourmeamused"


### PR DESCRIPTION
# Description

[Github repository for parameterized-scheduler plugin](https://github.com/jenkinsci/parameterized-scheduler-plugin)

Please add @colourmeamused (username for both Github and Jenkins infra) as release uploader.
[Github user page](https://github.com/colourmeamused)
[Jenkins Infra LDAP user](https://issues.jenkins-ci.org/secure/ViewProfile.jspa?name=colourmeamused)
Current release uploader: @batmat 
Current maintainers: @batmat and @colourmeamused
[ci.jenkins.io builds](https://ci.jenkins.io/job/Plugins/job/parameterized-scheduler-plugin/job/master/) enabled via buildPlugin()



# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
