### PR TITLE
Add kbriggs to plugin-git-chooser-alternative

### DIFF
--- a/permissions/plugin-git-chooser-alternative.yml
+++ b/permissions/plugin-git-chooser-alternative.yml
@@ -2,4 +2,5 @@
 name: "git-chooser-alternative"
 paths:
 - "org/jenkins-ci/plugins/git-chooser-alternative"
-developers: []
+developers:
+- "kbriggs"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Add uploader for https://github.com/jenkinsci/git-chooser-alternative-plugin. The plugin did not get a developer assignment on initial import because there had been no recent uploads.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
