### PR TITLE
Add blueocean-maven-plugin permissions

### DIFF
--- a/permissions/component-blueocean-maven-plugin.yml
+++ b/permissions/component-blueocean-maven-plugin.yml
@@ -1,0 +1,8 @@
+---
+name: "blueocean-maven-plugin"
+paths:
+- "io/jenkins/blueocean/blueocean-maven-plugin"
+developers:
+- "michaelneale"
+- "vivek"
+- "kzantow"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

This is a *Maven plugin*, it is only needed for build time and is optional to support javascript tooling while developing Blue Ocean plugins.

Add path to a blueocean-maven-plugin, from here: https://github.com/jenkinsci/blueocean-maven-plugin from @kzantow

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] ~Add link to resolved HOSTING issue in description above~

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
