### PR TITLE
Add 'flow' as dev to plugin-jabber

### DIFF
--- a/permissions/plugin-jabber.yml
+++ b/permissions/plugin-jabber.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jvnet/hudson/plugins/jabber"
 developers:
 - "kutzi"
+- "flow"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Add 'flow' as developer to [plugin-jabber](https://github.com/jenkinsci/jabber-plugin). See https://groups.google.com/d/msg/jenkinsci-dev/woTwauXx5mU/EhpBTa3KAwAJ and summoning @kutzi.


<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above



### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
