### PR TITLE
Adding more authors to vSphere Plugin

### DIFF
--- a/permissions/plugin-vsphere-cloud.yml
+++ b/permissions/plugin-vsphere-cloud.yml
@@ -5,3 +5,5 @@ paths:
 developers:
 - "jswager"
 - "jswager1"
+- "pjdarton"
+- "elordahl"


### PR DESCRIPTION
# Description
Requesting access for more authors to the vSphere Plugin

# Submitter checklist for changing permissions
- [x] GitHub Repo: https://github.com/jenkinsci/vsphere-cloud-plugin
- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
- [x] @jswager is myself
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
