### PR TITLE
Adding abayer to workflow-durable-task-step

### DIFF
--- a/permissions/plugin-workflow-durable-task-step.yml
+++ b/permissions/plugin-workflow-durable-task-step.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
+- "abayer"


### PR DESCRIPTION
# Description

Adding myself to https://github.com/jenkinsci/workflow-durable-task-step-plugin. cc @jglick and @kohsuke for approval.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
