### PR TITLE
Add perms so I can cut alpha releases of random-job-builder

### DIFF
--- a/permissions/plugin-random-job-builder.yml
+++ b/permissions/plugin-random-job-builder.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/random-job-builder"
 developers:
 - "stephenconnolly"
+- "svanoort"


### PR DESCRIPTION
# Description

Requesting permissions to cut releases of https://github.com/jenkinsci/random-job-builder-plugin so that I can cut alpha/beta releases of the new load generators work pre-Jenkins World (since @stephenc is on vacation and won't be able to review for full merge).

Requesting from @stephenc - thanks!

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
