### PR TITLE
Edit plugin path

### DIFF
--- a/permissions/plugin-labeled-test-groups-publisher.yml
+++ b/permissions/plugin-labeled-test-groups-publisher.yml
@@ -1,6 +1,6 @@
 ---
 name: "labeled-test-groups-publisher"
 paths:
-- "org/jvnet/hudson/plugins/labeled-test-groups-publisher"
+- "org/jenkins-ci/plugins/labeled-test-groups-publisher"
 developers:
 - "lbordowitz"


### PR DESCRIPTION
The groupid has been updated/modernized for this plugin to allow pipeline stuff. The path permissions should reflect this.

https://wiki.jenkins.io/display/JENKINS/LabeledTestGroupsPublisher+Plugin

