### PR TITLE
Add gurumaia to slack plugin

### DIFF
--- a/permissions/plugin-slack.yml
+++ b/permissions/plugin-slack.yml
@@ -6,3 +6,4 @@ developers:
 - "grantmd"
 - "kmadel"
 - "sag47"
+- "gurumaia"


### PR DESCRIPTION
# Description

Requesting access to upload the slack plugin, of which I'm now a maintainer as can be seen here:
https://github.com/jenkinsci/slack-plugin
@kmadel or @samrocketman can confirm.

# Submitter checklist for changing permissions
### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
