### PR TITLE
Add jbochenski to logstash-plugin

### DIFF
--- a/permissions/plugin-logstash.yml
+++ b/permissions/plugin-logstash.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/logstash"
 developers:
 - "rgerard"
+- "jbochenski"


### PR DESCRIPTION
I'm the only active maintainer https://groups.google.com/forum/#!msg/jenkinsci-dev/0H5rgM3Qf58/AvbGbE1XBwAJ

# Description

https://github.com/jenkinsci/logstash-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above 

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
