### PR TITLE
Adds abayer and svanoort to a bunch of Pipeline-related plugins

### DIFF
--- a/permissions/plugin-branch-api.yml
+++ b/permissions/plugin-branch-api.yml
@@ -7,3 +7,4 @@ developers:
 - "recena"
 - "stephenconnolly"
 - "abayer"
+- "svanoort"

--- a/permissions/plugin-cloudbees-bitbucket-branch-source.yml
+++ b/permissions/plugin-cloudbees-bitbucket-branch-source.yml
@@ -5,3 +5,5 @@ paths:
 developers:
 - "amuniz"
 - "stephenconnolly"
+- "abayer"
+- "svanoort"

--- a/permissions/plugin-github-branch-source.yml
+++ b/permissions/plugin-github-branch-source.yml
@@ -6,3 +6,5 @@ developers:
 - "jglick"
 - "recena"
 - "stephenconnolly"
+- "abayer"
+- "svanoort"

--- a/permissions/plugin-pipeline-build-step.yml
+++ b/permissions/plugin-pipeline-build-step.yml
@@ -4,3 +4,5 @@ paths:
 - "org/jenkins-ci/plugins/pipeline-build-step"
 developers:
 - "jglick"
+- "abayer"
+- "svanoort"

--- a/permissions/plugin-pipeline-milestone-step.yml
+++ b/permissions/plugin-pipeline-milestone-step.yml
@@ -6,3 +6,4 @@ developers:
 - "amuniz"
 - "svanoort"
 - "jglick"
+- "abayer"

--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -7,3 +7,4 @@ developers:
 - "oleg_nenashev"
 - "stephenconnolly"
 - "rsandell"
+- "svanoort"

--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -7,3 +7,4 @@ developers:
 - "oleg_nenashev"
 - "stephenconnolly"
 - "rsandell"
+- "svanoort"

--- a/permissions/plugin-pipeline-model-extensions.yml
+++ b/permissions/plugin-pipeline-model-extensions.yml
@@ -7,3 +7,4 @@ developers:
 - "oleg_nenashev"
 - "stephenconnolly"
 - "rsandell"
+- "svanoort"

--- a/permissions/plugin-pipeline-stage-tags-metadata.yml
+++ b/permissions/plugin-pipeline-stage-tags-metadata.yml
@@ -7,3 +7,4 @@ developers:
 - "oleg_nenashev"
 - "stephenconnolly"
 - "rsandell"
+- "svanoort"

--- a/permissions/plugin-script-security.yml
+++ b/permissions/plugin-script-security.yml
@@ -6,3 +6,4 @@ developers:
 - "jglick"
 - "kohsuke"
 - "abayer"
+- "svanoort"

--- a/permissions/plugin-structs.yml
+++ b/permissions/plugin-structs.yml
@@ -7,3 +7,5 @@ developers:
 - "kohsuke"
 - "oleg_nenashev"
 - "stephenconnolly"
+- "abayer"
+- "svanoort"

--- a/permissions/plugin-workflow-aggregator.yml
+++ b/permissions/plugin-workflow-aggregator.yml
@@ -5,3 +5,5 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
+- "abayer"
+- "svanoort"

--- a/permissions/plugin-workflow-cps-global-lib.yml
+++ b/permissions/plugin-workflow-cps-global-lib.yml
@@ -6,3 +6,4 @@ developers:
 - "jglick"
 - "kohsuke"
 - "abayer"
+- "svanoort"

--- a/permissions/plugin-workflow-durable-task-step.yml
+++ b/permissions/plugin-workflow-durable-task-step.yml
@@ -6,3 +6,4 @@ developers:
 - "jglick"
 - "kohsuke"
 - "abayer"
+- "svanoort"

--- a/permissions/plugin-workflow-multibranch.yml
+++ b/permissions/plugin-workflow-multibranch.yml
@@ -7,3 +7,4 @@ developers:
 - "recena"
 - "abayer"
 - "stephenconnolly"
+- "svanoort"

--- a/permissions/plugin-workflow-scm-step.yml
+++ b/permissions/plugin-workflow-scm-step.yml
@@ -5,3 +5,5 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
+- "abayer"
+- "svanoort"

--- a/permissions/plugin-workflow-support.yml
+++ b/permissions/plugin-workflow-support.yml
@@ -6,3 +6,4 @@ developers:
 - "jglick"
 - "kohsuke"
 - "svanoort"
+- "abayer"


### PR DESCRIPTION
# Description

We're now maintaining these as a whole, so we should probably be able
to, y'know, *release* them.

Repos in question:
* https://github.com/jenkinsci/branch-api-plugin
* https://github.com/jenkinsci/bitbucket-branch-source-plugin
* https://github.com/jenkinsci/github-branch-source-plugin
* https://github.com/jenkinsci/pipeline-build-step-plugin
* https://github.com/jenkinsci/pipeline-milestone-step-plugin
* https://github.com/jenkinsci/pipeline-model-definition-plugin
* https://github.com/jenkinsci/script-security-plugin/
* https://github.com/jenkinsci/structs-plugin
* https://github.com/jenkinsci/workflow-aggregator-plugin/
* https://github.com/jenkinsci/workflow-cps-global-lib-plugin
* https://github.com/jenkinsci/workflow-durable-task-step-plugin
* https://github.com/jenkinsci/workflow-multibranch-plugin/
* https://github.com/jenkinsci/workflow-scm-step-plugin
* https://github.com/jenkinsci/workflow-support-plugin

Relevant maintainers:
* myself for Declarative - I approve adding Sam. =)
* @jglick and @stephenc for pretty much everything else

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
