### PR TITLE
Change maintainer list for ghprb. benpatterson is transitioning off.

### DIFF
--- a/permissions/plugin-ghprb.yml
+++ b/permissions/plugin-ghprb.yml
@@ -3,7 +3,8 @@ name: "ghprb"
 paths:
 - "org/jenkins-ci/plugins/ghprb"
 developers:
-- "davidtanner"
-- "valdisrigdon"
+- "bjoernhaeuser"
 - "bpatterson"
-- "mmitche"
+- "jpwku"
+- "papajulio"
+- "sag47"


### PR DESCRIPTION
I am going to transition off of maintaining this plugin. (It was awesome, but I need to transition duties since I won't have enough time to properly maintain it, and it'll be good to get fresh eyes on it.)

# Description
We're adding a group of folks who have either contributed before, maintain other plugins, or otherwise have a vested interest in this plugin and cycles to help. Ghprb plugin can be found [here](https://github.com/jenkinsci/ghprb-plugin/)

# Submitter checklist for changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
