### PR TITLE
Upload permissions for android-apk-size-watcher

### DIFF
--- a/permissions/plugin-android-apk-size-watcher.yml
+++ b/permissions/plugin-android-apk-size-watcher.yml
@@ -1,0 +1,6 @@
+---
+name: "android-apk-size-watcher"
+paths:
+- "org/jenkins-ci/plugins/android-apk-size-watcher"
+developers:
+- "xgleich1"


### PR DESCRIPTION
Requesting permission to release my plugin.

Wiki: [https://wiki.jenkins.io/display/JENKINS/Android+Apk+Size+Watcher+Plugin](https://wiki.jenkins.io/display/JENKINS/Android+Apk+Size+Watcher+Plugin)

Repository: [https://github.com/jenkinsci/android-apk-size-watcher-plugin](https://github.com/jenkinsci/android-apk-size-watcher-plugin)

Hosting Request: [https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-391?filter=allissues](https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-391?filter=allissues)

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

Question for the group id: Do I have to specify my own in the pom? Or is it enough to have the org.jenkins-ci.plugins parent?

Thank you in advance!
