### PR TITLE
Add blueocean-test-ssh-server

### DIFF
--- a/permissions/component-blueocean-maven-plugin.yml
+++ b/permissions/component-blueocean-maven-plugin.yml
@@ -1,0 +1,8 @@
+---
+name: "blueocean-maven-plugin"
+paths:
+- "io/jenkins/blueocean/blueocean-maven-plugin"
+developers:
+- "michaelneale"
+- "vivek"
+- "kzantow"

--- a/permissions/component-blueocean-test-ssh-server.yml
+++ b/permissions/component-blueocean-test-ssh-server.yml
@@ -1,0 +1,8 @@
+---
+name: "blueocean-test-ssh-server"
+paths:
+- "io/jenkins/blueocean/blueocean-test-ssh-server"
+developers:
+- "michaelneale"
+- "vivek"
+- "kzantow"


### PR DESCRIPTION
# Description

Need a test SSH server for blueocean with a more recent SSHD version but it will conflict with Jenkins core otherwise.

Repo here: https://github.com/kzantow/blueocean-test-ssh-server
HOSTING: https://issues.jenkins-ci.org/browse/HOSTING-400


# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
