### PR TITLE
Remove old maintainers from gitlab-plugin deploy permissions

### DIFF
--- a/permissions/plugin-gitlab-plugin.yml
+++ b/permissions/plugin-gitlab-plugin.yml
@@ -4,8 +4,4 @@ paths:
 - "com/dabsquared/gitlab-plugin"
 - "org/jenkins-ci/plugins/gitlab-plugin"
 developers:
-- "bass_rock"
-- "batmat"
-- "coderhugo"
 - "owenmehegan"
-- "xaniasd"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Remove old maintainers from deploy permissions for https://github.com/jenkinsci/gitlab-plugin

In addition, please remove the following from the GitHub Developers group for the plugin, as they are no longer active maintainers:
@slide 
@batmat 
@bassrock
@colourmeamused 
@omorillo
@coder-hugo
@xaniasd
@trance1st

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above