### PR TITLE
Remove never-logged-in account from vsphere-cloud plugin permissions

### DIFF
--- a/permissions/plugin-vsphere-cloud.yml
+++ b/permissions/plugin-vsphere-cloud.yml
@@ -6,4 +6,3 @@ developers:
 - "jswager"
 - "jswager1"
 - "pjdarton"
-- "elordahl"


### PR DESCRIPTION
# Description

PR #376 is [failing to take effect](https://github.com/jenkins-infra/repository-permissions-updater/pull/376#issuecomment-321300373) because Eric (@elordahl) has yet to log in to Artifactory.
We can re-add Eric once he has logged in to Artifactory, but in the meantime I need the remaining changes to get applied in order to do a release on the vsphere-cloud plugin.
This PR has been raised following advice from @daniel-beck in [INFRA-1327](https://issues.jenkins-ci.org/browse/INFRA-1327)

# Submitter checklist for changing permissions
- [x] GitHub Repo: https://github.com/jenkinsci/vsphere-cloud-plugin
- [x] Permission to make this change was approved in #376 and [INFRA-1327](https://issues.jenkins-ci.org/browse/INFRA-1327)
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions) - This should _now_ be the case.
