### PR TITLE
Add danielbeck to matrix-auth

### DIFF
--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -3,6 +3,7 @@ name: "matrix-auth"
 paths:
 - "org/jenkins-ci/plugins/matrix-auth"
 developers:
+- "danielbeck"
 - "jglick"
 - "kohsuke"
 - "mathias_nyman"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/matrix-auth-plugin/

I'd like to merge and release https://github.com/jenkinsci/matrix-auth-plugin/pull/18 and https://github.com/jenkinsci/matrix-auth-plugin/pull/20 and, if I find the time, ideally take over some maintainership duties to ensure the plugin isn't terrible.

As existing uploaders I need your approval @jglick @mathias-nyman 

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
