### PR TITLE
Add abayer and svanoort to scm-api

### DIFF
--- a/permissions/plugin-scm-api.yml
+++ b/permissions/plugin-scm-api.yml
@@ -6,3 +6,5 @@ developers:
 - "jglick"
 - "recena"
 - "stephenconnolly"
+- "abayer"
+- "svanoort"


### PR DESCRIPTION
# Description

Forgot to add myself and @svanoort to `scm-api` previously! cc @stephenc @jglick 

https://github.com/jenkinsci/scm-api-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
