### PR TITLE
ask one question here due to not found issue tab

### DIFF
--- a/permissions/plugin-cisco-spark.yml
+++ b/permissions/plugin-cisco-spark.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/cisco-spark"
 developers:
 - "fujian"
+


### PR DESCRIPTION
[DEBUG] Using connector WagonRepositoryConnector with priority 0.0 for https://repo.jenkins-ci.org/content/repositories/releases/ with username=fujian, password=***
[INFO] Uploading: https://repo.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/cisco-spark/1.1.0/cisco-spark-1.1.0.hpi
[INFO] Uploading: https://repo.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/cisco-spark/1.1.0/cisco-spark-1.1.0.pom


Caused by: org.apache.maven.artifact.deployer.ArtifactDeploymentException: Failed to deploy artifacts: Could not transfer artifact org.jenkins-ci.plugins:cisco-spark:hpi:1.1.0 from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/content/repositories/releases/): Access denied to: https://repo.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/cisco-spark/1.1.0/cisco-spark-1.1.0.hpi, ReasonPhrase: Forbidden.

Hi, I am the author for this plugin. and the name and password is ok for login into to community. and also this file existed and I also login into https://repo.jenkins-ci.org/webapp/#/home at once. 
But why I am receiving forbidden to release new version.


Just ask this question here by updating one file to error, please don't merge the PR,
 
anybody can help to take a look at this question? Thank you very much!