### PR TITLE
Initialize the permission file for bytecode-compatiliby-transformer

### DIFF
--- a/permissions/component-lib-bytecode-compatibility-transformer.yml
+++ b/permissions/component-lib-bytecode-compatibility-transformer.yml
@@ -1,0 +1,6 @@
+---
+name: "lib-jenkins-bytecode-compatibility-transformer"
+paths:
+- "org/jenkins-ci/bytecode-compatibility-transformer"
+developers:
+- "batmat"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

I would like to be able to release a 2.x pre-release of [bytecode-compatibility-transformer](https://github.com/jenkinsci/bytecode-compatibility-transformer/b) that includes ASM6 with https://github.com/jenkinsci/bytecode-compatibility-transformer/pull/9, to keep doing baby steps with moving forward our Java 9 compatibility.

Please @kohsuke @rtyler @markewaite @jglick @abayer @jtnord @daniel-beck can you weigh in? Thanks

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
