### PR TITLE
Stupid mistake, name must be artifactId...

### DIFF
--- a/permissions/component-bytecode-compatibility-transformer.yml
+++ b/permissions/component-bytecode-compatibility-transformer.yml
@@ -1,5 +1,5 @@
 ---
-name: "lib-jenkins-bytecode-compatibility-transformer"
+name: "bytecode-compatibility-transformer"
 paths:
 - "org/jenkins-ci/bytecode-compatibility-transformer"
 developers:


### PR DESCRIPTION
Stupid followup of https://github.com/jenkins-infra/repository-permissions-updater/pull/441 where I didn't even manage to make name == artifactId