### PR TITLE
Request upload permission for azure-commons, azure-acs, azure-container-agents and kubernetes-cd

### DIFF
--- a/permissions/plugin-azure-acs.yml
+++ b/permissions/plugin-azure-acs.yml
@@ -1,0 +1,6 @@
+---
+name: "azure-acs"
+paths:
+- "org/jenkins-ci/plugins/azure-acs"
+developers:
+- "chenkennt"

--- a/permissions/plugin-azure-commons.yml
+++ b/permissions/plugin-azure-commons.yml
@@ -1,0 +1,6 @@
+---
+name: "azure-commons"
+paths:
+- "org/jenkins-ci/plugins/azure-commons"
+developers:
+- "chenkennt"

--- a/permissions/plugin-azure-container-agents.yml
+++ b/permissions/plugin-azure-container-agents.yml
@@ -1,0 +1,6 @@
+---
+name: "azure-container-agents"
+paths:
+- "org/jenkins-ci/plugins/azure-container-agents"
+developers:
+- "chenkennt"

--- a/permissions/plugin-kubernetes-cd.yml
+++ b/permissions/plugin-kubernetes-cd.yml
@@ -1,0 +1,6 @@
+---
+name: "kubernetes-cd"
+paths:
+- "org/jenkins-ci/plugins/kubernetes-cd"
+developers:
+- "chenkennt"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
Request upload permission for the following plugins:

### Azure Commons Plugin
https://github.com/jenkinsci/azure-commons-plugin
https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-422

### Azure Container Agents Plugin
https://github.com/jenkinsci/azure-container-agents-plugin
https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-423

### Azure Container Service Plugin
https://github.com/jenkinsci/azure-acs-plugin
https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-424

### Kubernetes Continuous Deploy Plugin
https://github.com/jenkinsci/kubernetes-cd-plugin
https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-425

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
