### PR TITLE
Lowercase user names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,11 +6,13 @@ properties([
         ]]
 ])
 
-/* Exit early if we are executing in a pull request, until this ticket is resolved:
+def dryRun = true
+
+/* Exit early if we are executing in a pull request or branch in trusted.ci, until this ticket is resolved:
  * https://issues.jenkins-ci.org/browse/INFRA-902
  */
-if (env.CHANGE_ID) {
-    return
+if (!env.CHANGE_ID && (!env.BRANCH_NAME || env.BRANCH_NAME == 'master') && infra.isTrusted()) {
+    dryRun = false
 }
 
 node('java') {
@@ -28,13 +30,19 @@ node('java') {
         sh "${mvnHome}/bin/mvn -U clean verify"
 
         stage 'Run'
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'artifactoryAdmin',
-                          usernameVariable: 'ARTIFACTORY_USERNAME', passwordVariable: 'ARTIFACTORY_PASSWORD']]) {
-            sh '${JAVA_HOME}/bin/java' +
-                    ' -DdefinitionsDir=$PWD/permissions' +
-                    ' -DartifactoryApiTempDir=$PWD/json' +
-                    ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
-                    ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
+
+        def javaArgs = ' -DdefinitionsDir=$PWD/permissions' +
+                       ' -DartifactoryApiTempDir=$PWD/json' +
+                       ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
+                       ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
+
+
+        if (dryRun) {
+            sh '${JAVA_HOME}/bin/java -DdryRun=true' + javaArgs
+        } else {
+            withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                sh '${JAVA_HOME}/bin/java ' + javaArgs
+            }
         }
     } finally {
         stage 'Archive'

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -161,7 +161,7 @@ public class ArtifactoryPermissionsUpdater {
                         users [:]
                     } else {
                         users definition.developers.collectEntries { developer ->
-                            ["$developer": ["w", "n"]]
+                            ["${developer.toLowerCase()}": ["w", "n"]]
                         }
                     }
                     groups([:])


### PR DESCRIPTION
Frequent source of mistakes in the permissions files.

Examples:
https://github.com/jenkins-infra/repository-permissions-updater/pull/454#pullrequestreview-66068789
https://github.com/jenkins-infra/repository-permissions-updater/pull/443#pullrequestreview-64527584
https://github.com/jenkins-infra/repository-permissions-updater/pull/416#discussion_r137341919
etc.

It doesn't look like any user name in Artifactory (i.e. LDAP) has uppercase letters, so just lowercase whatever is in the file.

CC @olblak who could confirm we have no user names with uppercase letters.