### PR TITLE
Requesting permissions for several branch-source traits

### DIFF
--- a/permissions/plugin-bitbucket-source-aged-refs-trait.yml
+++ b/permissions/plugin-bitbucket-source-aged-refs-trait.yml
@@ -1,0 +1,6 @@
+---
+name: "bitbucket-source-aged-refs-trait"
+paths:
+- "org/jenkins-ci/plugins/bitbucket-source-aged-refs-trait"
+developers:
+- "witokondoria"

--- a/permissions/plugin-bitbucket-source-commit-skip-trait.yml
+++ b/permissions/plugin-bitbucket-source-commit-skip-trait.yml
@@ -1,0 +1,6 @@
+---
+name: "bitbucket-source-commit-skip-trait"
+paths:
+- "org/jenkins-ci/plugins/bitbucket-source-commit-skip-trait"
+developers:
+- "witokondoria"

--- a/permissions/plugin-bitbucket-source-jira-validator-trait.yml
+++ b/permissions/plugin-bitbucket-source-jira-validator-trait.yml
@@ -1,0 +1,6 @@
+---
+name: "bitbucket-source-jira-validator-trait"
+paths:
+- "org/jenkins-ci/plugins/bitbucket-source-jira-validator-trait"
+developers:
+- "witokondoria"

--- a/permissions/plugin-github-source-aged-refs-trait.yml
+++ b/permissions/plugin-github-source-aged-refs-trait.yml
@@ -1,0 +1,7 @@
+---
+name: "github-source-aged-refs-trait"
+paths:
+- "org/jenkins-ci/plugins/github-source-aged-refs-trait"
+developers:
+- "witokondoria"
+

--- a/permissions/plugin-github-source-commit-skip-trait.yml
+++ b/permissions/plugin-github-source-commit-skip-trait.yml
@@ -1,0 +1,6 @@
+---
+name: "github-source-commit-skip-trait"
+paths:
+- "org/jenkins-ci/plugins/github-source-commit-skip-trait"
+developers:
+- "witokondoria"

--- a/permissions/plugin-github-source-jira-validator-trait.yml
+++ b/permissions/plugin-github-source-jira-validator-trait.yml
@@ -1,0 +1,6 @@
+---
+name: "github-source-jira-validator-trait"
+paths:
+- "org/jenkins-ci/plugins/github-source-jira-validator-trait"
+developers:
+- "witokondoria"

--- a/permissions/pom-branch-source-aged-refs-traits.yml
+++ b/permissions/pom-branch-source-aged-refs-traits.yml
@@ -1,0 +1,6 @@
+---
+name: "branch-source-aged-refs-traits"
+paths:
+- "org/jenkins-ci/plugins/branch-source-aged-refs-traits"
+developers:
+- "witokondoria"

--- a/permissions/pom-branch-source-commit-skip-traits.yml
+++ b/permissions/pom-branch-source-commit-skip-traits.yml
@@ -1,0 +1,6 @@
+---
+name: "branch-source-commit-skip-traits"
+paths:
+- "org/jenkins-ci/plugins/branch-source-commit-skip-traits"
+developers:
+- "witokondoria"

--- a/permissions/pom-branch-source-jira-validator-traits.yml
+++ b/permissions/pom-branch-source-jira-validator-traits.yml
@@ -1,0 +1,6 @@
+---
+name: "branch-source-jira-validator-traits"
+paths:
+- "org/jenkins-ci/plugins/branch-source-jira-validator-traits"
+developers:
+- "witokondoria"


### PR DESCRIPTION
# Description

Three new plugins, implementing additional traits over branch-source plugins (currently github and bitbucket)

https://github.com/jenkinsci/branch-source-aged-refs-traits-plugin
https://github.com/jenkinsci/branch-source-commit-skip-traits-plugin
https://github.com/jenkinsci/branch-source-jira-validator-traits-plugin

https://issues.jenkins-ci.org/browse/HOSTING-414
https://issues.jenkins-ci.org/browse/HOSTING-417
https://issues.jenkins-ci.org/browse/HOSTING-428

branch-source-aged-refs-traits-plugin has a pending pull request (jenkinsci/branch-source-aged-refs-traits-plugin#1), blocked due a dependency, where the GAV will be changed to the one in this permission request.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
