### PR TITLE
google-storage-plugin permissions: add Alexandra and Brad

### DIFF
--- a/permissions/plugin-google-storage-plugin.yml
+++ b/permissions/plugin-google-storage-plugin.yml
@@ -7,3 +7,5 @@ developers:
 - "mattmoor"
 - "reprogrammer"
 - "tcnghia"
+- "a_goulti"
+- "bwkimmel"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

Adding @bwkimmel and myself to the list of developers for ([Google Storage Plugin](https://github.com/jenkinsci/google-storage-plugin/)).
We are the [new maintainers for the plugin](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/V6XoKTF8LYs/hxN795h9AQAJ) 

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
