### PR TITLE
scm-trait-commit-skip permissions

### DIFF
--- a/permissions/plugin-bitbucket-scm-trait-commit-skip.yml
+++ b/permissions/plugin-bitbucket-scm-trait-commit-skip.yml
@@ -1,0 +1,6 @@
+---
+name: "bitbucket-scm-trait-commit-skip"
+paths:
+- "org/jenkins-ci/plugins/bitbucket-scm-trait-commit-skip"
+developers:
+- "witokondoria"

--- a/permissions/plugin-bitbucket-source-commit-skip-trait.yml
+++ b/permissions/plugin-bitbucket-source-commit-skip-trait.yml
@@ -1,6 +1,0 @@
----
-name: "bitbucket-source-commit-skip-trait"
-paths:
-- "org/jenkins-ci/plugins/bitbucket-source-commit-skip-trait"
-developers:
-- "witokondoria"

--- a/permissions/plugin-github-scm-trait-commit-skip.yml
+++ b/permissions/plugin-github-scm-trait-commit-skip.yml
@@ -1,0 +1,6 @@
+---
+name: "github-scm-trait-commit-skip"
+paths:
+- "org/jenkins-ci/plugins/github-scm-trait-commit-skip"
+developers:
+- "witokondoria"

--- a/permissions/plugin-github-source-commit-skip-trait.yml
+++ b/permissions/plugin-github-source-commit-skip-trait.yml
@@ -1,6 +1,0 @@
----
-name: "github-source-commit-skip-trait"
-paths:
-- "org/jenkins-ci/plugins/github-source-commit-skip-trait"
-developers:
-- "witokondoria"

--- a/permissions/pom-branch-source-commit-skip-traits.yml
+++ b/permissions/pom-branch-source-commit-skip-traits.yml
@@ -1,6 +1,0 @@
----
-name: "branch-source-commit-skip-traits"
-paths:
-- "org/jenkins-ci/plugins/branch-source-commit-skip-traits"
-developers:
-- "witokondoria"

--- a/permissions/pom-scm-trait-commit-skip-parent.yml
+++ b/permissions/pom-scm-trait-commit-skip-parent.yml
@@ -1,0 +1,6 @@
+---
+name: "scm-trait-commit-skip-parent"
+paths:
+- "org/jenkins-ci/plugins/scm-trait-commit-skip-parent"
+developers:
+- "witokondoria"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/scm-trait-commit-skip

That repo was renamed from branch-source-commit-skip-traits ans so were its artifacts, as per naming recommendations on #456 ([stephen comment](https://github.com/jenkins-infra/repository-permissions-updater/pull/456#issuecomment-334703864)). Thus, this PR is just meant to fix upload paths.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
