### PR TITLE
Durable task perms for pipeline team

### DIFF
--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -5,3 +5,5 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
+- "svanoort"
+- "abayer"


### PR DESCRIPTION
# Description

Grant permissions to release the [Durable task plugin](https://github.com/jenkinsci/durable-task-plugin) to the same people who use it in [Workflow-durable-task-step](https://github.com/jenkinsci/workflow-durable-task-step-plugin/). 

@jglick 

# Submitter checklist for changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
