### PR TITLE
Add casz to Confluence publisher

### DIFF
--- a/permissions/plugin-confluence-publisher.yml
+++ b/permissions/plugin-confluence-publisher.yml
@@ -3,4 +3,5 @@ name: "confluence-publisher"
 paths:
 - "org/jenkins-ci/plugins/confluence-publisher"
 developers:
+- "jhansche"
 - "casz"

--- a/permissions/plugin-confluence-publisher.yml
+++ b/permissions/plugin-confluence-publisher.yml
@@ -2,4 +2,5 @@
 name: "confluence-publisher"
 paths:
 - "org/jenkins-ci/plugins/confluence-publisher"
-developers: []
+developers:
+- "casz"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
please add write access for me (casz) to confluence publisher plugin and merge this PR so we can have a release 👍 

Plugin Maintainer:

@jhansche

Plugin Repository:

https://github.com/jenkinsci/confluence-publisher-plugin

Pull Request reference:

https://github.com/jenkinsci/confluence-publisher-plugin/pull/10#issuecomment-338097034

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
