### PR TITLE
Add Blue Ocean dependencies: JDL and core-js as plugins

### DIFF
--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -1,0 +1,8 @@
+---
+name: "blueocean-core-js"
+paths:
+- "io/jenkins/blueocean/blueocean-core-js"
+developers:
+- "michaelneale"
+- "vivek"
+- "kzantow"

--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -5,4 +5,7 @@ paths:
 developers:
 - "michaelneale"
 - "vivek"
+- "tfennelly"
 - "kzantow"
+- "tscherler"
+

--- a/permissions/plugin-jenkins-design-language.yml
+++ b/permissions/plugin-jenkins-design-language.yml
@@ -5,4 +5,7 @@ paths:
 developers:
 - "michaelneale"
 - "vivek"
+- "tfennelly"
 - "kzantow"
+- "tscherler"
+

--- a/permissions/plugin-jenkins-design-language.yml
+++ b/permissions/plugin-jenkins-design-language.yml
@@ -1,0 +1,8 @@
+---
+name: "jenkins-design-language"
+paths:
+- "io/jenkins/blueocean/jenkins-design-language"
+developers:
+- "michaelneale"
+- "vivek"
+- "kzantow"


### PR DESCRIPTION
# Description

Adds Jenkins Design Language and Blue Ocean Core JS as plugins. Necessary to fix a painful development process. Part of Blue Ocean: https://github.com/jenkinsci/blueocean-plugin

See:
https://github.com/jenkinsci/blueocean-plugin/tree/master/blueocean-core-js
https://github.com/jenkinsci/blueocean-plugin/tree/master/jenkins-design-language

cc: @vivek @michaelneale 

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
