### PR TITLE
Add myself as jsoup developer

### DIFF
--- a/permissions/plugin-jsoup.yml
+++ b/permissions/plugin-jsoup.yml
@@ -2,4 +2,5 @@
 name: "jsoup"
 paths:
 - "org/jenkins-ci/plugins/jsoup"
-developers: []
+developers:
+- "stephenconnolly"


### PR DESCRIPTION
# Description

For the JSoup plugin, I did not get picked up as the maintainer.

https://wiki.jenkins.io/display/JENKINS/JSoup+Plugin

https://github.com/jenkinsci/jsoup-plugin

# Submitter checklist for changing permissions

- [x] Add link to plugin/component Git repository in description above
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
