### PR TITLE
scm-filter-aged-refs permissinons

### DIFF
--- a/permissions/plugin-bitbucket-scm-filter-aged-refs.yml
+++ b/permissions/plugin-bitbucket-scm-filter-aged-refs.yml
@@ -1,0 +1,6 @@
+---
+name: "bitbucket-scm-filter-aged-refs"
+paths:
+- "org/jenkins-ci/plugins/bitbucket-scm-filter-aged-refs"
+developers:
+- "witokondoria"

--- a/permissions/plugin-bitbucket-source-aged-refs-trait.yml
+++ b/permissions/plugin-bitbucket-source-aged-refs-trait.yml
@@ -1,6 +1,0 @@
----
-name: "bitbucket-source-aged-refs-trait"
-paths:
-- "org/jenkins-ci/plugins/bitbucket-source-aged-refs-trait"
-developers:
-- "witokondoria"

--- a/permissions/plugin-github-scm-filter-aged-refs.yml
+++ b/permissions/plugin-github-scm-filter-aged-refs.yml
@@ -1,0 +1,7 @@
+---
+name: "github-scm-filter-aged-refs"
+paths:
+- "org/jenkins-ci/plugins/github-scm-filter-aged-refs"
+developers:
+- "witokondoria"
+

--- a/permissions/plugin-github-source-aged-refs-trait.yml
+++ b/permissions/plugin-github-source-aged-refs-trait.yml
@@ -1,7 +1,0 @@
----
-name: "github-source-aged-refs-trait"
-paths:
-- "org/jenkins-ci/plugins/github-source-aged-refs-trait"
-developers:
-- "witokondoria"
-

--- a/permissions/pom-branch-source-aged-refs-traits.yml
+++ b/permissions/pom-branch-source-aged-refs-traits.yml
@@ -1,6 +1,0 @@
----
-name: "branch-source-aged-refs-traits"
-paths:
-- "org/jenkins-ci/plugins/branch-source-aged-refs-traits"
-developers:
-- "witokondoria"

--- a/permissions/pom-scm-filter-aged-refs-parent.yml
+++ b/permissions/pom-scm-filter-aged-refs-parent.yml
@@ -1,0 +1,6 @@
+---
+name: "scm-filter-aged-refs-parent"
+paths:
+- "org/jenkins-ci/plugins/scm-filter-aged-refs-parent"
+developers:
+- "witokondoria"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/scm-filter-aged-refs-plugin

That repo was renamed from branch-source-aged-refs-traits and so were its artifacts, as per naming recommendations on #456 ([stephen comment](https://github.com/jenkins-infra/repository-permissions-updater/pull/456#issuecomment-334703864)). Thus, this PR is just meant to fix upload paths.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
