### PR TITLE
scm-filter-jira-validator permissions

### DIFF
--- a/permissions/plugin-bitbucket-scm-filter-jira-validator.yml
+++ b/permissions/plugin-bitbucket-scm-filter-jira-validator.yml
@@ -1,0 +1,6 @@
+---
+name: "bitbucket-scm-filter-jira-validator"
+paths:
+- "org/jenkins-ci/plugins/bitbucket-scm-filter-jira-validator"
+developers:
+- "witokondoria"

--- a/permissions/plugin-bitbucket-source-jira-validator-trait.yml
+++ b/permissions/plugin-bitbucket-source-jira-validator-trait.yml
@@ -1,6 +1,0 @@
----
-name: "bitbucket-source-jira-validator-trait"
-paths:
-- "org/jenkins-ci/plugins/bitbucket-source-jira-validator-trait"
-developers:
-- "witokondoria"

--- a/permissions/plugin-github-scm-filter-jira-validator.yml
+++ b/permissions/plugin-github-scm-filter-jira-validator.yml
@@ -1,0 +1,6 @@
+---
+name: "github-scm-filter-jira-validator"
+paths:
+- "org/jenkins-ci/plugins/github-scm-filter-jira-validator"
+developers:
+- "witokondoria"

--- a/permissions/plugin-github-source-jira-validator-trait.yml
+++ b/permissions/plugin-github-source-jira-validator-trait.yml
@@ -1,6 +1,0 @@
----
-name: "github-source-jira-validator-trait"
-paths:
-- "org/jenkins-ci/plugins/github-source-jira-validator-trait"
-developers:
-- "witokondoria"

--- a/permissions/pom-branch-source-jira-validator-traits.yml
+++ b/permissions/pom-branch-source-jira-validator-traits.yml
@@ -1,6 +1,0 @@
----
-name: "branch-source-jira-validator-traits"
-paths:
-- "org/jenkins-ci/plugins/branch-source-jira-validator-traits"
-developers:
-- "witokondoria"

--- a/permissions/pom-scm-filter-jira-validator-parent.yml
+++ b/permissions/pom-scm-filter-jira-validator-parent.yml
@@ -1,0 +1,6 @@
+---
+name: "scm-filter-jira-validator-parent"
+paths:
+- "org/jenkins-ci/plugins/scm-filter-jira-validator-parent"
+developers:
+- "witokondoria"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/scm-filter-jira-validator-plugin

That repo was renamed from branch-source-jira-validator-traits and so were its artifacts, as per naming recommendations on #456 ([stephen comment](https://github.com/jenkins-infra/repository-permissions-updater/pull/456#issuecomment-334703864)). Thus, this PR is just meant to fix upload paths.

The scm-filter-jira-validator-plugin repo has pending work to rename GAVs to match this PR content.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
