### PR TITLE
Added gigasproule to pitmutation plugin permissions

### DIFF
--- a/permissions/plugin-pitmutation.yml
+++ b/permissions/plugin-pitmutation.yml
@@ -4,4 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/pitmutation"
 developers:
 - "edwardk"
-- "gigaSproule"
+- "gigasproule"

--- a/permissions/plugin-pitmutation.yml
+++ b/permissions/plugin-pitmutation.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/pitmutation"
 developers:
 - "edwardk"
+- "gigaSproule"


### PR DESCRIPTION
# Description
Added myself to the list of developers for [pitmutation plugin](https://github.com/jenkinsci/pitmutation-plugin) as the previous maintainer has agreed to allow me to help maintain this plugin.

# Submitter checklist for changing permissions
@edwardwe7

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
