### PR TITLE
Add vgaidarji to plot plugin maintainers

### DIFF
--- a/permissions/plugin-plot.yml
+++ b/permissions/plugin-plot.yml
@@ -5,3 +5,4 @@ paths:
 developers:
 - "ericbn"
 - "drulli"
+- "vgaidarji"


### PR DESCRIPTION
# Description

[Link to plot-plugin](https://github.com/jenkinsci/plot-plugin).
Mentioning other maintainers (@alanharder @sschuberth @uhafner @ericbn), but this plugin is up for adoption and no one supports it at the moment. 
I was given access to [plot-plugin](https://github.com/jenkinsci/plot-plugin) repository during JenkinsWorld 2017 conference by @rtyler. 
I have worked on plugin [compatibility with pipeline](https://github.com/jenkinsci/plot-plugin/pull/32) (reviewed by @svanoort).

# Submitter checklist for changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
