### PR TITLE
Add new maintainer to scm-sync-configuration

### DIFF
--- a/permissions/plugin-scm-sync-configuration.yml
+++ b/permissions/plugin-scm-sync-configuration.yml
@@ -7,3 +7,4 @@ developers:
 - "fcamblor"
 - "ndeloof"
 - "rodrigc"
+- "palacgui"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
After trying to contact the current maintainers (@fcamblor,@rodrigc) of https://github.com/jenkinsci/scm-sync-configuration-plugin for 1 month, i receive no answer so i would like to be a maintainer for the plugin. I would also need write permissions on the github repo for my user @guipal.

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above


### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
