### PR TITLE
Add greybird as maintainer of claim plugin

### DIFF
--- a/permissions/plugin-claim.yml
+++ b/permissions/plugin-claim.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/claim"
 developers:
 - "ki82"
+- "greybird"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I'd like to be added as a maintainer of https://github.com/jenkinsci/claim-plugin.
Current maintainer,  @ki82 agreed to share the ownership on this [mailing list thread](https://groups.google.com/d/msg/jenkinsci-dev/-XEbuDgB9SI/c7LwtO3cBQAJ)

🔺 I will also need the github access to the repository.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
