### PR TITLE
Request upload permission for warrior-plugin

### DIFF
--- a/permissions/plugin-warrior.yml
+++ b/permissions/plugin-warrior.yml
@@ -1,0 +1,6 @@
+---
+name: "warrior"
+paths:
+- "org/jenkins-ci/plugins/warrior"
+developers:
+- "venkat1077"


### PR DESCRIPTION
# Description
Warrior Framework Plugin allows user to integrate Warrior Automation Framework with Jenkins to execute Warrior files.
https://github.com/jenkinsci/warrior-plugin
https://issues.jenkins-ci.org/browse/HOSTING-447

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
