### PR TITLE
remove plugin loadrunner

### DIFF
--- a/permissions/plugin-loadrunner.yml
+++ b/permissions/plugin-loadrunner.yml
@@ -1,6 +1,0 @@
----
-name: "loadrunner"
-paths:
-- "de/tsystems/mms/apm/loadrunner"
-developers:
-- "rpionke"


### PR DESCRIPTION
This closed-source plugin was accidentally uploaded and needs to be removed from UC.

Also see https://github.com/jenkins-infra/backend-update-center2/pull/171