### PR TITLE
Add permissions file for Themis plugin

### DIFF
--- a/permissions/plugin-themis.yml
+++ b/permissions/plugin-themis.yml
@@ -1,0 +1,6 @@
+---
+name: themis
+paths:
+    - org/jenkins-ci/plugins/themis
+developers:
+    - rdelamare


### PR DESCRIPTION
# Description

This pull request adds permission for the Themis plugin, newly added.
- GitHub repository: https://github.com/jenkinsci/themis-plugin
- Hosting request: https://issues.jenkins-ci.org/browse/HOSTING-454

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
