### PR TITLE
plan to move docker-plugin groupId to io.jenkins.docker

### DIFF
--- a/permissions/plugin-docker-plugin.yml
+++ b/permissions/plugin-docker-plugin.yml
@@ -2,6 +2,7 @@
 name: "docker-plugin"
 paths:
 - "com/nirima/docker-plugin"
+- "io/jenkins/docker"
 developers:
 - "integer"
 - "magnayn"


### PR DESCRIPTION
# Description

I plan to move docker-plugin away from com.nirima, as this plugin is now fully hosted by jenkins community
https://github.com/jenkinsci/docker-plugin/

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above
