### PR TITLE
Permission for uploading page-decoration plugin

### DIFF
--- a/permissions/plugin-environment-variable-page-decoration.yml
+++ b/permissions/plugin-environment-variable-page-decoration.yml
@@ -1,0 +1,6 @@
+---
+name: "environment-variable-page-decoration"
+paths:
+- "org/jenkins-ci/plugins/environment-variable-page-decoration"
+developers:
+- "tvon"

--- a/permissions/plugin-page-decoration.yml
+++ b/permissions/plugin-page-decoration.yml
@@ -1,6 +1,0 @@
----
-name: "page-decoration"
-paths:
-- "org/jenkins-ci/plugins/page-decoration"
-developers:
-- "tvon"

--- a/permissions/plugin-page-decoration.yml
+++ b/permissions/plugin-page-decoration.yml
@@ -1,0 +1,6 @@
+---
+name: "page-decoration"
+paths:
+- "org/jenkins-ci/plugins/page-decoration"
+developers:
+- "tvon"


### PR DESCRIPTION
# Description

Add permission to upload page-decoration-plugin.

* [link to plugin/component Git repository in description above](https://github.com/jenkinsci/page-decoration-plugin)
* [link to resolved HOSTING issue in description above](https://issues.jenkins-ci.org/browse/HOSTING-465)

# Submitter checklist for changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
