### PR TITLE
Added permissions for logfilesizechecker

### DIFF
--- a/permissions/plugin-logfilesizechecker.yml
+++ b/permissions/plugin-logfilesizechecker.yml
@@ -2,4 +2,6 @@
 name: "logfilesizechecker"
 paths:
 - "org/jenkins-ci/plugins/logfilesizechecker"
-developers: []
+developers:
+- "stefanbrausch"
+- "jochenafuerbacher"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
We need permissions to publish new releases of LogFileSizeChecker.
https://github.com/jenkinsci/logfilesizechecker-plugin
@stefanbrausch

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
