### PR TITLE
Grant @oleg-nenashev release permissions for jackson-databind and jackson2-api plugins

### DIFF
--- a/permissions/plugin-jackson-databind.yml
+++ b/permissions/plugin-jackson-databind.yml
@@ -4,3 +4,5 @@ paths:
 - "org/jenkins-ci/plugins/jackson-databind"
 developers:
 - "tfennelly"
+- "oleg_nenashev"
+

--- a/permissions/plugin-jackson2-api.yml
+++ b/permissions/plugin-jackson2-api.yml
@@ -4,3 +4,5 @@ paths:
 - "org/jenkins-ci/plugins/jackson2-api"
 developers:
 - "stephenconnolly"
+- "oleg_nenashev"
+


### PR DESCRIPTION
I would like to get release permissions for two Jackson API library plugins we have in the jenkinsci organization. Reason: my current team maintains plugins depending on these API plugin, and I would like to do regular updates to pick improvements and fixes in the libs.

CC @stephenc @tfennelly 

