### PR TITLE
Add perms to release test-harness for a couple pipeline team members

### DIFF
--- a/permissions/component-jenkins-test-harness.yml
+++ b/permissions/component-jenkins-test-harness.yml
@@ -3,10 +3,12 @@ name: "jenkins-test-harness"
 paths:
 - "org/jenkins-ci/main/jenkins-test-harness"
 developers:
+- "abayer"
 - "andresrc"
 - "jglick"
 - "kohsuke"
 - "olivergondza"
 - "stephenconnolly"
+- "svanoort"
 - "tfennelly"
 - "olamy"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Grant 2 of the pipeline team members (abayer and svanoort) permission to cut releases of https://github.com/jenkinsci/jenkins-test-harness/

@jglick for approval


# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above


### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
