### PR TITLE
Added debian pbuilder YAML

### DIFF
--- a/permissions/plugin-debian-pbuilder.yml
+++ b/permissions/plugin-debian-pbuilder.yml
@@ -1,0 +1,6 @@
+---
+name: "debian-pbuilder"
+paths:
+- "com/rm5248/debian-pbuilder"
+developers:
+- "rm5248"


### PR DESCRIPTION
# Description

Repo: https://github.com/jenkinsci/debian-pbuilder-plugin
Hosting request: https://issues.jenkins-ci.org/browse/HOSTING-474

# Submitter checklist for changing permissions

DONE

### Always

- [x ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x ] Make sure the file is created in `permissions/` directory
- [x ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
