### PR TITLE
github-scm-trait-notification-context

### DIFF
--- a/permissions/plugin-github-scm-trait-notification-context.yml
+++ b/permissions/plugin-github-scm-trait-notification-context.yml
@@ -1,6 +1,6 @@
 ---
 name: "github-scm-trait-notification-context"
 paths:
-- "org/jenkinsci/plugins/githubScmTraitNotificationContext"
+- "org/jenkinsci/plugins/github-scm-trait-notification-context"
 developers:
 - "stevenfoster"

--- a/permissions/plugin-github-scm-trait-notification-context.yml
+++ b/permissions/plugin-github-scm-trait-notification-context.yml
@@ -1,0 +1,6 @@
+---
+name: "github-scm-trait-notification-context"
+paths:
+- "org/jenkinsci/plugins/githubScmTraitNotificationContext"
+developers:
+- "stevenfoster"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/github-scm-trait-notification-context-plugin
https://issues.jenkins-ci.org/browse/HOSTING-485
@steven-foster

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)


