### PR TITLE
Grant @olivergondza and @oleg-nenashev permissions to release the Build Name Setter plugin

### DIFF
--- a/permissions/plugin-build-name-setter.yml
+++ b/permissions/plugin-build-name-setter.yml
@@ -4,3 +4,6 @@ paths:
 - "org/jenkins-ci/plugins/build-name-setter"
 developers:
 - "le0"
+- "olivergondza"
+- "oleg_nenashev"
+


### PR DESCRIPTION
There is a pending fix for JEP-200 (https://github.com/jenkinsci/build-name-setter-plugin/pull/17). Would be great to release it

I am not sure whose authorization is required. 
@olivergondza did the last release, also @Le0Michine in case he is still interested in maintaining the plugin

