### PR TITLE
Add jgangemi to repository-connector-plugin

### DIFF
--- a/permissions/plugin-repository-connector.yml
+++ b/permissions/plugin-repository-connector.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "imod"
 - "mikee805"
+- "jgangemi"


### PR DESCRIPTION
# Description

grant permission to `jgangemi` (jenkins ldap) to allow uploads.

@imod 

link to google groups discussion: https://groups.google.com/d/msg/jenkinsci-dev/X3nHpfaeD9M/Fa6UfT0JAgAJ

plugin: https://github.com/jenkinsci/repository-connector-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
