### PR TITLE
Add myself to simple-theme-plugin.

### DIFF
--- a/permissions/plugin-simple-theme-plugin.yml
+++ b/permissions/plugin-simple-theme-plugin.yml
@@ -2,4 +2,6 @@
 name: "simple-theme-plugin"
 paths:
 - "org/codefirst/jenkins/simplethemeplugin/simple-theme-plugin"
-developers: []
+- "org/jenkins-ci/plugins/simple-theme-plugin"
+developers:
+- "tgr"


### PR DESCRIPTION
# Description

This adds myself as uploader for the simple-theme-plugin, repository https://github.com/jenkinsci/simple-theme-plugin.

I'd also like to change the groupId to the default `org.jenkins-ci.plugins`, if that's okay (The update center has no problem with groupId changes, if I understood that correctly?).

See https://groups.google.com/forum/#!topic/jenkinsci-dev/aX5Ru5KvYQw
 
# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
