### PR TITLE
Grant @oleg-nenashev and @Wadeck permissions to release Reverse Proxy Auth Plugin

### DIFF
--- a/permissions/plugin-reverse-proxy-auth-plugin.yml
+++ b/permissions/plugin-reverse-proxy-auth-plugin.yml
@@ -4,3 +4,6 @@ paths:
 - "org/jenkins-ci/plugins/reverse-proxy-auth-plugin"
 developers:
 - "wilder_rodrigues"
+- "oleg_nenashev"
+- "wfollonier"
+


### PR DESCRIPTION
It is a follow-up to this thread: https://groups.google.com/forum/#!topic/jenkinsci-dev/9mX-S7kLnHk, the new plugin release is required to fix the JEP-200 issue in the plugin. I think that the level of authorization from @wilderrodrigues in the thread is enough in this case.

https://issues.jenkins-ci.org/browse/JENKINS-48970

CC @Wadeck @daniel-beck 