### PR TITLE
Fix structs component perms mismatch

### DIFF
--- a/permissions/component-symbol-annotation.yml
+++ b/permissions/component-symbol-annotation.yml
@@ -7,3 +7,5 @@ developers:
 - "kohsuke"
 - "oleg_nenashev"
 - "stephenconnolly"
+- "abayer"
+- "svanoort"

--- a/permissions/pom-structs-parent.yml
+++ b/permissions/pom-structs-parent.yml
@@ -7,3 +7,5 @@ developers:
 - "kohsuke"
 - "oleg_nenashev"
 - "stephenconnolly"
+- "abayer"
+- "svanoort"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
[Structs plugin](https://github.com/jenkinsci/structs-plugin) has 3 distributables -- Abayer and I were already permissioned for the plugin itself, but due to an oversight missed the other two bits (parent pom and the symbol annotation). 

For sanity's sake and the ability to release, we need to fix that.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
