### PR TITLE
Add developer to leastload plugin

### DIFF
--- a/permissions/plugin-leastload.yml
+++ b/permissions/plugin-leastload.yml
@@ -2,4 +2,5 @@
 name: "leastload"
 paths:
 - "org/jenkins-ci/plugins/leastload"
-developers: []
+developers:
+- "bstick12"


### PR DESCRIPTION
# Description

Adding developer [bstick12](https://github.com/jenkinsci/leastload-plugin/graphs/contributors)

Owner of plugin - https://github.com/jenkinsci/leastload-plugin 

Was never added as the original developer.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
