### PR TITLE
[jsch] - Grant @oleg-nenashev and @dwnusbaum permissions to release the plugin

### DIFF
--- a/permissions/plugin-jsch.yml
+++ b/permissions/plugin-jsch.yml
@@ -5,3 +5,6 @@ paths:
 developers:
 - "zregvart"
 - "ljader"
+- "oleg_nenashev"
+- "dnusbaum"
+


### PR DESCRIPTION
It has been confirmed by the @ljader in https://github.com/jenkinsci/jsch-plugin/pull/3#issuecomment-365753117. The idea is to release the facelifted plugin to prevent warnings in startup logs.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
