### PR TITLE
Adding myself to junit-attachments

### DIFF
--- a/permissions/plugin-junit-attachments.yml
+++ b/permissions/plugin-junit-attachments.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jvnet/hudson/plugins/junit-attachments"
 developers:
 - "abayer"
+- "jglick"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

As mentioned on the dev list I would like to cut at least one release of this plugin to get https://github.com/jenkinsci/junit-attachments-plugin/pull/16 & https://github.com/jenkinsci/junit-attachments-plugin/pull/19 out there.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

@reviewbybees @orrc @abayer