### PR TITLE
Grant @oleg-nenashev permissions to release the JDepend plugin

### DIFF
--- a/permissions/plugin-jdepend.yml
+++ b/permissions/plugin-jdepend.yml
@@ -5,3 +5,5 @@ paths:
 - "org/jvnet/hudson/plugins/jdepend"
 developers:
 - "ndeloof"
+- "oleg_nenashev"
+


### PR DESCRIPTION
It is a follow-up to the discussion with @ndeloof in https://github.com/jenkinsci/jdepend-plugin/pull/2 . He approved the release in that thread.


