### PR TITLE
Grant @dwnusbaum permissions to release Promoted Builds, Apache HttpComponents and Jackson API Plugins

### DIFF
--- a/permissions/plugin-apache-httpcomponents-client-4-api.yml
+++ b/permissions/plugin-apache-httpcomponents-client-4-api.yml
@@ -4,4 +4,5 @@ paths:
 - "org/jenkins-ci/plugins/apache-httpcomponents-client-4-api"
 developers:
 - "oleg_nenashev"
+- "dnusbaum"
 

--- a/permissions/plugin-jackson-databind.yml
+++ b/permissions/plugin-jackson-databind.yml
@@ -5,4 +5,5 @@ paths:
 developers:
 - "tfennelly"
 - "oleg_nenashev"
+- "dnusbaum"
 

--- a/permissions/plugin-jackson2-api.yml
+++ b/permissions/plugin-jackson2-api.yml
@@ -5,4 +5,5 @@ paths:
 developers:
 - "stephenconnolly"
 - "oleg_nenashev"
+- "dnusbaum"
 

--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -9,5 +9,5 @@ developers:
 - "oleg_nenashev"
 - "stephenconnolly"
 - "wolfs"
-- "escoem"
-- "mcardenasblanco"
+- "dnusbaum"
+


### PR DESCRIPTION
I would like to share Release permissions in several my plugins with @dwnusbaum so that I am not longer a bottleneck there. Also removed two maintainers of Promoted Builds.

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

@reviewbybees