### PR TITLE
Stop distribution of foreman-node-sharing in favour of node-sharing

### DIFF
--- a/permissions/component-foreman-node-sharing-configurator.yml
+++ b/permissions/component-foreman-node-sharing-configurator.yml
@@ -1,8 +1,0 @@
----
-name: "configurator"
-paths:
-- "org/jenkins-ci/plugins/nodesharing/configurator"
-developers:
-- "scoheb"
-- "pajasoft"
-- "olivergondza"

--- a/permissions/component-node-sharing-lib.yml
+++ b/permissions/component-node-sharing-lib.yml
@@ -1,0 +1,8 @@
+---
+name: "node-sharing-lib"
+paths:
+- "org/jenkins-ci/plugins/nodesharing/node-sharing-lib"
+developers:
+- "scoheb"
+- "pajasoft"
+- "olivergondza"

--- a/permissions/plugin-foreman-node-sharing.yml
+++ b/permissions/plugin-foreman-node-sharing.yml
@@ -1,8 +1,0 @@
----
-name: "foreman-node-sharing"
-paths:
-- "org/jenkins-ci/plugins/nodesharing/foreman-node-sharing"
-developers:
-- "scoheb"
-- "pajasoft"
-- "olivergondza"

--- a/permissions/plugin-node-sharing-executor.yml
+++ b/permissions/plugin-node-sharing-executor.yml
@@ -1,0 +1,8 @@
+---
+name: "node-sharing-executor"
+paths:
+- "org/jenkins-ci/plugins/nodesharing/node-sharing-executor"
+developers:
+- "scoheb"
+- "pajasoft"
+- "olivergondza"

--- a/permissions/plugin-node-sharing-orchestrator.yml
+++ b/permissions/plugin-node-sharing-orchestrator.yml
@@ -1,0 +1,8 @@
+---
+name: "node-sharing-orchestrator"
+paths:
+- "org/jenkins-ci/plugins/nodesharing/node-sharing-orchestrator"
+developers:
+- "scoheb"
+- "pajasoft"
+- "olivergondza"

--- a/permissions/pom-foreman-node-sharing-parent.yml
+++ b/permissions/pom-foreman-node-sharing-parent.yml
@@ -1,8 +1,0 @@
----
-name: "parent"
-paths:
-- "org/jenkins-ci/plugins/nodesharing/parent"
-developers:
-- "scoheb"
-- "pajasoft"
-- "olivergondza"

--- a/permissions/pom-node-sharing-parent.yml
+++ b/permissions/pom-node-sharing-parent.yml
@@ -1,0 +1,8 @@
+---
+name: "node-sharing-parent"
+paths:
+- "org/jenkins-ci/plugins/nodesharing/node-sharing-parent"
+developers:
+- "scoheb"
+- "pajasoft"
+- "olivergondza"


### PR DESCRIPTION
# Description

The project is reworked from scratch: https://github.com/jenkinsci/node-sharing-plugin/pull/65. These snapshots are being pushed now (just to crosscheck):

```
https://repo.jenkins-ci.org/snapshots/org/jenkins-ci/plugins/nodesharing/node-sharing-parent/
https://repo.jenkins-ci.org/snapshots/org/jenkins-ci/plugins/nodesharing/node-sharing-lib/
https://repo.jenkins-ci.org/snapshots/org/jenkins-ci/plugins/nodesharing/node-sharing-orchestrator/
https://repo.jenkins-ci.org/snapshots/org/jenkins-ci/plugins/nodesharing/node-sharing-executor/
```

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

Just restructured, no new uploaders.
