### PR TITLE
Add escoem to releasers for support-core

### DIFF
--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -9,3 +9,4 @@ developers:
 - "stephenconnolly"
 - "batmat"
 - "owood"
+- "escoem"


### PR DESCRIPTION
add "escoem" to releasers

# Description

Adding escoem to the existing releasers for https://github.com/jenkinsci/support-core-plugin. cc @batmat @Evildethow as existing maintainer for confirmation.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
