### PR TITLE
Grant @dwnusbaum permission to release support-core

### DIFF
--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -10,3 +10,4 @@ developers:
 - "batmat"
 - "owood"
 - "escoem"
+- "dnusbaum"


### PR DESCRIPTION
# Description

Adds @dwnusbaum to the list of uploaders for https://github.com/jenkinsci/support-core-plugin.
CC @jglick @batmat @escoem for confirmation from existing maintainers.

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
