### PR TITLE
Grant release permissions for plugin-urltrigger to Tony Noble 

### DIFF
--- a/permissions/plugin-urltrigger.yml
+++ b/permissions/plugin-urltrigger.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/urltrigger"
 developers:
 - "gbois"
+- "stealthdj"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

New maintainer for urltrigger plugin, requiring release permissions.  Agreed by @oleg-nenashev in group conversation.

Repo is at https://github.com/jenkinsci/urltrigger-plugin

Group conversation here: https://groups.google.com/d/msg/jenkinsci-dev/voKBrqz7V_o/l0cBcYzlAQAJ

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above


### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
