### PR TITLE
New maintainers for amazon-ecs plugin

### DIFF
--- a/permissions/plugin-amazon-ecs.yml
+++ b/permissions/plugin-amazon-ecs.yml
@@ -5,3 +5,5 @@ paths:
 developers:
 - "ndeloof"
 - "roehrijn2"
+- "tekkamanendless"
+- "pgarbe"


### PR DESCRIPTION


<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
ECS plugin is lacking active maintainer for several months with candidates in mailing list 
https://github.com/jenkinsci/amazon-ecs-plugin/pulls

See also https://issues.jenkins-ci.org/browse/INFRA-1501

Current maintainers: @roehrijn @ndeloof 

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
