### PR TITLE
Fix typo in the Custom WAR Packager Lib release path

### DIFF
--- a/permissions/component-custom-war-packager-lib.yml
+++ b/permissions/component-custom-war-packager-lib.yml
@@ -1,7 +1,7 @@
 ---
 name: "custom-war-packager-lib"
 paths:
-- "io/jenkins/tools/custom-war-packager/custom-war-packager-maven-lib"
+- "io/jenkins/tools/custom-war-packager/custom-war-packager-lib"
 developers:
 - "oleg_nenashev"
 - "jglick"


### PR DESCRIPTION
It’s a follow-up to https://github.com/jenkins-infra/repository-permissions-updater/pull/643
Sorry, messed up the config a bit.

