### PR TITLE
Add scpeters to flaky-test-handler

### DIFF
--- a/permissions/plugin-flaky-test-handler.yml
+++ b/permissions/plugin-flaky-test-handler.yml
@@ -3,4 +3,5 @@ name: "flaky-test-handler"
 paths:
 - "org/jenkins-ci/plugins/flaky-test-handler"
 developers:
+- "scpeters"
 - "seriousamlqz"


### PR DESCRIPTION
# Description

I have push access to the [flaky-test-handler-plugin](https://github.com/jenkinsci/flaky-test-handler-plugin), and I'd like to release the following pull requests that have been merged:

* https://github.com/jenkinsci/flaky-test-handler-plugin/pull/4
* https://github.com/jenkinsci/flaky-test-handler-plugin/pull/5

cc @seriousamlqz

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name (they are identical)
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)