### PR TITLE
Permission request for nodepool-agents plugin

### DIFF
--- a/permissions/plugin-nodepool-agents.yml
+++ b/permissions/plugin-nodepool-agents.yml
@@ -1,0 +1,7 @@
+---
+name: "nodepool-agents"
+paths:
+- "org/jenkins-ci/plugins/nodepool-agents"
+developers:
+- "nairbttoille"
+- "hughsaunders"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Add a permission request for nodepool-agents plugin.

https://github.com/jenkinsci/nodepool-agents-plugin

@hsaunders

https://issues.jenkins-ci.org/browse/HOSTING-535

# Submitter checklist for changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
