### PR TITLE
Change plasticscm-plugin developers

### DIFF
--- a/permissions/plugin-plasticscm-plugin.yml
+++ b/permissions/plugin-plasticscm-plugin.yml
@@ -4,5 +4,7 @@ paths:
 - "org/jenkins-ci/plugins/plasticscm-plugin"
 - "org/jvnet/hudson/plugins/plasticscm-plugin"
 developers:
-- "lrodriguez"
 - "mig42"
+- "miryamgsm"
+- "jemagoga"
+- "rubarax"


### PR DESCRIPTION
# Description

Requesting uploader status to plasticscm-plugin for three new developers, as detailed in https://issues.jenkins-ci.org/browse/INFRA-1557

The plugin repository is https://github.com/jenkinsci/plasticscm-plugin. You'll see that I (@mig42) am currently an active maintainer of that plugin.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
