### PR TITLE
Add config for platformlabeler plugin

### DIFF
--- a/permissions/plugin-platformlabeler.yml
+++ b/permissions/plugin-platformlabeler.yml
@@ -1,0 +1,6 @@
+---
+name: "platformlabeler"
+paths:
+- "org/jvnet/hudson/plugins/platformlabeler"
+developers:
+- "markewaite"


### PR DESCRIPTION
# Description

Grant markewaite permission to release new versions of the [platformlabeler plugin](https://github.com/jenkinsci/platformlabeler-plugin).

@ndeloof and Robert Collins are listed as current maintainers.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file). I used permissions/plugin-platformlabeler.yml to match the [artifactid](https://github.com/jenkinsci/platformlabeler-plugin/blob/c1c030cbd55d4ccf6e76eaae16a77dfa7834a36b/pom.xml#L9)
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Authorization

- [x] See [e-mail authorization](https://groups.google.com/d/msg/jenkinsci-dev/xYO1JY83GF4/Q1MnERi1BAAJ) from current maintainer