### PR TITLE
Add @dwnusbaum as a maintainer of file-leak-detector

### DIFF
--- a/permissions/plugin-file-leak-detector.yml
+++ b/permissions/plugin-file-leak-detector.yml
@@ -4,3 +4,4 @@ paths:
 - "com/cloudbees/jenkins/plugins/file-leak-detector"
 developers:
 - "jglick"
+- "dnusbaum"


### PR DESCRIPTION
# Description

Add @dwnusbaum as a maintainer of https://github.com/jenkinsci/file-leak-detector-plugin. CC @jglick for confirmation from an existing maintainer.

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
