### PR TITLE
Added agentgonzo to kubernetes-credentials-provider

### DIFF
--- a/permissions/plugin-kubernetes-credentials-provider.yml
+++ b/permissions/plugin-kubernetes-credentials-provider.yml
@@ -4,3 +4,4 @@ paths:
 - "com/cloudbees/jenkins/plugins/kubernetes-credentials-provider"
 developers:
 - "teilo"
+- "agentgonzo"


### PR DESCRIPTION
# Adding agentgonzo (Steve Arch) to kubernetes-credentials-provider admin

* Github repo: https://github.com/jenkinsci/kubernetes-credentials-provider-plugin

# Submitter checklist for changing permissions

### Always

- [x ] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

@jtnord 