### PR TITLE
Add slide_o_mix to release list

### DIFF
--- a/permissions/plugin-validating-string-parameter.yml
+++ b/permissions/plugin-validating-string-parameter.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/validating-string-parameter"
 developers:
 - "vlatombe"
+- "slide_o_mix"


### PR DESCRIPTION
# Description

Please add slide_o_mix to the release list for https://github.com/jenkinsci/validating-string-parameter-plugin. @vlatombe has said he is no longer maintaining the plugin (see https://github.com/jenkinsci/validating-string-parameter-plugin/pull/10#issuecomment-378964013) and he is the only one in the current yaml file for the validating-string-parameter-plugin

# Submitter checklist for changing permissions

- [x] Add link to plugin/component Git repository in description above
- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
