### PR TITLE
Request to access the statistics-gatherer plugin

### DIFF
--- a/permissions/plugin-statistics-gatherer.yml
+++ b/permissions/plugin-statistics-gatherer.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins/plugins/statistics/gatherer/statistics-gatherer"
 developers:
 - "macha762"
+- "lucamilanesio"


### PR DESCRIPTION


References:
[1] https://groups.google.com/forum/?nomobile=true#!topic/jenkinsci-dev/-aWiThbXSIo
[2] https://github.com/jenkinsci/statistics-gatherer-plugin/pull/4

# Description

As discussed on the jenkins-dev mailing list (see [1])
the [statistics-gatherer-plugin](https://github.com/jenkinsci/statistics-gatherer-plugin) has not been actively maintained for over 12 months and there are important bugs to be fixed (see [2]).

I have tried multiple times to get in touch with the maintainer
(@maximecharron) but without any results.
The 2nd top contributor (@alexgandy) said that
he is not sure that the project is still active and maintained.

I am willing to take the plugin onboard, fix the bugs and
improve it to fully support Jenkins 2.0 and the pipelines.

# Submitter checklist for changing permissions

### Always

- [v ] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ v] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ v] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ v] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
