### PR TITLE
Add permissions for logback-nats-appender

### DIFF
--- a/permissions/plugin-logback-nats-appender.yml
+++ b/permissions/plugin-logback-nats-appender.yml
@@ -1,0 +1,6 @@
+---
+name: "logback-nats-appender"
+paths:
+- "org/jenkins-ci/plugins/logback-nats-appender"
+developers:
+- "lucamilanesio"


### PR DESCRIPTION
### Always

- [v ] Add link to plugin/component Git repository in description above: https://github.com/jenkinsci/logback-nats-appender-plugin

### For a newly hosted plugin only

- [v ] Add link to resolved HOSTING issue in description above
https://issues.jenkins-ci.org/browse/HOSTING-546

### For a new permissions file only

- [ v] Make sure the file is created in `permissions/` directory
- [v] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [v] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [v] Check that the file is named `plugin-${artifactId}.yml` for plugins

