### PR TITLE
tomasbjerre maintainer git-changelog-plugin

### DIFF
--- a/permissions/plugin-git-changelog.yml
+++ b/permissions/plugin-git-changelog.yml
@@ -3,5 +3,4 @@ name: "git-changelog"
 paths:
 - "de/wellnerbou/jenkins/git-changelog"
 developers:
-- "paulwellnerbou"
 - "tomasbjerre"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

https://github.com/jenkinsci/git-changelog-plugin

I talked to Paul Wellner Bau about this.

I should be the maintainer of this plugin and also be auto assigned new Jiras. The motivation for that is clear when looking at the contribution history:
https://github.com/jenkinsci/git-changelog-plugin/graphs/contributors

# Submitter checklist for changing permissions

### Always

- [x ] Add link to plugin/component Git repository in description above
