### PR TITLE
Adding NetBeans-specific ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ lib/
 .classpath
 .project
 .settings
+
+# NetBeans
+nb-configuration.xml
+nbactions-*.xml


### PR DESCRIPTION
Actually `nb-configuration.xml` would better be committed

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project-shared-configuration>
    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
        <netbeans.compile.on.save>none</netbeans.compile.on.save>
    </properties>
</project-shared-configuration>
```

to force execution to run the Maven mojo to compile `ArtifactoryPermissionsUpdater.groovy`, but I do not have time to fight that fight. (CC @oleg-nenashev)