### PR TITLE
[INFRA-1571] Add github field for incrementals deployment

### DIFF
--- a/permissions/plugin-buildtriggerbadge.yml
+++ b/permissions/plugin-buildtriggerbadge.yml
@@ -1,5 +1,6 @@
 ---
 name: "buildtriggerbadge"
+github: "jenkinsci/buildtriggerbadge-plugin"
 paths:
 - "org/jenkins-ci/plugins/buildtriggerbadge"
 developers:


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

Follows up @jglick comment in https://github.com/jenkinsci/buildtriggerbadge-plugin/pull/27 where I'm testing `incrementals` (cf. [INFRA-1571](https://issues.jenkins-ci.org/browse/INFRA-1571)).

I am already the co-maintainer of https://github.com/jenkinsci/buildtriggerbadge-plugin with @mpailloncy

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
