### PR TITLE
Permissions added for alauda-devops-sync

### DIFF
--- a/permissions/plugin-alauda-devops-sync.yml
+++ b/permissions/plugin-alauda-devops-sync.yml
@@ -1,0 +1,6 @@
+---
+name: "alauda-devops-sync"
+paths:
+- "io/alauda/jenkins/plugins/alauda-devops-sync"
+developers:
+- "surenpi"

--- a/permissions/plugin-alauda-devops-sync.yml
+++ b/permissions/plugin-alauda-devops-sync.yml
@@ -4,3 +4,5 @@ paths:
 - "io/alauda/jenkins/plugins/alauda-devops-sync"
 developers:
 - "surenpi"
+- "danielfbm"
+- "chengjingtao"


### PR DESCRIPTION
### Links
- [x] Hosting Ticket : https://issues.jenkins-ci.org/browse/HOSTING-552
- [x] Repo : https://github.com/jenkinsci/alauda-devops-sync-plugin

### File checks
- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
