### PR TITLE
Add user name check based on Artifactory LDAP users report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ node('java') {
 
         def javaArgs = ' -DdefinitionsDir=$PWD/permissions' +
                        ' -DartifactoryApiTempDir=$PWD/json' +
+                       ' -DartifactoryUserNamesJsonListUrl=http://reports.jenkins.io/reports/artifactory-ldap-users-report.json' +
                        ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
                        ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
 

--- a/permissions/plugin-phabricator-plugin.yml
+++ b/permissions/plugin-phabricator-plugin.yml
@@ -5,4 +5,3 @@ paths:
 developers:
 - "ai"
 - "kageiit"
-- "jjx"

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -23,6 +23,11 @@ public class ArtifactoryPermissionsUpdater {
     private static final File ARTIFACTORY_API_DIR = new File(System.getProperty('artifactoryApiTempDir', './json'))
 
     /**
+     * URL to JSON with a list of valid Artifactory user names.
+     */
+    private static final String ARTIFACTORY_USER_NAMES_URL = System.getProperty('artifactoryUserNamesJsonListUrl')
+
+    /**
      * URL to the permissions API of Artifactory
      */
     private static final String ARTIFACTORY_PERMISSIONS_API_URL = 'https://repo.jenkins-ci.org/api/security/permissions'
@@ -115,6 +120,11 @@ public class ArtifactoryPermissionsUpdater {
             throw new IOException("Directory ${DEFINITIONS_DIR} does not exist")
         }
 
+        def knownUsers = []
+        if (ARTIFACTORY_USER_NAMES_URL) {
+            knownUsers = new JsonSlurper().parse(new URL(ARTIFACTORY_USER_NAMES_URL))
+        }
+
         if (apiOutputDir.exists()) {
             throw new IOException(apiOutputDir.path + " already exists")
         }
@@ -174,6 +184,9 @@ public class ArtifactoryPermissionsUpdater {
                         users [:]
                     } else {
                         users definition.developers.collectEntries { developer ->
+                            if (!knownUsers.contains(developer.toLowerCase())) {
+                                throw new IllegalStateException("User name not known to Artifactory: " + developer)
+                            }
                             ["${developer.toLowerCase()}": ["w", "n"]]
                         }
                     }


### PR DESCRIPTION
Untested.

CC @oleg-nenashev @batmat @orrc and whoever else benefits from this. You can already access the specified URL manually to check for existence of a user in Artifactory.