### PR TITLE
Permissions add for hugo

### DIFF
--- a/permissions/plugin-hugo.yml
+++ b/permissions/plugin-hugo.yml
@@ -1,0 +1,6 @@
+---
+name: "hugo"
+paths:
+- "io/jenkins/plugins/hugo"
+developers:
+- "surenpi"


### PR DESCRIPTION
### Links
- [x] Hosting Ticket : https://issues.jenkins-ci.org/browse/HOSTING-557
- [x] Repo : https://github.com/jenkinsci/hugo-plugin

### File checks
- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
