### PR TITLE
icedq: first commit :  added plugin-icedq.yml file

### DIFF
--- a/permissions/plugin-icedq.yml
+++ b/permissions/plugin-icedq.yml
@@ -1,0 +1,7 @@
+---
+name: "icedq"
+github: "jenkinsci/icedq-plugin"
+paths:
+- "com/icedq/ci/plugin/icedq"
+developers:
+- "toranainc"

--- a/permissions/plugin-icedq.yml
+++ b/permissions/plugin-icedq.yml
@@ -5,3 +5,4 @@ paths:
 - "com/icedq/ci/plugin/icedq"
 developers:
 - "toranainc"
+- "devlopertoranainc"

--- a/permissions/plugin-icedq.yml
+++ b/permissions/plugin-icedq.yml
@@ -4,7 +4,5 @@ github: "jenkinsci/icedq-plugin"
 paths:
 - "com/icedq/ci/plugin/icedq"
 developers:
-- "devlopertoranainc"
 - "toranainc"
-- "DevloperToranaInc"
 

--- a/permissions/plugin-icedq.yml
+++ b/permissions/plugin-icedq.yml
@@ -4,5 +4,7 @@ github: "jenkinsci/icedq-plugin"
 paths:
 - "com/icedq/ci/plugin/icedq"
 developers:
+- "devlopertoranainc"
 - "toranainc"
 - "DevloperToranaInc"
+

--- a/permissions/plugin-icedq.yml
+++ b/permissions/plugin-icedq.yml
@@ -5,4 +5,3 @@ paths:
 - "com/icedq/ci/plugin/icedq"
 developers:
 - "toranainc"
-

--- a/permissions/plugin-icedq.yml
+++ b/permissions/plugin-icedq.yml
@@ -5,4 +5,4 @@ paths:
 - "com/icedq/ci/plugin/icedq"
 developers:
 - "toranainc"
-- "devlopertoranainc"
+- "DevloperToranaInc"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always
https://github.com/jenkinsci/icedq-plugin
- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only
https://issues.jenkins-ci.org/browse/HOSTING-544
- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
