### PR TITLE
Remove mgelman08

### DIFF
--- a/permissions/plugin-contrast-continuous-application-security.yml
+++ b/permissions/plugin-contrast-continuous-application-security.yml
@@ -4,6 +4,5 @@ github: "jenkinsci/contrast-continuous-application-security-plugin"
 paths:
 - "org/jenkins-ci/plugins/contrast-continuous-application-security"
 developers:
-- "mgelman08"
 - "gsmoore"
 - "sergii_contrast"


### PR DESCRIPTION
# Description

mgelman08 will no longer need permissions to our repository. Please remove his permissions from Artifactory.

https://github.com/jenkinsci/contrast-continuous-application-security-plugin

cc/ @meg23

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
