### PR TITLE
Edit Permissions for Delphix Plugin

### DIFF
--- a/permissions/plugin-delphix.yml
+++ b/permissions/plugin-delphix.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/delphix-plugin"
 paths:
 - "org/jenkins-ci/plugins/delphix"
 developers:
-- "peterlvilim"
+- "mcred"


### PR DESCRIPTION
# Description
Repo: https://github.com/jenkinsci/delphix-plugin
Please give @mcred write permissions to the repo above and remove @peterlvilim.

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
