### PR TITLE
Added permissions file for osf-builder-suite-for-sfcc-data-import

### DIFF
--- a/permissions/plugin-osf-builder-suite-for-sfcc-data-import.yml
+++ b/permissions/plugin-osf-builder-suite-for-sfcc-data-import.yml
@@ -1,0 +1,7 @@
+---
+name: "osf-builder-suite-for-sfcc-data-import"
+github: "jenkinsci/osf-builder-suite-for-sfcc-data-import-plugin"
+paths:
+  - "org/jenkins-ci/plugins/osf-builder-suite-for-sfcc-data-import"
+developers:
+  - "danechitoaie"


### PR DESCRIPTION
# Description
This plugin adds a build step that will import metadata to a Salesforce Commerce Cloud (former Demandware) instance.

https://github.com/jenkinsci/osf-builder-suite-for-sfcc-data-import-plugin

https://issues.jenkins-ci.org/browse/HOSTING-566

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
