### PR TITLE
Added user ddeal to nodepool-agents credentials

### DIFF
--- a/permissions/plugin-nodepool-agents.yml
+++ b/permissions/plugin-nodepool-agents.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "nairbttoille"
 - "hughsaunders"
+- "ddeal"


### PR DESCRIPTION
# Description

Add permission for Jenkins community (LDAP) account name ddeal to nodepool-agents-plugin.

GitHub Repository URL: https://github.com/jenkinsci/nodepool-agents-plugin
CC: @hughsaunders, @bdelliott for review/approval.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
