### PR TITLE
Update plugin-cerberus-testing.yml

### DIFF
--- a/permissions/plugin-cerberus-testing.yml
+++ b/permissions/plugin-cerberus-testing.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/cerberus-testing"
 developers:
 - "nicodeur"
+- "vertigo17"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

The GitHub repo is an already existing jenkinsci repo: 
https://github.com/jenkinsci/cerberus-testing-plugin
The purpose of the request is only to add my Jenkins account (vertigo17) to the authorized account that can upload the new release.
This is to fix the error I got when uploading my new release of the plugin:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project cerberus-testing: Failed to deploy artifacts: Could not transfer artifact org.jenkins-ci.plugins:cerberus-testing:hpi:1.0.5 from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): Access denied to: https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/cerberus-testing/1.0.5/cerberus-testing-1.0.5.hpi, ReasonPhrase: . -> [Help 1]`

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
