### PR TITLE
Add update-center2

### DIFF
--- a/permissions/component-update-center2.yml
+++ b/permissions/component-update-center2.yml
@@ -1,0 +1,7 @@
+---
+name: "update-center2"
+github: "jenkins-infra/update-center2"
+paths:
+- "org/jenkins-ci/update-center2"
+developers:
+- "danielbeck"


### PR DESCRIPTION

# Description

Last released in 2012, the [update-center2](https://github.com/jenkins-infra/update-center2) artifact is used as a dependency by https://github.com/jenkins-infra/crawler to [sign tool metadata files](https://github.com/jenkins-infra/crawler/blob/42bbe011f232a2717533eaf979e1845ae6e415a5/lib/DataWriter.groovy#L20).

A new release is a prerequisite for https://github.com/jenkinsci/jenkins/pull/3356 unless we want to introduce tons of warnings about outdated signatures.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [n/a] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] `groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [n/a] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [n/a] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
