### PR TITLE
Edit permissions for Text Finder plugin

### DIFF
--- a/permissions/plugin-text-finder.yml
+++ b/permissions/plugin-text-finder.yml
@@ -5,4 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/text-finder"
 - "org/jvnet/hudson/plugins/text-finder"
 developers:
+- "basil"
 - "jglick"


### PR DESCRIPTION
# Description

Relevant repository: [text-finder-plugin](https://github.com/jenkinsci/text-finder-plugin)

See the discussion with @jglick and @oleg-nenashev in [this PR](https://github.com/jenkinsci/text-finder-plugin/pull/12#issuecomment-397089427).

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)