### PR TITLE
Grant @oleg-nenashev permissions to release Bytecode Compatibility Transformer

### DIFF
--- a/permissions/component-bct-integration-tests.yml
+++ b/permissions/component-bct-integration-tests.yml
@@ -1,8 +1,8 @@
 ---
-name: "bytecode-compatibility-transformer"
+name: "bct-integration-tests"
 github: "jenkinsci/bytecode-compatibility-transformer"
 paths:
-- "org/jenkins-ci/bytecode-compatibility-transformer"
+- "org/jenkins-ci/main/bct/bct-integration-tests"
 developers:
 - "batmat"
 - "oleg_nenashev"

--- a/permissions/component-bct-test-client.yml
+++ b/permissions/component-bct-test-client.yml
@@ -1,8 +1,8 @@
 ---
-name: "bytecode-compatibility-transformer"
+name: "bct-test-client"
 github: "jenkinsci/bytecode-compatibility-transformer"
 paths:
-- "org/jenkins-ci/bytecode-compatibility-transformer"
+- "org/jenkins-ci/main/bct/bct-test-client"
 developers:
 - "batmat"
 - "oleg_nenashev"

--- a/permissions/component-bct-test-v1.yml
+++ b/permissions/component-bct-test-v1.yml
@@ -1,8 +1,8 @@
 ---
-name: "bytecode-compatibility-transformer"
+name: "bct-test-v1"
 github: "jenkinsci/bytecode-compatibility-transformer"
 paths:
-- "org/jenkins-ci/bytecode-compatibility-transformer"
+- "org/jenkins-ci/main/bct/bct-test-v1"
 developers:
 - "batmat"
 - "oleg_nenashev"

--- a/permissions/component-bct-test-v2.yml
+++ b/permissions/component-bct-test-v2.yml
@@ -1,8 +1,8 @@
 ---
-name: "bytecode-compatibility-transformer"
+name: "bct-test-v2"
 github: "jenkinsci/bytecode-compatibility-transformer"
 paths:
-- "org/jenkins-ci/bytecode-compatibility-transformer"
+- "org/jenkins-ci/main/bct/bct-test-v2"
 developers:
 - "batmat"
 - "oleg_nenashev"

--- a/permissions/pom-bct-parent-pom.yml
+++ b/permissions/pom-bct-parent-pom.yml
@@ -1,8 +1,8 @@
 ---
-name: "bytecode-compatibility-transformer"
+name: "bct-parent-pom"
 github: "jenkinsci/bytecode-compatibility-transformer"
 paths:
-- "org/jenkins-ci/bytecode-compatibility-transformer"
+- "org/jenkins-ci/main/bct/bct-parent-pom"
 developers:
 - "batmat"
 - "oleg_nenashev"


### PR DESCRIPTION
As a Core contributor, I would like to update BCT for the Java 10 and Java 11 support branches. https://github.com/jenkinsci/bytecode-compatibility-transformer/pull/11 is the pull request I want to merge and release as alpha-4.

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above


### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
