### PR TITLE
new kryptowire permission file

### DIFF
--- a/permissions/plugin-kryptowire.yml
+++ b/permissions/plugin-kryptowire.yml
@@ -1,0 +1,10 @@
+---
+name: "kryptowire"
+github: "jenkinsci/kryptowire-plugin"
+paths:
+- "io/jenkins/plugins/kryptowire"
+developers:
+- "lrossett"
+- "mnairn"
+- "jasonmadigan"
+- "maleck13"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Repository: https://github.com/jenkinsci/kryptowire-plugin

Hosting Ticket: https://issues.jenkins-ci.org/browse/HOSTING-584

I would like to enable the following users to make kryptowire plugin releases:

* lrossett
* mnairn
* jasonmadigan
* maleck13

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
