### PR TITLE
add @sghill as maintainer for gradle-jpi-plugin

### DIFF
--- a/permissions/component-gradle-jpi-plugin.yml
+++ b/permissions/component-gradle-jpi-plugin.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/tools/gradle-jpi-plugin"
 developers:
 - "daspilker"
+- "sghill"


### PR DESCRIPTION
# Description

Adding @sghill as a maintainer for https://github.com/jenkinsci/gradle-jpi-plugin. I am the current maintainer.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
