### PR TITLE
Plugin is not listed in the Jenkins page

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node('java') {
         if (dryRun) {
             sh '${JAVA_HOME}/bin/java -DdryRun=true' + javaArgs
         } else {
-            withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+            withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'Ontash123', usernameVariable: 'ontash')]) {
                 sh '${JAVA_HOME}/bin/java ' + javaArgs
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node('java') {
         if (dryRun) {
             sh '${JAVA_HOME}/bin/java -DdryRun=true' + javaArgs
         } else {
-            withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'Ontash123', usernameVariable: 'ontash')]) {
+            withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ontpass18!!', usernameVariable: 'ontash')]) {
                 sh '${JAVA_HOME}/bin/java ' + javaArgs
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node('java') {
         if (dryRun) {
             sh '${JAVA_HOME}/bin/java -DdryRun=true' + javaArgs
         } else {
-            withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ontpass18!!', usernameVariable: 'ontash')]) {
+            withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ontash')]) {
                 sh '${JAVA_HOME}/bin/java ' + javaArgs
             }
         }

--- a/permissions/plugin-stride-notification.yml
+++ b/permissions/plugin-stride-notification.yml
@@ -1,0 +1,8 @@
+---
+name: "stride-notification"
+github: "jenkinsci/stride-notification-plugin"
+paths:
+- "org/jenkins-ci/plugins/stride-notification"
+
+developers: 
+- "ontash"

--- a/permissions/plugin-stride-notification.yml
+++ b/permissions/plugin-stride-notification.yml
@@ -3,6 +3,5 @@ name: "stride-notification"
 github: "jenkinsci/stride-notification-plugin"
 paths:
 - "org/jenkins-ci/plugins/stride-notification"
-
 developers: 
 - "ontash"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
