### PR TITLE
Add osf-builder-suite-xml-linter plugin

### DIFF
--- a/permissions/plugin-osf-builder-suite-xml-linter.yml
+++ b/permissions/plugin-osf-builder-suite-xml-linter.yml
@@ -1,0 +1,8 @@
+---
+name: "osf-builder-suite-xml-linter"
+github: "jenkinsci/osf-builder-suite-xml-linter-plugin"
+paths:
+  - "org/jenkins-ci/plugins/osf-builder-suite-xml-linter"
+developers:
+  - "danechitoaie"
+  


### PR DESCRIPTION
# Description

- https://github.com/jenkinsci/osf-builder-suite-xml-linter-plugin
- https://issues.jenkins-ci.org/browse/HOSTING-585

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
