### PR TITLE
Add back yafim_kazak as maintainer at hp-application-automation-tools-plugin

### DIFF
--- a/permissions/plugin-hp-application-automation-tools-plugin.yml
+++ b/permissions/plugin-hp-application-automation-tools-plugin.yml
@@ -4,7 +4,4 @@ github: "jenkinsci/hpe-application-automation-tools-plugin"
 paths:
 - "org/jenkins-ci/plugins/hp-application-automation-tools-plugin"
 developers:
-- "mrman"
-- "ofirshaked"
-- "shimor"
-- "yafim_kazak"
+- "gront"

--- a/permissions/plugin-hp-application-automation-tools-plugin.yml
+++ b/permissions/plugin-hp-application-automation-tools-plugin.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/hp-application-automation-tools-plugin"
 developers:
 - "gront"
+- "yafim_kazak"


### PR DESCRIPTION
Adding Yafim back in order to avoid future issues with the releases.
GitHub: https://github.com/jenkinsci/hpe-application-automation-tools-plugin

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
