### PR TITLE
Add @jthompson as maintainer for file-leak-detector plugin.

### DIFF
--- a/permissions/plugin-file-leak-detector.yml
+++ b/permissions/plugin-file-leak-detector.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "jglick"
 - "dnusbaum"
+- "jthompson"


### PR DESCRIPTION
Add @jthompson as maintainer for file-leak-detector plugin.

Approved by Devin Nusbaum (@dnusbaum).

https://github.com/jenkinsci/file-leak-detector-plugin

- [x] Add link to plugin/component Git repository in description above
- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
