### PR TITLE
Adapt to new URL for users list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ node('java') {
 
         def javaArgs = ' -DdefinitionsDir=$PWD/permissions' +
                        ' -DartifactoryApiTempDir=$PWD/json' +
-                       ' -DartifactoryUserNamesJsonListUrl=http://reports.jenkins.io/reports/artifactory-ldap-users-report.json' +
+                       ' -DartifactoryUserNamesJsonListUrl=https://reports.jenkins.io/artifactory-ldap-users-report.json' +
                        ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
                        ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
 


### PR DESCRIPTION
[INFRA-1689](https://issues.jenkins-ci.org/browse/INFRA-1689) changed the URL.

Corresponding change to jenkins.io is at https://github.com/jenkins-infra/jenkins.io/pull/1640