### PR TITLE
Clean up matrix-auth permissions

### DIFF
--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -5,6 +5,3 @@ paths:
 - "org/jenkins-ci/plugins/matrix-auth"
 developers:
 - "danielbeck"
-- "jglick"
-- "kohsuke"
-- "mathias_nyman"


### PR DESCRIPTION
I've been actively maintaining the plugin alone for almost a year now, so cleaning up this file.

@jglick and @kohsuke are from the initial import based on past releases. @mathias-nyman did a single release, and in #311 wrote he didn't want to take over maintainership anyway, and hasn't been active since.

Once this is accepted, GitHub repo permissions will follow.

https://github.com/jenkinsci/matrix-auth-plugin/

### Always

- [x] Add link to plugin/component Git repository in description above
