### PR TITLE
adding ctronco as developer on vmware-vrealize-automation plugin

### DIFF
--- a/permissions/plugin-vmware-vrealize-automation-plugin.yml
+++ b/permissions/plugin-vmware-vrealize-automation-plugin.yml
@@ -4,4 +4,5 @@ github: "jenkinsci/vmware-vrealize-automation-plugin"
 paths:
 - "com/inkysea/vmware/vra/vmware-vrealize-automation-plugin"
 developers:
+- "ctronco"
 - "inkysea"


### PR DESCRIPTION
# Description
Adding  ctronco as a maintainer on the existing vmware-vrealize-automation plugin.  (GitHub userid  @cars will also need access to the GitHub repo for this project as well). 

The previous maintainer @inkysea has approved this on the Jenkins Developers mailing list. 

I have logged into the Jenkins Artifactory as ctronco. 

