### PR TITLE
Create component-jdependency.yml

### DIFF
--- a/permissions/component-jdependency.yml
+++ b/permissions/component-jdependency.yml
@@ -1,0 +1,9 @@
+---
+name: "jdependency"
+github: "jenkinsci/jdependency"
+paths:
+- "io/jenkins/org/vafer/jdependency"
+developers:
+- "rsandell"
+- "svanoort"
+- "abayer"


### PR DESCRIPTION


# Description
Needed to fork jdependency library to use org.kohsuke.asm6 instead of standard asm6.
The repo is already forked @ https://github.com/jenkinsci/jdependency/blob/1.4-jenkins-1

# Submitter checklist for changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
