### PR TITLE
Add @jeffret-b as maintainer for bouncycastle-api and jsch plugins.

### DIFF
--- a/permissions/plugin-bouncycastle-api.yml
+++ b/permissions/plugin-bouncycastle-api.yml
@@ -7,3 +7,4 @@ developers:
 - "alobato"
 - "stephenconnolly"
 - "dnusbaum"
+- "jthompson"

--- a/permissions/plugin-jsch.yml
+++ b/permissions/plugin-jsch.yml
@@ -8,4 +8,5 @@ developers:
 - "ljader"
 - "oleg_nenashev"
 - "dnusbaum"
+- "jthompson"
 


### PR DESCRIPTION
Add @jeffret-b as maintainer for bouncycastle-api and jsch plugins.

Approved by Devin Nusbaum ( @dwnusbaum )

https://github.com/jenkinsci/bouncycastle-api-plugin
https://github.com/jenkinsci/jsch-plugin

- [x] Add link to plugin/component Git repository in description above
- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
