### PR TITLE
Clean up release permissions for Pipeline plugins (2)

### DIFF
--- a/permissions/plugin-pipeline-graph-analysis.yml
+++ b/permissions/plugin-pipeline-graph-analysis.yml
@@ -5,3 +5,7 @@ paths:
 - "org/jenkins-ci/plugins/pipeline-graph-analysis"
 developers:
 - "svanoort"
+- "abayer"
+- "dnusbaum"
+- "jglick"
+- "rsandell"

--- a/permissions/plugin-pipeline-stage-view.yml
+++ b/permissions/plugin-pipeline-stage-view.yml
@@ -5,3 +5,7 @@ paths:
 - "org/jenkins-ci/plugins/pipeline-stage-view/pipeline-stage-view"
 developers:
 - "svanoort"
+- "abayer"
+- "dnusbaum"
+- "jglick"
+- "rsandell"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Adds @abayer, @dwnusbaum, @jglick, and @rsandell as maintainers for the following plugins:

- https://github.com/jenkinsci/pipeline-stage-view-plugin
- https://github.com/jenkinsci/pipeline-graph-analysis-plugin

CC @svanoort for confirmation from an existing maintainer. Related to [INFRA-1713](https://issues.jenkins-ci.org/browse/INFRA-1713).

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
