### PR TITLE
Adding rsandell and dnusbaum to script-security

### DIFF
--- a/permissions/plugin-script-security.yml
+++ b/permissions/plugin-script-security.yml
@@ -8,3 +8,5 @@ developers:
 - "kohsuke"
 - "abayer"
 - "svanoort"
+- "rsandell"
+- "dnusbaum"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/script-security-plugin

Just realized that @dwnusbaum and @rsandell didn't have permissions for `script-security`, so, hey, adding them. cc @jglick and @svanoort if signoff from other maintainers besides myself is needed.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
