### PR TITLE
pipeline-log-fluentd-cloudwatch

### DIFF
--- a/permissions/plugin-pipeline-log-fluentd-cloudwatch.yml
+++ b/permissions/plugin-pipeline-log-fluentd-cloudwatch.yml
@@ -1,0 +1,9 @@
+---
+name: "pipeline-log-fluentd-cloudwatch"
+github: "jenkinsci/pipeline-log-fluentd-cloudwatch-plugin"
+paths:
+- "io/jenkins/plugins/pipeline-log-fluentd-cloudwatch"
+developers:
+- "jglick"
+- "csanchez"
+- "oleg_nenashev"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

https://github.com/jenkinsci/pipeline-log-fluentd-cloudwatch-plugin/pull/1 failed to deploy. Cryptically @rtyler, the console log ended with

```
[Pipeline] stage
[Pipeline] { (Deploy)
[Pipeline] node
09:49:28 Still waiting to schedule task
09:49:28 Waiting for next available executor on linux
09:56:04 Running on ubuntu-jenkinsinfra4870e0 in /home/jenkins/workspace/entd-cloudwatch-plugin_PR-1-5NKGUJJHNLM7ZG4EGNCQQSRCS3PXIXRSSX7U252H4ZGPAFEJTPPA
[Pipeline] {
[Pipeline] withCredentials
[Pipeline] {
[Pipeline] sh
09:56:04 [entd-cloudwatch-plugin_PR-1-5NKGUJJHNLM7ZG4EGNCQQSRCS3PXIXRSSX7U252H4ZGPAFEJTPPA] Running shell script
09:56:04 + curl -H Content-Type: application/json -d {"build_url":"https://ci.jenkins.io/job/Plugins/job/pipeline-log-fluentd-cloudwatch-plugin/job/PR-1/1/"} https://jenkins-incrementals.azurewebsites.net/api/incrementals-publisher?clientId=default&code=****
09:56:04   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
09:56:04                                  Dload  Upload   Total   Spent    Left  Speed
09:57:33 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   104    0     0  100   104      0     75  0:00:01  0:00:01 --:--:--    75
100   104    0     0  100   104      0     43  0:00:02  0:00:02 --:--:--    43
…
100   104    0     0  100   104      0      1  0:01:44  0:01:28  0:00:16     0
100   104    0     0  100   104      0      1  0:01:44  0:01:28  0:00:16     0
[Pipeline] }
[Pipeline] // withCredentials
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // timestamps
[Pipeline] End of Pipeline

GitHub has been notified of this commit’s build result

Finished: SUCCESS
```

with no explanation of why. I finally figured out that after [HOSTING-604](https://issues.jenkins-ci.org/browse/HOSTING-604) I had neglected to file this. @oleg-nenashev @carlossg

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
