### PR TITLE
Not able to add labels on wiki page

### DIFF
--- a/permissions/plugin-deployit-plugin.yml
+++ b/permissions/plugin-deployit-plugin.yml
@@ -10,3 +10,4 @@ developers:
 - "adityakalia"
 - "kmalhotra"
 - "tmehra"
+  


### PR DESCRIPTION
Hi 

I have permission in this file but I am not able to add labels on page  https://plugins.jenkins.io/deployit-plugin 
I added the labels on page https://wiki.jenkins.io/display/JENKINS/XL+Deploy+Plugin

Any idea why it's not reflecting ??

Sorry for creating PR for same, not seeing an option to create the issue
