### PR TITLE
[JENKINS-53164] Rebrand from Essentials to Evergreen the "essentials jenkins plugin"

### DIFF
--- a/permissions/plugin-essentials.yml
+++ b/permissions/plugin-essentials.yml
@@ -1,8 +1,0 @@
----
-name: "essentials"
-github: "jenkinsci/essentials-plugin"
-paths:
-- "io/jenkins/plugins/essentials"
-developers:
-- "batmat"
-- "rtyler"

--- a/permissions/plugin-evergreen.yml
+++ b/permissions/plugin-evergreen.yml
@@ -1,0 +1,8 @@
+---
+name: "evergreen"
+github: "jenkinsci/evergreen-plugin"
+paths:
+- "io/jenkins/plugins/evergreen"
+developers:
+- "batmat"
+- "rtyler"


### PR DESCRIPTION
**Note to GitHub admin for `jenkinsci` organization: this is blocked by the rename to be done described in https://issues.jenkins-ci.org/browse/INFRA-1753, thanks!**

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

https://github.com/jenkinsci/essentials-plugin should be renamed `evergreen-plugin`.
ArtifactId and code already changed through https://github.com/jenkinsci/essentials-plugin/pull/13, approved and merged by @rtyler 

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- ~~[ ] Add link to resolved HOSTING issue in description above~~

### For a new permissions file only

- ~~[ ] Make sure the file is created in `permissions/` directory~~
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
