### PR TITLE
Add the new plasticscm-mergebot plugin definition

### DIFF
--- a/permissions/plugin-plasticscm-mergebot.yml
+++ b/permissions/plugin-plasticscm-mergebot.yml
@@ -1,0 +1,10 @@
+---
+name: "plasticscm-mergebot"
+github: "jenkinsci/plasticscm-mergebot-plugin"
+paths:
+- "org/jenkins-ci/plugins/plasticscm-mergebot"
+developers:
+- "mig42"
+- "miryamgsm"
+- "jemagoga"
+- "rubarax"


### PR DESCRIPTION
# Description
Requesting upload permissions for our new plugin **plasticscm-mergebot**, hosted at https://github.com/jenkinsci/plasticscm-mergebot-plugin. The list of maintainers is: @rubarax, @miryamGSM, @jemagoga and myself, @mig42. The original hosting request in JIRA is: https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-613

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
