### PR TITLE
Temporarily reintroduce essentials-plugin to be able to release a tombstone version

### DIFF
--- a/permissions/plugin-essentials.yml
+++ b/permissions/plugin-essentials.yml
@@ -1,0 +1,8 @@
+---
+name: "essentials"
+github: "jenkinsci/essentials-plugin"
+paths:
+- "io/jenkins/plugins/essentials"
+developers:
+- "batmat"
+- "rtyler"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

Reintroducing the `plugin-essentials.yml` renamed in https://github.com/jenkins-infra/repository-permissions-updater/pull/819, at least temporarily, to be able to release a tombstoned version of the plugin (i.e. empty with no content, to be able to potentially have both artifactId installed together).

