### PR TITLE
Permissions add for localization-zh-cn

### DIFF
--- a/permissions/plugin-localization-zh-cn.yml
+++ b/permissions/plugin-localization-zh-cn.yml
@@ -1,0 +1,7 @@
+---
+name: "localization-zh-cn"
+github: "jenkinsci/localization-zh-cn-plugin"
+paths:
+- "org/jenkins-ci/plugins/localization-zh-cn"
+developers:
+- "surenpi"


### PR DESCRIPTION
### Links
- [x] Hosting Ticket : https://issues.jenkins-ci.org/browse/HOSTING-615
- [x] Repo : https://github.com/jenkinsci/localization-zh-cn-plugin

### File checks
- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
