### PR TITLE
Add permissions for alauda-devops-pipeline-plugin

### DIFF
--- a/permissions/plugin-alauda-devops-pipeline.yml
+++ b/permissions/plugin-alauda-devops-pipeline.yml
@@ -1,0 +1,9 @@
+---
+name: "alauda-devops-pipeline"
+github: "jenkinsci/alauda-devops-pipeline-plugin"
+paths:
+- "com/alauda/jenkins/plugins/alauda-devops-pipeline"
+developers:
+- "surenpi"
+- "danielfbm"
+- "chengjingtao"


### PR DESCRIPTION
### Links
- [x] Hosting Ticket : https://issues.jenkins-ci.org/browse/HOSTING-618
- [x] Repo : https://github.com/jenkinsci/alauda-devops-pipeline-plugin

### File checks
- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
