### PR TITLE
Change maintainer for view-job-filters plugin to svenschoenung

### DIFF
--- a/permissions/plugin-view-job-filters.yml
+++ b/permissions/plugin-view-job-filters.yml
@@ -5,4 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/view-job-filters"
 - "org/jvnet/hudson/plugins/view-job-filters"
 developers:
-- "jglick"
+- "svenschoenung"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

GitHub repo: https://github.com/jenkinsci/view-job-filters-plugin

I've adopted the view-job-filters-plugin, see this thread on the mailing list:

https://groups.google.com/forum/#!topic/jenkinsci-dev/k7YL8MEK5bM

I'm removing @jglick from the list of developers since he indicated that he's not a maintainer of the plugin and his only release was a one-off thing:

https://groups.google.com/d/msg/jenkinsci-dev/k7YL8MEK5bM/apba6I32EQAJ

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
