### PR TITLE
Add permission to pipeline-giphy-api-plugin

### DIFF
--- a/permissions/plugin-pipeline-giphy-api.yml
+++ b/permissions/plugin-pipeline-giphy-api.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-giphy-api"
+github: "jenkinsci/pipeline-giphy-api-plugin"
+paths:
+- "org/jenkins-ci/plugins/pipeline-giphy-api"
+developers:
+- "aviadlevy"

--- a/permissions/plugin-pipeline-giphy-api.yml
+++ b/permissions/plugin-pipeline-giphy-api.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/pipeline-giphy-api"
 developers:
 - "aviadlevy"
+


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
https://github.com/jenkinsci/pipeline-giphy-api-plugin 
https://issues.jenkins-ci.org/browse/HOSTING-623 

# Submitter checklist for changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
