### PR TITLE
Initial permissions file for tricentis-ci plugin

### DIFF
--- a/permissions/plugin-tricentis-ci.yml
+++ b/permissions/plugin-tricentis-ci.yml
@@ -2,7 +2,7 @@
 name: "tricentis-ci"
 github: "jenkinsci/tricentis-ci-plugin"
 paths:
-- "org/jenkins-ci/plugins/tricentis-ci"
+- "io/jenkins/plugins/tricentis-ci"
 developers:
 - "tricentis"
 - "sergey_oplavin"

--- a/permissions/plugin-tricentis-ci.yml
+++ b/permissions/plugin-tricentis-ci.yml
@@ -1,0 +1,8 @@
+---
+name: "tricentis-ci"
+github: "jenkinsci/tricentis-ci-plugin"
+paths:
+- "org/jenkins-ci/plugins/tricentis-ci"
+developers:
+- "tricentis"
+- "sergey_oplavin"


### PR DESCRIPTION
Add initial permissions for tricentis-ci plugin

# Description
Add @tricentis and @sergey_oplavin as maintainers for newly created tricentis-ci plugin
GitHub repository: https://github.com/jenkinsci/tricentis-ci-plugin
https://issues.jenkins-ci.org/browse/HOSTING-624

# Submitter checklist for changing permissions
### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
