### PR TITLE
add performance-signature-dynatracesaas as new plugin

### DIFF
--- a/permissions/plugin-performance-signature-dynatracesaas.yml
+++ b/permissions/plugin-performance-signature-dynatracesaas.yml
@@ -1,0 +1,8 @@
+---
+name: "performance-signature-dynatracesaas"
+github: "jenkinsci/performance-signature-dynatrace-plugin"
+paths:
+- "de/tsystems/mms/apm/performance-signature-dynatracesaas"
+developers:
+- "rpionke"
+- "robkuehn"


### PR DESCRIPTION
# Description
We created a new maven module for the Dynatrace Saas/Managed solution in the Performance Signature. We are also using the same Github repository: https://github.com/jenkinsci/performance-signature-dynatrace-plugin.
Plugin Links:
https://wiki.jenkins.io/display/JENKINS/Performance+Signature+with+Dynatrace+Plugin
https://plugins.jenkins.io/performance-signature-dynatrace

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
