### PR TITLE
Adding permissions to upload for nowsecure-auto-security-test plugin

### DIFF
--- a/permissions/plugin-nowsecure-auto-security-test.yml
+++ b/permissions/plugin-nowsecure-auto-security-test.yml
@@ -1,0 +1,11 @@
+---
+name: "nowsecure-auto-security-test"
+github: "jenkinsci/nowsecure-auto-security-test-plugin"
+paths:
+- "org/jenkins-ci/plugins/nowsecure-auto-security-test"
+developers:
+- "bhatti"
+- "ekristen"
+- "dweinstein"
+- "srjefe"
+- "sttwalker"

--- a/permissions/plugin-nowsecure-auto-security-test.yml
+++ b/permissions/plugin-nowsecure-auto-security-test.yml
@@ -2,7 +2,7 @@
 name: "nowsecure-auto-security-test"
 github: "jenkinsci/nowsecure-auto-security-test-plugin"
 paths:
-- "org/jenkins-ci/plugins/nowsecure-auto-security-test"
+- "org/jenkins-ci/plugins/nowsecure"
 developers:
 - "bhatti"
 - "ekristen"


### PR DESCRIPTION

# Description
Adding permissions to upload for nowsecure-auto-security-test plugin. Here is the original jira for hosting:
https://issues.jenkins-ci.org/browse/HOSTING-632
and the new github repo under jenkinsci:
https://github.com/jenkinsci/nowsecure-auto-security-test-plugin

cc /@bhatti, @ekristen, @dweinstein, @srjefe, @sttwalker


### Always

- [ X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ X] Make sure the file is created in `permissions/` directory
- [X ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
