### PR TITLE
Corrected existing permissions file for sge-cloud-plugin

### DIFF
--- a/permissions/plugin-sge-cloud-plugin.yml
+++ b/permissions/plugin-sge-cloud-plugin.yml
@@ -2,6 +2,7 @@
 name: "sge-cloud-plugin"
 github: "jenkinsci/sge-cloud-plugin"
 paths:
-- "org/jenkins-ci/plugins/sge-cloud-plugin"
+- "io/jenkins/plugins/sge-cloud-plugin"
 developers:
 - "jmcgeheeiv"
+


### PR DESCRIPTION
# Description

The permissions file already existed and was almost entirely correct.  I corrected only the beginning of the repository path to the new path on Artifactory.

I, @jmcgeheeiv, am still the only maintainer (unchanged).  jmcgeheeiv is both my GitHub and Jenkins LDAP user name.  I have successfully logged in to Artifactory.

The Git repo is https://github.com/jenkinsci/sge-cloud-plugin (unchanged)

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

I am sorry, I do not quite understand.  I can tell you that everything related to this plugin has been hosted on Jenkins servers for quite a while now.

The only new thing is that this plugin has never been *released*.

### For a new permissions file only

Not a new permissions file; only a very minor correction.

- [x ] Make sure the file is created in `permissions/` directory
- [x ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
