### PR TITLE
Add Bernardo Buelga as a cloudformation-plugin dev

### DIFF
--- a/permissions/plugin-jenkins-cloudformation-plugin.yml
+++ b/permissions/plugin-jenkins-cloudformation-plugin.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "edovale"
 - "nathanagood"
+- "tolivia"


### PR DESCRIPTION
# Description

Bernardo Buelga wants to adopt the [jenkins-cloudformation-plugin](https://github.com/jenkinsci/jenkins-cloudformation-plugin).  He's an active user of AWS CloudFormation and would like to merge several pull requests and perform additional maintenance on the plugin.

Last commit to the repository was over 2 years ago.  @edovale and @nathanagood are listed as current developers.  Mail request to adopt the plugin has been sent to the [Jenkins dev list](https://groups.google.com/d/msg/jenkinsci-dev/RMXrntZfJWs/VPd1vSiXEwAJ), edovale, and nathanagood requesting that Bernardo be allowed to develop and release new versions of the plugin.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable (@edovale approval received by tweet to @MarkEWaite)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

Don't merge until I've confirmed that @tolivia has a Jenkins community (LDAP) account and that he has logged into Artifactory at least once.