### PR TITLE
Create plugin-compuware-topaz-utilities.yml

### DIFF
--- a/permissions/plugin-compuware-topaz-utilities.yml
+++ b/permissions/plugin-compuware-topaz-utilities.yml
@@ -1,0 +1,10 @@
+---
+name: "compuware-topaz-utilities"
+github: "jenkinsci/compuware-topaz-utilities-plugin"
+paths:
+- "com/compuware/jenkins/compuware-topaz-utilities"
+developers:
+- "jgoering41"
+- "dave-dresser"
+- "sallenCPWR"
+- "cpwr_jenkins"

--- a/permissions/plugin-compuware-topaz-utilities.yml
+++ b/permissions/plugin-compuware-topaz-utilities.yml
@@ -4,6 +4,4 @@ github: "jenkinsci/compuware-topaz-utilities-plugin"
 paths:
 - "com/compuware/jenkins/compuware-topaz-utilities"
 developers:
-- "jgoering41"
-- "sallenCPWR"
 - "cpwr_jenkins"

--- a/permissions/plugin-compuware-topaz-utilities.yml
+++ b/permissions/plugin-compuware-topaz-utilities.yml
@@ -5,6 +5,5 @@ paths:
 - "com/compuware/jenkins/compuware-topaz-utilities"
 developers:
 - "jgoering41"
-- "dave-dresser"
 - "sallenCPWR"
 - "cpwr_jenkins"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

This plugin provides access to various Compuware Topaz utilities, such as submitting Jobs on the mainframe.
[Link to plugin Git repository](https://github.com/jenkinsci/compuware-topaz-utilities-plugin)
[Link to HOSTING issue](https://issues.jenkins-ci.org/browse/HOSTING-626)

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
