### PR TITLE
Request upload permission for micro-focus-performance-center-integration plugin

### DIFF
--- a/permissions/plugin-micro-focus-performance-center-integration.yml
+++ b/permissions/plugin-micro-focus-performance-center-integration.yml
@@ -1,0 +1,8 @@
+---
+name: "micro-focus-performance-center-integration"
+github: "jenkinsci/micro-focus-performance-center-integration-plugin"
+paths:
+- "org/jenkins-ci/plugins/micro-focus-performance-center-integration"
+developers:
+- "danieldanan"
+- "bamh"


### PR DESCRIPTION
Following https://issues.jenkins-ci.org/browse/HOSTING-644, requesting upload permission for micro-focus-performance-center-integration plugin:
1.  name = micro-focus-performance-center-integration
2.  Github = https://github.com/jenkinsci/micro-focus-performance-center-integration-plugin
3. paths = org.jenkins-ci.plugins.micro-focus-performance-center-integration
4. developers = danieldanan and bamh  