### PR TITLE
create plugin-in-toto

### DIFF
--- a/permissions/plugin-in-toto.yml
+++ b/permissions/plugin-in-toto.yml
@@ -1,0 +1,7 @@
+---
+name: "in-toto"
+github: "jenkinsci/in-toto-plugin"
+paths:
+- "io/jenkins/plugins/artifactory"
+developers:
+- "SantiagoTorres"

--- a/permissions/plugin-in-toto.yml
+++ b/permissions/plugin-in-toto.yml
@@ -2,6 +2,6 @@
 name: "in-toto"
 github: "jenkinsci/in-toto-plugin"
 paths:
-- "io/jenkins/plugins/artifactory"
+- "io/jenkins/plugins/in-toto"
 developers:
 - "SantiagoTorres"


### PR DESCRIPTION
# Description

Add permissions to push to the repository for the [in-toto plugin](https://github.com/jenkinsci/in-toto-plugin) See hosting request [HOSTING-647](https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-647). Plugin developed by @SantiagoTorres 

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)