### PR TITLE
Create plugin-downstream-build-cache.yml

### DIFF
--- a/permissions/plugin-downstream-build-cache.yml
+++ b/permissions/plugin-downstream-build-cache.yml
@@ -1,0 +1,7 @@
+---
+name: "downstream-build-cache"
+github: "jenkinsci/downstream-build-cache-plugin"
+paths:
+- "com/axis/system/jenkins/plugins/downstream/downstream-build-cache"
+developers:
+- "gustafl"


### PR DESCRIPTION
# Description
Downstream Build Cache Plugin

* https://github.com/jenkinsci/downstream-build-cache-plugin
* https://issues.jenkins-ci.org/browse/HOSTING-656

Maintains mappings of upstream -> downstream Runs. Efficient, thread safe and does not add any actions or meta data to any Runs, hence totally safe to install/remove without risking serialization issues.

# Submitter checklist for changing permissions
### Always
* [x]  Add link to plugin/component Git repository in description above

### For a newly hosted plugin only
* [x]  Add link to resolved HOSTING issue in description above

### For a new permissions file only
* [x]  Make sure the file is created in `permissions/` directory
* [x]  `artifactId` (pom.xml) is used for `name` (permissions YAML file).
* [x]  [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
* [x]  Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)
* [x]  [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
* [x]  Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
* [x]  [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
