### PR TITLE
Upload permissions after HOSTING-665

### DIFF
--- a/permissions/component-async-http-client.yml
+++ b/permissions/component-async-http-client.yml
@@ -1,0 +1,7 @@
+---
+name: "async-http-client"
+github: "jenkinsci/async-http-client"
+paths:
+- "com/ning/async-http-client" # For the 1.7.x branch which is the only needed one at the moment
+developers:
+- "egutierrez"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Request upload permissions for [async-http-client](https://github.com/jenkinsci/async-http-client) after [https://issues.jenkins-ci.org/browse/HOSTING-665](https://issues.jenkins-ci.org/browse/HOSTING-665)

# Submitter checklist for changing permissions

N/A

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [N/A] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
