### PR TITLE
Add @oleg-nenashev to the list of JTH maintainers

### DIFF
--- a/permissions/component-jenkins-test-harness.yml
+++ b/permissions/component-jenkins-test-harness.yml
@@ -14,3 +14,5 @@ developers:
 - "tfennelly"
 - "olamy"
 - "batmat"
+- "oleg_nenashev"
+


### PR DESCRIPTION
I would like to release JTH 2.41.1 without HTML Unit bump. I have some issues with JS-based tests and I am pretty much stuck there: https://github.com/jenkinsci/jenkins/pull/3661. Want to workaround it, because I am not a JS expert.

2.41.1 would unblock testing of Java 11 within the Jenkins Core CI pipeline.

CC @batmat @jglick 
