### PR TITLE
pipeline-cloudwatch-logs

### DIFF
--- a/permissions/plugin-pipeline-cloudwatch-logs.yml
+++ b/permissions/plugin-pipeline-cloudwatch-logs.yml
@@ -1,0 +1,9 @@
+---
+name: "pipeline-cloudwatch-logs"
+github: "jenkinsci/pipeline-cloudwatch-logs-plugin"
+paths:
+- "io/jenkins/plugins/pipeline-cloudwatch-logs"
+developers:
+- "jglick"
+- "csanchez"
+- "oleg_nenashev"

--- a/permissions/plugin-pipeline-log-fluentd-cloudwatch.yml
+++ b/permissions/plugin-pipeline-log-fluentd-cloudwatch.yml
@@ -1,9 +1,0 @@
----
-name: "pipeline-log-fluentd-cloudwatch"
-github: "jenkinsci/pipeline-log-fluentd-cloudwatch-plugin"
-paths:
-- "io/jenkins/plugins/pipeline-log-fluentd-cloudwatch"
-developers:
-- "jglick"
-- "csanchez"
-- "oleg_nenashev"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Preparing for an initial release of the Pipeline [CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html) plugin, as slated to be renamed after https://github.com/jenkinsci/pipeline-log-fluentd-cloudwatch-plugin/pull/8 is merged. Amends #804.

@carlossg @oleg-nenashev

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
