### PR TITLE
Fix the GitHub location of the lib-async-http-client repository

### DIFF
--- a/permissions/component-async-http-client.yml
+++ b/permissions/component-async-http-client.yml
@@ -1,6 +1,6 @@
 ---
 name: "async-http-client"
-github: "jenkinsci/async-http-client"
+github: "jenkinsci/lib-async-http-client"
 paths:
 - "com/ning/async-http-client" # For the 1.7.x branch which is the only needed one at the moment
 developers:


### PR DESCRIPTION
The repo was renamed after the discussion with @varyvol , I want to replace the GitHub link here accordingly

CC @batmat 
