### PR TITLE
Add @oleg-nenashev and @batmat to the list of Maven HPI Plugin maintainers

### DIFF
--- a/permissions/component-maven-hpi-plugin.yml
+++ b/permissions/component-maven-hpi-plugin.yml
@@ -11,4 +11,3 @@ developers:
 - "olamy"
 - "oleg_nenashev"
 - "batmat"
-

--- a/permissions/component-maven-hpi-plugin.yml
+++ b/permissions/component-maven-hpi-plugin.yml
@@ -9,3 +9,6 @@ developers:
 - "kohsuke"
 - "stephenconnolly"
 - "olamy"
+- "oleg_nenashev"
+- "batmat"
+


### PR DESCRIPTION
In the Java 11 maintenance team we will need to make some changes around HPI packaging, e.g. https://github.com/jenkinsci/maven-hpi-plugin/pull/75

CC @jglick @batmat 
