### PR TITLE
Requesting write access to mailer plugin

### DIFF
--- a/permissions/plugin-mailer.yml
+++ b/permissions/plugin-mailer.yml
@@ -10,3 +10,4 @@ developers:
 - "rsandell"
 - "tfennelly"
 - "oleg_nenashev"
+- "alecharp"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I'd like to have write access on the [mailer-plugin](https://github.com/jenkinsci/mailer-plugin) repository to help with its maintenance.

cc @oleg-nenashev 

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
