### PR TITLE
binary-deployer was never meant to be deployed

### DIFF
--- a/permissions/plugin-binary-deployer.yml
+++ b/permissions/plugin-binary-deployer.yml
@@ -1,6 +1,0 @@
----
-name: "binary-deployer"
-paths:
-- "org/jenkins-ci/plugins/binary-deployer"
-developers:
-- "alecharp"


### PR DESCRIPTION
I wrote this plugin but never published it officially and it not part of the Jenkins community.

cc @daniel-beck 