### PR TITLE
Add "imeredith" to blueocean-executor-info-plugin upload

### DIFF
--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -8,3 +8,4 @@ developers:
 - "michaelneale"
 - "vivek"
 - "kzantow"
+- "imeredith"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/blueocean-executor-info-plugin

@kzantow @michaelneale 

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
