### PR TITLE
Add @thomas-dee as maintainer to the Embeddable Build Status Plugin

### DIFF
--- a/permissions/plugin-embeddable-build-status.yml
+++ b/permissions/plugin-embeddable-build-status.yml
@@ -7,3 +7,4 @@ developers:
 - "christiangalsterer"
 - "jglick"
 - "mgedmin"
+- "thomas_dee"

--- a/permissions/plugin-embeddable-build-status.yml
+++ b/permissions/plugin-embeddable-build-status.yml
@@ -1,11 +1,8 @@
 ---
 name: "embeddable-build-status"
-
 github: "jenkinsci/embeddable-build-status-plugin"
-
 paths:
 - "org/jenkins-ci/plugins/embeddable-build-status"
-
 developers:
 - "christiangalsterer"
 - "jglick"

--- a/permissions/plugin-embeddable-build-status.yml
+++ b/permissions/plugin-embeddable-build-status.yml
@@ -1,8 +1,11 @@
 ---
 name: "embeddable-build-status"
+
 github: "jenkinsci/embeddable-build-status-plugin"
+
 paths:
 - "org/jenkins-ci/plugins/embeddable-build-status"
+
 developers:
 - "christiangalsterer"
 - "jglick"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
cc @jglick and @mgedmin

https://github.com/jenkinsci/embeddable-build-status-plugin

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
