### PR TITLE
[JENKINS-54375] Permissions for jenkinsfile-runner.

### DIFF
--- a/permissions/component-jenkinsfile-runner-bootstrap.yml
+++ b/permissions/component-jenkinsfile-runner-bootstrap.yml
@@ -1,8 +1,8 @@
 ---
-name: "jenkinsfile-runner-bootstrap"
+name: "bootstrap"
 github: "jenkinsci/jenkinsfile-runner"
 paths:
-- "io/jenkins/jenkinsfile-runner-bootstrap"
+- "io/jenkins/jenkinsfile-runner/bootstrap"
 developers:
 - "oleg_nenashev"
 - "egutierrez"

--- a/permissions/component-jenkinsfile-runner-bootstrap.yml
+++ b/permissions/component-jenkinsfile-runner-bootstrap.yml
@@ -1,0 +1,9 @@
+---
+name: "jenkinsfile-runner-bootstrap"
+github: "jenkinsci/jenkinsfile-runner"
+paths:
+- "io/jenkins/jenkinsfile-runner-bootstrap"
+developers:
+- "oleg_nenashev"
+- "egutierrez"
+- "fcojfernandez"

--- a/permissions/component-jenkinsfile-runner-parent.yml
+++ b/permissions/component-jenkinsfile-runner-parent.yml
@@ -1,8 +1,8 @@
 ---
-name: "jenkinsfile-runner-parent"
+name: "parent"
 github: "jenkinsci/jenkinsfile-runner"
 paths:
-- "io/jenkins/jenkinsfile-runner-parent"
+- "io/jenkins/jenkinsfile-runner/parent"
 developers:
 - "oleg_nenashev"
 - "egutierrez"

--- a/permissions/component-jenkinsfile-runner-parent.yml
+++ b/permissions/component-jenkinsfile-runner-parent.yml
@@ -1,0 +1,9 @@
+---
+name: "jenkinsfile-runner-parent"
+github: "jenkinsci/jenkinsfile-runner"
+paths:
+- "io/jenkins/jenkinsfile-runner-parent"
+developers:
+- "oleg_nenashev"
+- "egutierrez"
+- "fcojfernandez"

--- a/permissions/component-jenkinsfile-runner-payload-dependencies.yml
+++ b/permissions/component-jenkinsfile-runner-payload-dependencies.yml
@@ -1,0 +1,9 @@
+---
+name: "jenkinsfile-runner-payload-dependencies"
+github: "jenkinsci/jenkinsfile-runner"
+paths:
+- "io/jenkins/jenkinsfile-runner-payload-dependencies"
+developers:
+- "oleg_nenashev"
+- "egutierrez"
+- "fcojfernandez"

--- a/permissions/component-jenkinsfile-runner-payload-dependencies.yml
+++ b/permissions/component-jenkinsfile-runner-payload-dependencies.yml
@@ -1,8 +1,8 @@
 ---
-name: "jenkinsfile-runner-payload-dependencies"
+name: "payload-dependencies"
 github: "jenkinsci/jenkinsfile-runner"
 paths:
-- "io/jenkins/jenkinsfile-runner-payload-dependencies"
+- "io/jenkins/jenkinsfile-runner/payload-dependencies"
 developers:
 - "oleg_nenashev"
 - "egutierrez"

--- a/permissions/component-jenkinsfile-runner-payload.yml
+++ b/permissions/component-jenkinsfile-runner-payload.yml
@@ -1,0 +1,9 @@
+---
+name: "jenkinsfile-runner-payload"
+github: "jenkinsci/jenkinsfile-runner"
+paths:
+- "io/jenkins/jenkinsfile-runner-payload"
+developers:
+- "oleg_nenashev"
+- "egutierrez"
+- "fcojfernandez"

--- a/permissions/component-jenkinsfile-runner-payload.yml
+++ b/permissions/component-jenkinsfile-runner-payload.yml
@@ -1,8 +1,8 @@
 ---
-name: "jenkinsfile-runner-payload"
+name: "payload"
 github: "jenkinsci/jenkinsfile-runner"
 paths:
-- "io/jenkins/jenkinsfile-runner-payload"
+- "io/jenkins/jenkinsfile-runner/payload"
 developers:
 - "oleg_nenashev"
 - "egutierrez"

--- a/permissions/component-jenkinsfile-runner-setup.yml
+++ b/permissions/component-jenkinsfile-runner-setup.yml
@@ -1,8 +1,8 @@
 ---
-name: "jenkinsfile-runner-setup"
+name: "setup"
 github: "jenkinsci/jenkinsfile-runner"
 paths:
-- "io/jenkins/jenkinsfile-runner-setup"
+- "io/jenkins/jenkinsfile-runner/setup"
 developers:
 - "oleg_nenashev"
 - "egutierrez"

--- a/permissions/component-jenkinsfile-runner-setup.yml
+++ b/permissions/component-jenkinsfile-runner-setup.yml
@@ -1,0 +1,9 @@
+---
+name: "jenkinsfile-runner-setup"
+github: "jenkinsci/jenkinsfile-runner"
+paths:
+- "io/jenkins/jenkinsfile-runner-setup"
+developers:
+- "oleg_nenashev"
+- "egutierrez"
+- "fcojfernandez"

--- a/permissions/component-jenkinsfile-runner.yml
+++ b/permissions/component-jenkinsfile-runner.yml
@@ -1,0 +1,9 @@
+---
+name: "jenkinsfile-runner"
+github: "jenkinsci/jenkinsfile-runner"
+paths:
+- "io/jenkins/jenkinsfile-runner"
+developers:
+- "oleg_nenashev"
+- "egutierrez"
+- "fcojfernandez"

--- a/permissions/component-jenkinsfile-runner.yml
+++ b/permissions/component-jenkinsfile-runner.yml
@@ -2,7 +2,7 @@
 name: "jenkinsfile-runner"
 github: "jenkinsci/jenkinsfile-runner"
 paths:
-- "io/jenkins/jenkinsfile-runner"
+- "io/jenkins/jenkinsfile-runner/jenkinsfile-runner"
 developers:
 - "oleg_nenashev"
 - "egutierrez"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

[jenkinsfile-runner/](https://github.com/jenkinsci/jenkinsfile-runner/)

@oleg-nenashev 

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
