### PR TITLE
Request upload permission for Katalon plugin

### DIFF
--- a/permissions/plugin-katalon.yml
+++ b/permissions/plugin-katalon.yml
@@ -1,0 +1,7 @@
+---
+name: "katalon"
+github: "jenkinsci/katalon-plugin"
+paths:
+- "org/jenkins-ci/plugins/katalon"
+developers:
+- "devalex88"


### PR DESCRIPTION
# Description

Request upload permission for Katalon plugin.
Request: https://issues.jenkins-ci.org/browse/HOSTING-684
Repository: https://github.com/jenkinsci/katalon-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)