### PR TITLE
added user bschulte3 to plugin-kryptowire

### DIFF
--- a/permissions/plugin-kryptowire.yml
+++ b/permissions/plugin-kryptowire.yml
@@ -8,3 +8,4 @@ developers:
 - "mnairn"
 - "jasonmadigan"
 - "maleck13"
+- "bschulte3"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Added myself (bschulte3) to the plugin-kryptowire permission file. Repo for the plugin is hosted here:
https://github.com/aerogear/aerogear-kryptowire-jenkins-plugin

@odra @mikenairn @camilamacedo86

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above


### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
