### PR TITLE
Add dmotpan as a developer

### DIFF
--- a/permissions/plugin-github-pr-coverage-status.yml
+++ b/permissions/plugin-github-pr-coverage-status.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/github-pr-coverage-status"
 developers:
 - "terma"
+- "dmotpan"


### PR DESCRIPTION
# Description
cc @terma 

https://github.com/jenkinsci/github-pr-coverage-status-plugin/

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
