### PR TITLE
Add permissions for `pipeline-timeline`

### DIFF
--- a/permissions/plugin-pipeline-timeline.yml
+++ b/permissions/plugin-pipeline-timeline.yml
@@ -1,0 +1,7 @@
+---
+name: "pipeline-timeline"
+github: "jenkinsci/pipeline-timeline-plugin"
+paths:
+- "org/jenkins-ci/plugins/pipeline-timeline"
+developers:
+- "mcataford"

--- a/permissions/plugin-pipeline-timeline.yml
+++ b/permissions/plugin-pipeline-timeline.yml
@@ -4,5 +4,5 @@ github: "jenkinsci/pipeline-timeline-plugin"
 paths:
 - "io/jenkins/plugins/pipeline-timeline"
 developers:
-- "mcataford"
 - "tophat"
+- "mcataford"

--- a/permissions/plugin-pipeline-timeline.yml
+++ b/permissions/plugin-pipeline-timeline.yml
@@ -5,3 +5,4 @@ paths:
 - "io/jenkins/plugins/pipeline-timeline"
 developers:
 - "mcataford"
+- "tophat"

--- a/permissions/plugin-pipeline-timeline.yml
+++ b/permissions/plugin-pipeline-timeline.yml
@@ -2,6 +2,6 @@
 name: "pipeline-timeline"
 github: "jenkinsci/pipeline-timeline-plugin"
 paths:
-- "org/jenkins-ci/plugins/pipeline-timeline"
+- "io/jenkins/plugins/pipeline-timeline"
 developers:
 - "mcataford"


### PR DESCRIPTION
# Description

This PR aims to add permissions so that the [Pipeline Timeline](https://github.com/jenkinsci/pipeline-timeline-plugin) plugin can be released.

The resolved `HOSTING` issue can be found [here](https://issues.jenkins-ci.org/browse/HOSTING-669).

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
