### PR TITLE
[JENKINS-55434] Permissions for audit-log-plugin

### DIFF
--- a/permissions/plugin-audit-log.yml
+++ b/permissions/plugin-audit-log.yml
@@ -2,7 +2,7 @@
 name: "audit-log"
 github: "jenkinsci/audit-log-plugin"
 paths:
-  - "org/jenkins-ci/plugins/audit-log"
+  - "io/jenkins/plugins/audit-log"
 developers:
 - "jvz"
 - "jthompson"

--- a/permissions/plugin-audit-log.yml
+++ b/permissions/plugin-audit-log.yml
@@ -1,0 +1,10 @@
+---
+name: "audit-log"
+github: "jenkinsci/audit-log-plugin"
+paths:
+  - "org/jenkins-ci/plugins/audit-log"
+developers:
+- "jvz"
+- "jthompson"
+- "lathasekar"
+- "mide"


### PR DESCRIPTION
# Description

[Audit-Log Plugin](https://github.com/jenkinsci/audit-log-plugin) description.

Resolved [HOSTING-670](https://issues.jenkins-ci.org/browse/HOSTING-670) issue.

cc @daniel-beck @jvz @jeffret-b @batmat 

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
