### PR TITLE
For multimodule plugin added valid path for 2.x ca-apm-plugin

### DIFF
--- a/permissions/plugin-ca-apm-api.yml
+++ b/permissions/plugin-ca-apm-api.yml
@@ -1,8 +1,10 @@
 ---
-name: "ca-apm"
+#artifactId
+name: "ca-apm-api"
 github: "jenkinsci/ca-apm-plugin"
+#groupId + artifcatId
 paths:
-- "org/jenkins-ci/plugins/ca-apm"
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-api"
 #added new developer
 developers:
 - "srikns"

--- a/permissions/plugin-ca-apm-api.yml
+++ b/permissions/plugin-ca-apm-api.yml
@@ -1,11 +1,8 @@
 ---
-#artifactId
 name: "ca-apm-api"
 github: "jenkinsci/ca-apm-plugin"
-#groupId + artifcatId
 paths:
 - "org/jenkins-ci/plugins/ca-apm/ca-apm-api"
-#added new developer
 developers:
 - "srikns"
 - "pramodanarase"

--- a/permissions/plugin-ca-apm-core.yml
+++ b/permissions/plugin-ca-apm-core.yml
@@ -1,9 +1,8 @@
 ---
-name: "ca-apm"
+name: "ca-apm-core"
 github: "jenkinsci/ca-apm-plugin"
 paths:
-- "org/jenkins-ci/plugins/ca-apm"
-#added new developer
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-core"
 developers:
 - "srikns"
 - "pramodanarase"

--- a/permissions/plugin-ca-apm-default-strategy.yml
+++ b/permissions/plugin-ca-apm-default-strategy.yml
@@ -1,0 +1,8 @@
+---
+name: "ca-apm-default-strategy"
+github: "jenkinsci/ca-apm-plugin"
+paths:
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-default-strategy"
+developers:
+- "srikns"
+- "pramodanarase"

--- a/permissions/plugin-ca-apm-dist.yml
+++ b/permissions/plugin-ca-apm-dist.yml
@@ -1,9 +1,8 @@
 ---
-name: "ca-apm"
+name: "ca-apm-dist"
 github: "jenkinsci/ca-apm-plugin"
 paths:
-- "org/jenkins-ci/plugins/ca-apm"
-#added new developer
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-dist"
 developers:
 - "srikns"
 - "pramodanarase"

--- a/permissions/plugin-ca-apm-parent.yml
+++ b/permissions/plugin-ca-apm-parent.yml
@@ -1,9 +1,8 @@
 ---
-name: "ca-apm"
+name: "ca-apm-parent"
 github: "jenkinsci/ca-apm-plugin"
 paths:
-- "org/jenkins-ci/plugins/ca-apm"
-#added new developer
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-parent"
 developers:
 - "srikns"
 - "pramodanarase"

--- a/permissions/plugin-ca-apm.yml
+++ b/permissions/plugin-ca-apm.yml
@@ -3,7 +3,6 @@ name: "ca-apm"
 github: "jenkinsci/ca-apm-plugin"
 paths:
 - "org/jenkins-ci/plugins/ca-apm"
-#added new developer
 developers:
 - "srikns"
 - "pramodanarase"

--- a/permissions/plugin-ca-apm.yml
+++ b/permissions/plugin-ca-apm.yml
@@ -3,7 +3,12 @@ name: "ca-apm"
 github: "jenkinsci/ca-apm-plugin"
 paths:
 - "org/jenkins-ci/plugins/ca-apm"
-- "org/jenkins-ci/plugins/ca-apm-plugin"
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-api"
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-core"
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-default-strategy"
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-dist"
+- "org/jenkins-ci/plugins/ca-apm/ca-apm-plugin"
+
 #added new developer
 developers:
 - "srikns"


### PR DESCRIPTION
Access denied to: https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ca-apm-plugin/2.0-alpha-2/ca-apm-plugin-2.0-alpha-2.pom, ReasonPhrase: Forbidden.

# Description
Git repository - https://github.com/jenkinsci/ca-apm-plugin
Git committer :  me (@pramodanarase ) and @srikns , also we have release permission on same plugin


# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
