### PR TITLE
Request permission for webhook-eventsource-plugin

### DIFF
--- a/permissions/plugin-webhook-eventsource.yml
+++ b/permissions/plugin-webhook-eventsource.yml
@@ -1,0 +1,7 @@
+---
+name: "webhook-eventsource"
+github: "jenkinsci/webhook-eventsource-plugin"
+paths:
+- "io/jenkins/plugins/webhook-eventsource"
+developers:
+- "surenpi"


### PR DESCRIPTION
# Description

This plugin has been forked into [jenkinsci/webhook-eventsource-plugin](https://github.com/jenkinsci/webhook-eventsource-plugin). Ths hosting request has been resolved, the ticket is [HOSTING-694](https://issues.jenkins-ci.org/browse/HOSTING-694).

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins