### PR TITLE
Permission to release jenkins-test-harness-htmlunit

### DIFF
--- a/permissions/component-jenkins-test-harness-htmlunit.yml
+++ b/permissions/component-jenkins-test-harness-htmlunit.yml
@@ -6,3 +6,6 @@ paths:
 developers:
 - "andresrc"
 - "drulli"
+- "jglick"
+- "batmat"
+- "oleg_nenashev"


### PR DESCRIPTION
I apparently have GH permissions to merge https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/4, but not Artifactory permissions to release it. Also adding some other people who are likely to deal with PRs like these, and who are already in `component-jenkins-test-harness.yml`, the only consumer of this repo: @oleg-nenashev & @batmat.