### PR TITLE
Updates maintainer for the sidebar-link plugin

### DIFF
--- a/permissions/plugin-sidebar-link.yml
+++ b/permissions/plugin-sidebar-link.yml
@@ -5,5 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/sidebar-link"
 - "org/jvnet/hudson/plugins/sidebar-link"
 developers:
-- "lvotypkova"
-- "oleg_nenashev"
+- "dszczepanik"


### PR DESCRIPTION
# Description

This change is related to transferring ownership of https://github.com/jenkinsci/sidebar-link-plugin as agreed https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/wOT9A47LZT4/YsQpYO9sFQAJ
@lvotypkova @oleg-nenashev

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
