### PR TITLE
Adopting plugin: google-oauth-plugin

### DIFF
--- a/permissions/plugin-google-oauth-plugin.yml
+++ b/permissions/plugin-google-oauth-plugin.yml
@@ -4,6 +4,5 @@ github: "jenkinsci/google-oauth-plugin"
 paths:
 - "org/jenkins-ci/plugins/google-oauth-plugin"
 developers:
-- "astroilov"
-- "mattmoor"
-- "orrc"
+- "craigbarber"
+- "evanbrown"


### PR DESCRIPTION
Changing permissions for plugin for plugin adoption.

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

The GCP Cloud Graphite: Platforms team will be adopting the google-oauth-plugin.
github repo: https://github.com/jenkinsci/google-oauth-plugin
We will also need to be granted access on the github repo. Github usernames:
https://github.com/craigatgoogle
https://github.com/evandbrown

dev list thread: https://groups.google.com/forum/#!msg/jenkinsci-dev/xvTsvnw_qk8/NF0VVEWaFgAJ
jira issue: https://issues.jenkins-ci.org/browse/JENKINS-55766
Existing maintainer @astroilov has approved.

# Submitter checklist for changing permissions

### Always

- [ X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
