### PR TITLE
Add a permission file for Jenkinsfile Runner tests

### DIFF
--- a/permissions/component-jenkinsfile-runner-tests.yml
+++ b/permissions/component-jenkinsfile-runner-tests.yml
@@ -1,0 +1,9 @@
+---
+name: "tests"
+github: "jenkinsci/jenkinsfile-runner"
+paths:
+- "io/jenkins/jenkinsfile-runner/tests"
+developers:
+- "oleg_nenashev"
+- "egutierrez"
+- "fcojfernandez"


### PR DESCRIPTION
A new submodule has been added to the project recently, but it was not reflected in the permissions files. So my release attempt has failed.

CC @varyvol @fcojfernandez 
