### PR TITLE
Adopting stash-pullrequest-builder-plugin

### DIFF
--- a/permissions/plugin-stash-pullrequest-builder.yml
+++ b/permissions/plugin-stash-pullrequest-builder.yml
@@ -5,3 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/stash-pullrequest-builder"
 developers:
 - "nemccarthy"
+- "jbochenski"
+- "jimklimov"

--- a/permissions/plugin-stash-pullrequest-builder.yml
+++ b/permissions/plugin-stash-pullrequest-builder.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "nemccarthy"
 - "jbochenski"
+- "jimklimov"

--- a/permissions/plugin-stash-pullrequest-builder.yml
+++ b/permissions/plugin-stash-pullrequest-builder.yml
@@ -6,4 +6,3 @@ paths:
 developers:
 - "nemccarthy"
 - "jbochenski"
-- "jimklimov"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

https://github.com/jenkinsci/stash-pullrequest-builder-plugin

The plugin has been effectively abandoned by the previous maintainer. Me and @jimklimov [volunteered to adopt it](https://groups.google.com/forum/?nomobile=true#!topic/jenkinsci-dev/oRBRP5-sZe4).

~~@jimklimov has not logged in to Artifactory ATM~~

# Submitter checklist for changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)