### PR TITLE
Adopting plugin google-storage-plugin

### DIFF
--- a/permissions/plugin-google-storage-plugin.yml
+++ b/permissions/plugin-google-storage-plugin.yml
@@ -4,9 +4,5 @@ github: "jenkinsci/google-storage-plugin"
 paths:
 - "org/jenkins-ci/plugins/google-storage-plugin"
 developers:
-- "astroilov"
-- "mattmoor"
-- "reprogrammer"
-- "tcnghia"
-- "a_goulti"
-- "bwkimmel"
+- "craigbarber"
+- "evanbrown"


### PR DESCRIPTION
# Description

The GCP Cloud Graphite: Platforms team will be adopting the google-storage-plugin.
github repo: https://github.com/jenkinsci/google-storage-plugin
We will also need to be granted admin access on the github repo. Github usernames:
https://github.com/craigatgoogle
https://github.com/evandbrown

dev list thread: https://groups.google.com/forum/#!searchin/jenkinsci-dev/google$20storage%7Csort:date/jenkinsci-dev/0uQtpNEGHNY/woO_KZcRFgAJ
Github issue: https://github.com/jenkinsci/google-storage-plugin/issues/49
Existing maintainer @agoulti has approved.

# Submitter checklist for changing permissions

### Always

- [X ] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
