### PR TITLE
Create new plugin Fortify

### DIFF
--- a/permissions/plugin-fortify.yml
+++ b/permissions/plugin-fortify.yml
@@ -1,0 +1,7 @@
+---
+name: "fortify"
+github: "jenkinsci/fortify-plugin"
+paths:
+- "org/jenkins-ci/plugins/fortify"
+developers:
+- "akaryakina"


### PR DESCRIPTION

# Description

We are adding the official Fortify plugin that will eventually replace all others (but not yet)
Here is our github repository: [https://github.com/jenkinsci/fortify-plugin]
The hosting request is here: [https://issues.jenkins-ci.org/browse/HOSTING-710]
At the moment the only maintainer is @akaryakina

# Submitter checklist for changing permissions

### Always
- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
