### PR TITLE
Added stephenshank to uploaders for plugin

### DIFF
--- a/permissions/plugin-google-kubernetes-engine.yml
+++ b/permissions/plugin-google-kubernetes-engine.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "craigbarber"
 - "evanbrown"
+- "stephanshank"

--- a/permissions/plugin-google-kubernetes-engine.yml
+++ b/permissions/plugin-google-kubernetes-engine.yml
@@ -6,4 +6,4 @@ paths:
 developers:
 - "craigbarber"
 - "evanbrown"
-- "stephanshank"
+- "stephenshank"


### PR DESCRIPTION
# Description

Add uploader to google-kubernetes-engine plugin project.
Project repo: https://github.com/jenkinsci/google-kubernetes-engine-plugin 
JIRA Issue: https://issues.jenkins-ci.org/browse/JENKINS-56253
Adding permissions for @stephenashank
Existing maintainer: @craigatgoogle 

# Submitter checklist for changing permissions


### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
