### PR TITLE
Update plugin-blueocean-executor-info.yml

### DIFF
--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -1,13 +1,13 @@
 ---
 name: "blueocean-executor-info"
-github: "jenkinsci/blueocean-executor-info-plugin"
+github: "jenkinsci/blueocean-plugin"
 paths:
-- "org/jenkins-ci/plugins/blueocean-executor-info"
+- "io/jenkins/blueocean/blueocean-executor-info"
 developers:
-- "jamesdumay"
 - "michaelneale"
 - "vivek"
+- "tfennelly"
 - "kzantow"
 - "davidbees"
 - "halkeye"
-- "imeredith"
+- "tscherler"

--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -10,4 +10,5 @@ developers:
 - "kzantow"
 - "davidbees"
 - "halkeye"
+- "imeredith"
 - "tscherler"


### PR DESCRIPTION
This plugin got merged into the main blueocean plugin.

I copied most of https://github.com/jenkins-infra/repository-permissions-updater/blob/master/permissions/plugin-blueocean-web.yml

I'm one of the existing maintainers of this plugin.

Trying to fix:
```
    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project blueocean-executor-info: Failed to deploy artifacts: Could not transfer artifact io.jenkins.blueocean:blueocean-executor-info:hpi:1.13.0 from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): Access denied to: https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-executor-info/1.13.0/blueocean-executor-info-1.13.0.hpi, ReasonPhrase: Forbidden. -> [Help 1]
```