### PR TITLE
Updates maintainer for the plugin Office-365-Connector

### DIFF
--- a/permissions/plugin-Office-365-Connector.yml
+++ b/permissions/plugin-Office-365-Connector.yml
@@ -4,3 +4,4 @@ paths:
 - "org/jenkins-ci/plugins/Office-365-Connector"
 developers:
 - "outconn"
+- "dszczepanik"


### PR DESCRIPTION
# Description

As the result of https://groups.google.com/forum/?nomobile=true#!topic/jenkinsci-dev/NolCZIkGc_M list of https://github.com/jenkinsci/office-365-connector-plugin maintainers is updated
 @outconn

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
