### PR TITLE
Added permissions for revapi-hpi-extractor.

### DIFF
--- a/permissions/component-revapi-hpi-extractor.yml
+++ b/permissions/component-revapi-hpi-extractor.yml
@@ -1,0 +1,7 @@
+---
+name: "revapi-hpi-extractor"
+github: "jenkinsci/lib-revapi-hpi-extractor"
+paths:
+- "io/jenkins/tools/revapi-hpi-extractor"
+developers:
+- "drulli"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

This simple library is an extension of Revapi to extract Jenkins Plugin Archives (hpi files) so that these could be used in a Revapi analysis.

- https://github.com/jenkinsci/lib-revapi-hpi-extractor
- https://issues.jenkins-ci.org/browse/HOSTING-722

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)