### PR TITLE
Add security contacts metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The above example will result in the Jira issue being assigned to `some_user_nam
 Both of `jira` and `email` are optional.
 
 Please note that we generally reject email contacts due to the additional overhead in reaching out via email.
-Unless you represent a large organization (e.g. cloud providers) in which most developers would not know how you coordinate security issues, please refrain from requesting to be contacted via email.
+Unless you represent a large organization with dedicated security team that needs to be involved in the coordination of a release, please refrain from requesting to be contacted via email.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ Rename and edit the existing permissions file, changing both `name` and the last
 
 Change the `paths` to match the new Maven coordinates, or, if further uploads for the old coordinates are expected, add a new list entry.
 
+Managing Security Process
+-------------------------
+
+The Jenkins project acts as a primary contact point for security researchers seeking to report security vulnerabilities in Jenkins and Jenkins plugins ([learn more](https://jenkins.io/security/)).
+
+Through additional metadata in the YAML file described above, you can define who should be contacted in the event of a report being received.
+Add a section like the following to your plugin's YAML file:
+
+```yaml
+security:
+  contacts:
+    jira: some_user_name
+    email: security@acme.org
+```
+
+The above example will result in the Jira issue being assigned to `some_user_name`, and an email notification being sent to `security@acme.org` to establish contact.
+Both of `jira` and `email` are optional.
+
+Please note that we generally reject email contacts due to the additional overhead in reaching out via email.
+Unless you represent a large organization (e.g. cloud providers) in which most developers would not know how you coordinate security issues, please refrain from requesting to be contacted via email.
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ security:
     email: security@acme.org
 ```
 
-The above example will result in the Jira issue being assigned to `some_user_name`, and an email notification being sent to `security@acme.org` to establish contact.
-Both of `jira` and `email` are optional.
+Given the above example, we will assign any security issue in Jira to `some_user_name` rather than one of the developers able to release the plugin, and send an email notification to `security@acme.org` to establish contact.
+Either of `jira` and `email` are optional.
 
 Please note that we generally reject email contacts due to the additional overhead in reaching out via email.
 Unless you represent a large organization with dedicated security team that needs to be involved in the coordination of a release, please refrain from requesting to be contacted via email.

--- a/permissions/plugin-aws-codebuild.yml
+++ b/permissions/plugin-aws-codebuild.yml
@@ -8,3 +8,6 @@ developers:
 - "johnhankataw"
 - "taoyong"
 - "leobaran_aws"
+security:
+  contacts:
+    email: "aws-security@amazon.com"

--- a/permissions/plugin-aws-codepipeline.yml
+++ b/permissions/plugin-aws-codepipeline.yml
@@ -6,3 +6,6 @@ paths:
 developers:
 - "belltimo"
 - "fgalmeida"
+security:
+  contacts:
+    email: "aws-security@amazon.com"

--- a/permissions/plugin-blueocean-bitbucket-pipeline.yml
+++ b/permissions/plugin-blueocean-bitbucket-pipeline.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-commons.yml
+++ b/permissions/plugin-blueocean-commons.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-config.yml
+++ b/permissions/plugin-blueocean-config.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -11,4 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
-
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-dashboard.yml
+++ b/permissions/plugin-blueocean-dashboard.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-events.yml
+++ b/permissions/plugin-blueocean-events.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -12,3 +12,6 @@ developers:
 - "halkeye"
 - "imeredith"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-git-pipeline.yml
+++ b/permissions/plugin-blueocean-git-pipeline.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-github-pipeline.yml
+++ b/permissions/plugin-blueocean-github-pipeline.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-i18n.yml
+++ b/permissions/plugin-blueocean-i18n.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-jira.yml
+++ b/permissions/plugin-blueocean-jira.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-jwt.yml
+++ b/permissions/plugin-blueocean-jwt.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-personalization.yml
+++ b/permissions/plugin-blueocean-personalization.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-pipeline-api-impl.yml
+++ b/permissions/plugin-blueocean-pipeline-api-impl.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-pipeline-editor.yml
+++ b/permissions/plugin-blueocean-pipeline-editor.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-pipeline-scm-api.yml
+++ b/permissions/plugin-blueocean-pipeline-scm-api.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-rest-impl.yml
+++ b/permissions/plugin-blueocean-rest-impl.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-rest.yml
+++ b/permissions/plugin-blueocean-rest.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean-web.yml
+++ b/permissions/plugin-blueocean-web.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-blueocean.yml
+++ b/permissions/plugin-blueocean.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-branch-api.yml
+++ b/permissions/plugin-branch-api.yml
@@ -11,3 +11,6 @@ developers:
 - "svanoort"
 - "rsandell"
 - "dnusbaum"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-codedeploy.yml
+++ b/permissions/plugin-codedeploy.yml
@@ -10,3 +10,6 @@ developers:
 - "yubangxi"
 - "feverlu"
 - "q13117god"
+security:
+  contacts:
+    email: "aws-security@amazon.com"

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-github-branch-source.yml
+++ b/permissions/plugin-github-branch-source.yml
@@ -12,3 +12,6 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-github.yml
+++ b/permissions/plugin-github.yml
@@ -7,3 +7,6 @@ developers:
 - "integer"
 - "lanwen"
 - "oleg_nenashev"
+security:
+  contacts:
+    jira: "integer"

--- a/permissions/plugin-jenkins-design-language.yml
+++ b/permissions/plugin-jenkins-design-language.yml
@@ -11,4 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
-
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-maven-plugin.yml
+++ b/permissions/plugin-maven-plugin.yml
@@ -11,3 +11,6 @@ developers:
 - "olamy"
 - "olivergondza"
 - "aheritier"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-build-step.yml
+++ b/permissions/plugin-pipeline-build-step.yml
@@ -9,3 +9,6 @@ developers:
 - "svanoort"
 - "dnusbaum"
 - "rsandell"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-github-lib.yml
+++ b/permissions/plugin-pipeline-github-lib.yml
@@ -10,3 +10,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "svanoort"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-graph-analysis.yml
+++ b/permissions/plugin-pipeline-graph-analysis.yml
@@ -10,3 +10,6 @@ developers:
 - "jglick"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-input-step.yml
+++ b/permissions/plugin-pipeline-input-step.yml
@@ -10,3 +10,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-milestone-step.yml
+++ b/permissions/plugin-pipeline-milestone-step.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -9,3 +9,6 @@ developers:
 - "stephenconnolly"
 - "rsandell"
 - "svanoort"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-model-declarative-agent.yml
+++ b/permissions/plugin-pipeline-model-declarative-agent.yml
@@ -8,3 +8,6 @@ developers:
 - "oleg_nenashev"
 - "stephenconnolly"
 - "rsandell"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -9,3 +9,6 @@ developers:
 - "stephenconnolly"
 - "rsandell"
 - "svanoort"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-model-extensions.yml
+++ b/permissions/plugin-pipeline-model-extensions.yml
@@ -9,3 +9,6 @@ developers:
 - "stephenconnolly"
 - "rsandell"
 - "svanoort"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-stage-step.yml
+++ b/permissions/plugin-pipeline-stage-step.yml
@@ -10,3 +10,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-stage-tags-metadata.yml
+++ b/permissions/plugin-pipeline-stage-tags-metadata.yml
@@ -9,3 +9,6 @@ developers:
 - "stephenconnolly"
 - "rsandell"
 - "svanoort"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-stage-view.yml
+++ b/permissions/plugin-pipeline-stage-view.yml
@@ -10,3 +10,6 @@ developers:
 - "jglick"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-scm-api.yml
+++ b/permissions/plugin-scm-api.yml
@@ -11,3 +11,6 @@ developers:
 - "svanoort"
 - "rsandell"
 - "dnusbaum"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-script-security.yml
+++ b/permissions/plugin-script-security.yml
@@ -11,3 +11,6 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-sse-gateway.yml
+++ b/permissions/plugin-sse-gateway.yml
@@ -13,3 +13,6 @@ developers:
 - "olamy"
 - "davidbees"
 - "halkeye"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/permissions/plugin-workflow-aggregator.yml
+++ b/permissions/plugin-workflow-aggregator.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-api.yml
+++ b/permissions/plugin-workflow-api.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-basic-steps.yml
+++ b/permissions/plugin-workflow-basic-steps.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-cps-global-lib.yml
+++ b/permissions/plugin-workflow-cps-global-lib.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-cps.yml
+++ b/permissions/plugin-workflow-cps.yml
@@ -11,3 +11,6 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-durable-task-step.yml
+++ b/permissions/plugin-workflow-durable-task-step.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-job.yml
+++ b/permissions/plugin-workflow-job.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-multibranch.yml
+++ b/permissions/plugin-workflow-multibranch.yml
@@ -12,3 +12,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-scm-step.yml
+++ b/permissions/plugin-workflow-scm-step.yml
@@ -11,3 +11,6 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-step-api.yml
+++ b/permissions/plugin-workflow-step-api.yml
@@ -10,3 +10,6 @@ developers:
 - "svanoort"
 - "rsandell"
 - "dnusbaum"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-support.yml
+++ b/permissions/plugin-workflow-support.yml
@@ -11,3 +11,6 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/pom-blueocean-parent.yml
+++ b/permissions/pom-blueocean-parent.yml
@@ -11,3 +11,6 @@ developers:
 - "davidbees"
 - "halkeye"
 - "tscherler"
+security:
+  contacts:
+    jira: "blueocean_security_members"

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -59,6 +59,7 @@ public class ArtifactoryPermissionsUpdater {
         private String[] paths = new String[0]
         private String[] developers = new String[0]
         String github
+        Object security // unused, just metadata for Jenkins security team
 
         String getName() {
             return name


### PR DESCRIPTION
So far we tracked this internally, but it cannot hurt adding it to the metadata here, and giving maintainers an easy way to define this themselves.
