### PR TITLE
Add maintainers to favorite and display-url-api

### DIFF
--- a/permissions/plugin-display-url-api.yml
+++ b/permissions/plugin-display-url-api.yml
@@ -10,7 +10,7 @@ developers:
 - "imeredith"
 - "stephenconnolly"
 - "abayer"
-- "carrol"
+- "carroll"
 - "dnusbaum"
 - "olamy"
 - "rsandell"

--- a/permissions/plugin-display-url-api.yml
+++ b/permissions/plugin-display-url-api.yml
@@ -9,3 +9,8 @@ developers:
 - "vivek"
 - "imeredith"
 - "stephenconnolly"
+- "abayer"
+- "carrol"
+- "dnusbaum"
+- "olamy"
+- "rsandell"

--- a/permissions/plugin-favorite.yml
+++ b/permissions/plugin-favorite.yml
@@ -7,3 +7,8 @@ developers:
 - "michaelneale"
 - "jamesdumay"
 - "vivek"
+- "abayer"
+- "carrol"
+- "dnusbaum"
+- "olamy"
+- "rsandell"

--- a/permissions/plugin-favorite.yml
+++ b/permissions/plugin-favorite.yml
@@ -8,7 +8,7 @@ developers:
 - "jamesdumay"
 - "vivek"
 - "abayer"
-- "carrol"
+- "carroll"
 - "dnusbaum"
 - "olamy"
 - "rsandell"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

This PR adds @abayer, @car-roll, @dwnusbaum, @olamy, and @rsandell as maintainers of https://github.com/jenkinsci/display-url-api-plugin and https://github.com/jenkinsci/favorite-plugin.

CC @vivek or @michaelneale for confirmation from existing maintainers.

CC @bitwiseman, @kshultzCB, @joseblas, I didn't see your name in any other plugin permission files, but if you give me your Jenkins community account name and confirm that you have logged in to Artifactory at least once then I will add you to the PR.
 
<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
