### PR TITLE
Add maintainers to Pipeline-related plugins

### DIFF
--- a/permissions/plugin-branch-api.yml
+++ b/permissions/plugin-branch-api.yml
@@ -11,6 +11,9 @@ developers:
 - "svanoort"
 - "rsandell"
 - "dnusbaum"
+- "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-display-url-api.yml
+++ b/permissions/plugin-display-url-api.yml
@@ -14,3 +14,5 @@ developers:
 - "dnusbaum"
 - "olamy"
 - "rsandell"
+- "bitwiseman"
+- "kshultz"

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -11,7 +11,7 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
-- "dwnusbaum"
+- "bitwiseman"
 - "kshultz"
 security:
   contacts:

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "dwnusbaum"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-favorite.yml
+++ b/permissions/plugin-favorite.yml
@@ -12,3 +12,5 @@ developers:
 - "dnusbaum"
 - "olamy"
 - "rsandell"
+- "bitwiseman"
+- "kshultz"

--- a/permissions/plugin-github-branch-source.yml
+++ b/permissions/plugin-github-branch-source.yml
@@ -12,6 +12,8 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-build-step.yml
+++ b/permissions/plugin-pipeline-build-step.yml
@@ -9,6 +9,9 @@ developers:
 - "svanoort"
 - "dnusbaum"
 - "rsandell"
+- "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-graph-analysis.yml
+++ b/permissions/plugin-pipeline-graph-analysis.yml
@@ -10,6 +10,8 @@ developers:
 - "jglick"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-input-step.yml
+++ b/permissions/plugin-pipeline-input-step.yml
@@ -10,6 +10,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-stage-step.yml
+++ b/permissions/plugin-pipeline-stage-step.yml
@@ -10,6 +10,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-stage-view.yml
+++ b/permissions/plugin-pipeline-stage-view.yml
@@ -10,6 +10,8 @@ developers:
 - "jglick"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-scm-api.yml
+++ b/permissions/plugin-scm-api.yml
@@ -11,6 +11,9 @@ developers:
 - "svanoort"
 - "rsandell"
 - "dnusbaum"
+- "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-script-security.yml
+++ b/permissions/plugin-script-security.yml
@@ -11,6 +11,8 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-structs.yml
+++ b/permissions/plugin-structs.yml
@@ -13,3 +13,5 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"

--- a/permissions/plugin-workflow-aggregator.yml
+++ b/permissions/plugin-workflow-aggregator.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-api.yml
+++ b/permissions/plugin-workflow-api.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-basic-steps.yml
+++ b/permissions/plugin-workflow-basic-steps.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-cps-global-lib.yml
+++ b/permissions/plugin-workflow-cps-global-lib.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-cps.yml
+++ b/permissions/plugin-workflow-cps.yml
@@ -11,6 +11,8 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-durable-task-step.yml
+++ b/permissions/plugin-workflow-durable-task-step.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-job.yml
+++ b/permissions/plugin-workflow-job.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-multibranch.yml
+++ b/permissions/plugin-workflow-multibranch.yml
@@ -12,6 +12,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-scm-step.yml
+++ b/permissions/plugin-workflow-scm-step.yml
@@ -11,6 +11,8 @@ developers:
 - "dnusbaum"
 - "rsandell"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-step-api.yml
+++ b/permissions/plugin-workflow-step-api.yml
@@ -10,6 +10,8 @@ developers:
 - "svanoort"
 - "rsandell"
 - "dnusbaum"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/plugin-workflow-support.yml
+++ b/permissions/plugin-workflow-support.yml
@@ -11,6 +11,8 @@ developers:
 - "rsandell"
 - "dnusbaum"
 - "carroll"
+- "bitwiseman"
+- "kshultz"
 security:
   contacts:
     jira: "pipeline_security_members"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

Adds @bitwiseman, and @kshultzCB as maintainers of the following 24 plugins (and @car-roll to a few of them):

* https://github.com/jenkinsci/branch-api-plugin
* https://github.com/jenkinsci/display-url-api-plugin
* https://github.com/jenkinsci/durable-task-plugin
* https://github.com/jenkinsci/favorite-plugin
* https://github.com/jenkinsci/github-branch-source-plugin
* https://github.com/jenkinsci/pipeline-build-step-plugin
* https://github.com/jenkinsci/pipeline-graph-analysis-plugin
* https://github.com/jenkinsci/pipeline-input-step-plugin
* https://github.com/jenkinsci/pipeline-stage-step-plugin
* https://github.com/jenkinsci/pipeline-stage-view-plugin
* https://github.com/jenkinsci/scm-api-plugin
* https://github.com/jenkinsci/script-security-plugin
* https://github.com/jenkinsci/structs-plugin
* https://github.com/jenkinsci/workflow-aggregator-plugin
* https://github.com/jenkinsci/workflow-api-plugin
* https://github.com/jenkinsci/workflow-basic-steps-plugin
* https://github.com/jenkinsci/workflow-cps-plugin
* https://github.com/jenkinsci/workflow-cps-global-lib-plugin
* https://github.com/jenkinsci/workflow-durable-task-step-plugin
* https://github.com/jenkinsci/workflow-job-plugin
* https://github.com/jenkinsci/workflow-multibranch-plugin
* https://github.com/jenkinsci/workflow-scm-step-plugin
* https://github.com/jenkinsci/workflow-step-api-plugin
* https://github.com/jenkinsci/workflow-support-plugin

I am currently a maintainer of the plugins and I approve the PR.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
