### PR TITLE
Maven plugins need to update maven-metadata.xml for the group

### DIFF
--- a/permissions/component-maven-hpi-plugin.yml
+++ b/permissions/component-maven-hpi-plugin.yml
@@ -2,8 +2,7 @@
 name: "maven-hpi-plugin"
 github: "jenkinsci/maven-hpi-plugin"
 paths:
-- "org/jenkins-ci/tools/maven-hpi-plugin"
-- "org/jvnet/hudson/tools/maven-hpi-plugin"
+- "org/jenkins-ci/tools"
 developers:
 - "jglick"
 - "kohsuke"

--- a/permissions/component-maven-hpi-plugin.yml
+++ b/permissions/component-maven-hpi-plugin.yml
@@ -3,6 +3,7 @@ name: "maven-hpi-plugin"
 github: "jenkinsci/maven-hpi-plugin"
 paths:
 - "org/jenkins-ci/tools"
+- "org/jenkins-ci/tools/maven-hpi-plugin"
 developers:
 - "jglick"
 - "kohsuke"

--- a/permissions/component-maven-hudson-dev-plugin.yml
+++ b/permissions/component-maven-hudson-dev-plugin.yml
@@ -2,6 +2,6 @@
 name: "maven-jenkins-dev-plugin"
 github: "jenkinsci/maven-hudson-dev-plugin"
 paths:
-- "org/jenkins-ci/tools/maven-jenkins-dev-plugin"
+- "org/jenkins-ci/tools"
 developers:
 - "olamy"

--- a/permissions/component-maven-hudson-dev-plugin.yml
+++ b/permissions/component-maven-hudson-dev-plugin.yml
@@ -3,5 +3,6 @@ name: "maven-jenkins-dev-plugin"
 github: "jenkinsci/maven-hudson-dev-plugin"
 paths:
 - "org/jenkins-ci/tools"
+- "org/jenkins-ci/tools/maven-jenkins-dev-plugin"
 developers:
 - "olamy"


### PR DESCRIPTION
I tried to publish a release of `maven-hpi-plugin` but was stymied:

```
…
[INFO] [INFO] --- maven-deploy-plugin:2.6:deploy (default-deploy) @ maven-hpi-plugin ---
[INFO] [INFO] Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/3.4/maven-hpi-plugin-3.4.jar
[INFO] [INFO] Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/3.4/maven-hpi-plugin-3.4.jar (141 kB at 108 kB/s)
[INFO] [INFO] Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/3.4/maven-hpi-plugin-3.4.pom
[INFO] [INFO] Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/3.4/maven-hpi-plugin-3.4.pom (12 kB at 45 kB/s)
[INFO] [INFO] Downloading from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/maven-metadata.xml
[INFO] [INFO] Downloaded from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/maven-metadata.xml (2.7 kB at 25 kB/s)
[INFO] [INFO] Downloading from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-metadata.xml
[INFO] [INFO] Downloaded from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-metadata.xml (385 B at 5.0 kB/s)
[INFO] [INFO] Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/maven-metadata.xml
[INFO] [INFO] Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-hpi-plugin/maven-metadata.xml (2.6 kB at 11 kB/s)
[INFO] [INFO] Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-metadata.xml
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] BUILD FAILURE
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Total time:  21.708 s
[INFO] [INFO] Finished at: 2019-03-28T11:54:03-04:00
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.6:deploy (default-deploy) on project maven-hpi-plugin: Failed to deploy metadata: Could not transfer metadata org.jenkins-ci.tools/maven-metadata.xml from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): Access denied to: https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-metadata.xml -> [Help 1]
```

It seems [this file](https://repo.jenkins-ci.org/releases/org/jenkins-ci/tools/maven-metadata.xml) gets uploaded, even though it is unchanged, to record

```xml
<plugin>
  <name>Maven Jenkins Plugin</name>
  <prefix>hpi</prefix>
  <artifactId>maven-hpi-plugin</artifactId>
</plugin>
```

so the publisher needs to have permission to the parent directory as well.

I assume from the lack of trailing `/`s that `paths` only lists directories, not individual file paths.

@daniel-beck @oleg-nenashev @batmat @olamy @stephenc