### PR TITLE
Add security contact for several plugins

### DIFF
--- a/permissions/plugin-artifact-manager-s3.yml
+++ b/permissions/plugin-artifact-manager-s3.yml
@@ -7,3 +7,6 @@ developers:
 - "jglick"
 - "csanchez"
 - "oleg_nenashev"
+security:
+  contacts:
+    jira: "cloud_platform_v2"

--- a/permissions/plugin-kubernetes-credentials.yml
+++ b/permissions/plugin-kubernetes-credentials.yml
@@ -7,3 +7,6 @@ developers:
 - "max_laverse"
 - "csanchez"
 - "sirstrahd"
+security:
+  contacts:
+    jira: "cloud_platform_v2"

--- a/permissions/plugin-mesos.yml
+++ b/permissions/plugin-mesos.yml
@@ -7,3 +7,6 @@ developers:
 - "maselvaraj"
 - "vinodkone"
 - "vlatombe"
+security:
+  contacts:
+    jira: "cloud_platform_v2"


### PR DESCRIPTION
@csanchez @Vlatombe As maintainers, please approve or contact @richbg.

FYI @maxlaverse @maselvaraj this is seeking to define who would be informed about security vulnerabilities in these plugins. In the past I've chosen a maintainer at random. Docs: https://github.com/jenkins-infra/repository-permissions-updater#managing-security-process