### PR TITLE
Add myself to weibo plugin

### DIFF
--- a/permissions/plugin-weibo.yml
+++ b/permissions/plugin-weibo.yml
@@ -3,4 +3,5 @@ name: "weibo"
 github: "jenkinsci/weibo-plugin"
 paths:
 - "org/jenkins-ci/plugins/weibo"
-developers: []
+developers:
+- "surenpi"


### PR DESCRIPTION
# Description

@jiafu1115 was the original maintainer of [weibo plugin](https://github.com/jenkinsci/weibo-plugin). I already created [a thread](https://groups.google.com/forum/#!msg/jenkinsci-dev/S5NrPK1HANs/bwOhRZRyAwAJ) in the jenkins-dev mailling list

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)