### PR TITLE
Add rodrigc to extended-choice-parameter

### DIFF
--- a/permissions/plugin-extended-choice-parameter.yml
+++ b/permissions/plugin-extended-choice-parameter.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/extended-choice-parameter"
 developers:
 - "vimil"
+- "rodrigc"


### PR DESCRIPTION
# Description

@vimil I would like to get write access to the extended-choice-parameter plugin https://github.com/jenkinsci/extended-choice-parameter-plugin so that I can merge this fix: https://github.com/jenkinsci/extended-choice-parameter-plugin/pull/25
which allows this plugin to be used in a Jenkins Pipeline

On March 6, I sent you a private e-mail to the Yahoo e-mail address listed on your GitHub profile here: https://github.com/vimil

I have not received a response from you, more than 3 weeks later.

I assume at this point, that you have abandoned this plugin.


# Submitter checklist for changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
