### PR TITLE
Fix repository name in permissions file for lib dtkit

### DIFF
--- a/permissions/component-dtkit-lib.yml
+++ b/permissions/component-dtkit-lib.yml
@@ -1,6 +1,6 @@
 ---
 name: "dtkit-lib"
-github: "jenkinsci/dtkit-libdtkit"
+github: "jenkinsci/libdtkit"
 paths:
 - "org/jenkins-ci/lib/dtkit"
 developers:


### PR DESCRIPTION
Fix github repository name in the permission files.

@oleg-nenashev my previos PR contains a wrong github repository name, at least I suppose the issue about push is denied is because of this.