### PR TITLE
permissions added for qaconsole-test-automation-reporter

### DIFF
--- a/permissions/plugin-qaconsole-test-automation-reporter.yml
+++ b/permissions/plugin-qaconsole-test-automation-reporter.yml
@@ -1,7 +1,7 @@
 ---
-name: "qaconsole-test-automation-reporter"
+name: "com/qaconsole/qaconsole-test-automation-reporter-plugin"
 github: "jenkinsci/qaconsole-test-automation-reporter-plugin"
 paths:
-  - "org/jenkins-ci/plugins/qaconsole-test-automation-reporter"
+  - "com/qaconsole/qaconsole-test-automation-reporter-plugin"
 developers:
   - "best4test_com"

--- a/permissions/plugin-qaconsole-test-automation-reporter.yml
+++ b/permissions/plugin-qaconsole-test-automation-reporter.yml
@@ -1,0 +1,7 @@
+---
+name: "qaconsole-test-automation-reporter"
+github: "jenkinsci/qaconsole-test-automation-reporter-plugin"
+paths:
+  - "org/jenkins-ci/plugins/qaconsole-test-automation-reporter"
+developers:
+  - "best4test"

--- a/permissions/plugin-qaconsole-test-automation-reporter.yml
+++ b/permissions/plugin-qaconsole-test-automation-reporter.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/qaconsole-test-automation-reporter-plugin"
 paths:
   - "org/jenkins-ci/plugins/qaconsole-test-automation-reporter"
 developers:
-  - "best4test"
+  - "best4test_com"

--- a/permissions/plugin-qaconsole-test-automation-reporter.yml
+++ b/permissions/plugin-qaconsole-test-automation-reporter.yml
@@ -1,5 +1,5 @@
 ---
-name: "com/qaconsole/qaconsole-test-automation-reporter-plugin"
+name: "qaconsole-test-automation-reporter-plugin"
 github: "jenkinsci/qaconsole-test-automation-reporter-plugin"
 paths:
   - "com/qaconsole/qaconsole-test-automation-reporter-plugin"


### PR DESCRIPTION

# Description
https://github.com/jenkinsci/qaconsole-test-automation-reporter-plugin
https://issues.jenkins-ci.org/browse/HOSTING-735

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

