### PR TITLE
Make permissions consistent across all stage-view modules

### DIFF
--- a/permissions/plugin-pipeline-rest-api.yml
+++ b/permissions/plugin-pipeline-rest-api.yml
@@ -5,3 +5,14 @@ paths:
 - "org/jenkins-ci/plugins/pipeline-stage-view/pipeline-rest-api"
 developers:
 - "svanoort"
+- "abayer"
+- "dnusbaum"
+- "jglick"
+- "rsandell"
+- "carroll"
+- "bitwiseman"
+- "kshultz"
+- "olamy"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/plugin-pipeline-stage-view.yml
+++ b/permissions/plugin-pipeline-stage-view.yml
@@ -12,6 +12,7 @@ developers:
 - "carroll"
 - "bitwiseman"
 - "kshultz"
+- "olamy"
 security:
   contacts:
     jira: "pipeline_security_members"

--- a/permissions/pom-pipeline-stage-view-parent.yml
+++ b/permissions/pom-pipeline-stage-view-parent.yml
@@ -5,3 +5,14 @@ paths:
 - "org/jenkins-ci/plugins/pipeline-stage-view/parent-pom"
 developers:
 - "svanoort"
+- "abayer"
+- "dnusbaum"
+- "jglick"
+- "rsandell"
+- "carroll"
+- "bitwiseman"
+- "kshultz"
+- "olamy"
+security:
+  contacts:
+    jira: "pipeline_security_members"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Pipeline Stage View is a multi-module project, but there were a lot of maintainers who only had permission for one of the modules. This PR makes the set of maintainers consistent for the 2 plugins and the parent POM. It also makes the security contact the same for all 3 modules.

GitHub Repository: https://github.com/jenkinsci/pipeline-stage-view-plugin (parent pom)
* pipeline-stage-view plugin: https://github.com/jenkinsci/pipeline-stage-view-plugin/tree/master/ui
* pipeline-rest-api plugin: https://github.com/jenkinsci/pipeline-stage-view-plugin/tree/master/rest-api

CC @svanoort for confirmation since he is the only one with release permissions for pipeline-rest-api and the parent pom.

Subsumes #1095 

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
