### PR TITLE
[HOSTING-741] Add localization-support plugin

### DIFF
--- a/permissions/plugin-localization-support.yml
+++ b/permissions/plugin-localization-support.yml
@@ -1,0 +1,7 @@
+---
+name: "localization-support"
+github: "jenkinsci/localization-support-plugin"
+paths:
+- "io/jenkins/plugins/localization-support"
+developers:
+- "danielbeck"


### PR DESCRIPTION
# Description

* [HOSTING-741](https://issues.jenkins-ci.org/browse/HOSTING-741)
* [GitHub repo](https://github.com/jenkinsci/localization-support-plugin)

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [n/a] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
