### PR TITLE
HOSTING-747 - Adds permissions for metrics-datadog plugin

### DIFF
--- a/permissions/plugin-metrics-datadog.yml
+++ b/permissions/plugin-metrics-datadog.yml
@@ -1,0 +1,7 @@
+---
+name: "metrics-datadog"
+github: "jenkinsci/metrics-datadog-plugin"
+paths:
+- "io/jenkins/plugins/metrics-datadog"
+developers:
+- "mpapo"


### PR DESCRIPTION
# Description

* Hosting request: [HOSTING-747](https://issues.jenkins-ci.org/browse/HOSTING-747)
* Plugin repository: https://github.com/jenkinsci/metrics-datadog-plugin

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [n/a] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
