### PR TITLE
Making structs-related permissions consistent

### DIFF
--- a/permissions/component-symbol-annotation.yml
+++ b/permissions/component-symbol-annotation.yml
@@ -10,3 +10,8 @@ developers:
 - "stephenconnolly"
 - "abayer"
 - "svanoort"
+- "dnusbaum"
+- "rsandell"
+- "carroll"
+- "bitwiseman"
+- "kshultz"

--- a/permissions/pom-structs-parent.yml
+++ b/permissions/pom-structs-parent.yml
@@ -10,3 +10,8 @@ developers:
 - "stephenconnolly"
 - "abayer"
 - "svanoort"
+- "dnusbaum"
+- "rsandell"
+- "carroll"
+- "bitwiseman"
+- "kshultz"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

https://github.com/jenkinsci/structs-plugin is a multi-module project, but the permissions on the plugin did not match the parent pom or the symbol-annotations library. This PR makes the permissions consistent. CC @abayer for confirmation from an existing maintainer.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
