### PR TITLE
Adding Tony Noble to 'changes-since-last-success' plugin

### DIFF
--- a/permissions/plugin-changes-since-last-success.yml
+++ b/permissions/plugin-changes-since-last-success.yml
@@ -3,4 +3,5 @@ name: "changes-since-last-success"
 github: "jenkinsci/changes-since-last-success-plugin"
 paths:
 - "org/jenkins-ci/plugins/changes-since-last-success"
-developers: []
+developers: 
+- stealthdj


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

Release upload access required for new maintainer for changes-since-last-success plugin.
https://github.com/jenkinsci/changes-since-last-success-plugin

github access to project already added by @oleg-nenashev 

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
