### PR TITLE
Update plugin-rigor-optimization.yml

### DIFF
--- a/permissions/plugin-rigor-optimization.yml
+++ b/permissions/plugin-rigor-optimization.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/rigor-optimization-plugin"
 paths:
 - "org/jenkins-ci/plugins/rigor-optimization"
 developers:
-- "mtisham"
+- "wcmonty"


### PR DESCRIPTION
Adding existing contributor, remove old contributor who is no longer with the organization.

# Description

I am submitting this pull request to add an existing contributor in our organization who has commit rights and remove old contributors who are no longer part of the organization that maintains this plugin.

Plugin page:
https://plugins.jenkins.io/rigor-optimization

GitHub repository:
https://github.com/jenkinsci/rigor-optimization-plugin

Hosting Issue:
N/A - This is an existing plugin

Commit history (including new contributor `wcmonty`):
https://github.com/jenkinsci/rigor-optimization-plugin/commits/master

# Submitter checklist for changing permissions
### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
