### PR TITLE
Creating permissions/plugin-results-cache-yml

### DIFF
--- a/permissions/plugin-results-cache.yml
+++ b/permissions/plugin-results-cache.yml
@@ -1,0 +1,8 @@
+---
+name: "results-cache"
+github: "jenkinsci/results-cache-plugin"
+paths:
+- "org/jenkins-ci/plugins/results-cache"
+developers:
+- francisco-orduna
+- kargath

--- a/permissions/plugin-results-cache.yml
+++ b/permissions/plugin-results-cache.yml
@@ -5,4 +5,3 @@ paths:
 - "com/king/jenkins/plugins/results-cache"
 developers:
 - "franciscoord"
-- "kargath"

--- a/permissions/plugin-results-cache.yml
+++ b/permissions/plugin-results-cache.yml
@@ -2,7 +2,7 @@
 name: "results-cache"
 github: "jenkinsci/results-cache-plugin"
 paths:
-- "org/jenkins-ci/plugins/results-cache"
+- "com/king/jenkins/plugins/results-cache"
 developers:
-- francisco-orduna
-- kargath
+- "franciscoord"
+- "kargath"

--- a/permissions/plugin-results-cache.yml
+++ b/permissions/plugin-results-cache.yml
@@ -5,3 +5,4 @@ paths:
 - "com/king/jenkins/plugins/results-cache"
 developers:
 - "franciscoord"
+- "kargath"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
https://github.com/jenkinsci/results-cache-plugin
https://issues.jenkins-ci.org/browse/HOSTING-756
@kargath

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
