### PR TITLE
adding @escoem to developers

### DIFF
--- a/permissions/plugin-aws-credentials.yml
+++ b/permissions/plugin-aws-credentials.yml
@@ -7,3 +7,4 @@ developers:
 - "andresrc"
 - "ndeloof"
 - "roehrijn2"
+- "escoem"


### PR DESCRIPTION
# Description

Gives @escoem release permission to https://github.com/jenkinsci/aws-credentials-plugin. CC @ndeloof  for confirmation from an existing maintainer.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
