### PR TITLE
Add plugin experitest-cloud

### DIFF
--- a/permissions/plugin-experitest-cloud.yml
+++ b/permissions/plugin-experitest-cloud.yml
@@ -1,0 +1,9 @@
+---
+name: "experitest-cloud"
+github: "jenkinsci/experitest-cloud-plugin"
+paths:
+  - "org/jenkins-ci/plugins/experitest-cloud"
+developers:
+  - "phuonghqh"
+  - "omerExperitest"
+

--- a/permissions/plugin-experitest-cloud.yml
+++ b/permissions/plugin-experitest-cloud.yml
@@ -5,5 +5,4 @@ paths:
   - "org/jenkins-ci/plugins/experitest-cloud"
 developers:
   - "phuonghqh"
-  - "omerExperitest"
 


### PR DESCRIPTION
# Description

New permissions for experitest-cloud plugin hosted in this repository: https://github.com/jenkinsci/experitest-cloud-plugin

Hosting issue link: https://issues.jenkins-ci.org/browse/HOSTING-757

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

