### PR TITLE
Add @chriskilding to AWS Secrets Manager Credentials Provider plugin

### DIFF
--- a/permissions/plugin-aws-secrets-manager-credentials-provider.yml
+++ b/permissions/plugin-aws-secrets-manager-credentials-provider.yml
@@ -1,0 +1,7 @@
+---
+name: "aws-secrets-manager-credentials-provider"
+github: "jenkinsci/aws-secrets-manager-credentials-provider-plugin"
+paths:
+- "io/jenkins/plugins/aws-secrets-manager-credentials-provider"
+developers:
+- "chriskilding"


### PR DESCRIPTION
# Description

- Enable uploads for [aws-secrets-manager-credentials-provider-plugin](https://github.com/jenkinsci/aws-secrets-manager-credentials-provider-plugin).
- Give @chriskilding upload access.
- Ticket: [HOSTING-763](https://issues.jenkins-ci.org/browse/HOSTING-763)

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)