### PR TITLE
Ownership of the Perforce Helix TeamHub integration

### DIFF
--- a/permissions/plugin-helix-teamhub.yml
+++ b/permissions/plugin-helix-teamhub.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/helix-teamhub-plugin"
 paths:
 - "org/jenkins-ci/plugins/helix-teamhub"
 developers:
-- "sayradley"
 - "p4paul"

--- a/permissions/plugin-helix-teamhub.yml
+++ b/permissions/plugin-helix-teamhub.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/helix-teamhub"
 developers:
 - "sayradley"
+- "p4paul"


### PR DESCRIPTION
# Description

Add myself to the helix-teamhub integration. 
https://www.perforce.com/products/helix-teamhub
https://github.com/perforce/hth-jenkins-plugin

@sayradley

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
