### PR TITLE
Fix grants of nfalco for dtkit plugin

### DIFF
--- a/permissions/component-dtkit-frmk.yml
+++ b/permissions/component-dtkit-frmk.yml
@@ -1,8 +1,8 @@
 ---
-name: "dtkit-lib"
+name: "dtkit-frmk"
 github: "jenkinsci/libdtkit"
 paths:
-- "org/jenkins-ci/lib/dtkit"
+- "org/jenkins-ci/lib/dtkit/dtkit-frmk"
 developers:
 - "gbois"
 - "nfalco"

--- a/permissions/component-dtkit-metrics-api.yml
+++ b/permissions/component-dtkit-metrics-api.yml
@@ -1,0 +1,8 @@
+---
+name: "dtkit-metrics-hudson-api"
+github: "jenkinsci/libdtkit"
+paths:
+- "org/jenkins-ci/lib/dtkit/dtkit-metrics-hudson-api"
+developers:
+- "gbois"
+- "nfalco"

--- a/permissions/component-dtkit-metrics-model.yml
+++ b/permissions/component-dtkit-metrics-model.yml
@@ -1,0 +1,8 @@
+---
+name: "dtkit-metrics-model"
+github: "jenkinsci/libdtkit"
+paths:
+- "org/jenkins-ci/lib/dtkit/dtkit-metrics-model"
+developers:
+- "gbois"
+- "nfalco"

--- a/permissions/component-dtkit-metrics-util.yml
+++ b/permissions/component-dtkit-metrics-util.yml
@@ -1,0 +1,8 @@
+---
+name: "dtkit-metrics-util"
+github: "jenkinsci/libdtkit"
+paths:
+- "org/jenkins-ci/lib/dtkit/dtkit-metrics-util"
+developers:
+- "gbois"
+- "nfalco"

--- a/permissions/plugin-dtkit-api.yml
+++ b/permissions/plugin-dtkit-api.yml
@@ -1,6 +1,6 @@
 ---
 name: "dtkit-api"
-github: "jenkinsci/dtkit-libdtkit"
+github: "jenkinsci/dtkit-plugin"
 paths:
 - "org/jenkins-ci/plugins/dtkit-api"
 developers:

--- a/permissions/plugin-dtkit.yml
+++ b/permissions/plugin-dtkit.yml
@@ -1,8 +1,8 @@
 ---
-name: "dtkit"
+name: "dtkit-plugin"
 github: "jenkinsci/dtkit-plugin"
 paths:
-- "org/jenkins-ci/plugins/dtkit"
+- "org/jenkins-ci/plugins/dtkit/dtkit-plugin"
 developers:
 - "gbois"
 - "nfalco"


### PR DESCRIPTION
# Description

Discussion at https://groups.google.com/forum/#!topic/jenkinsci-dev/251sqn85_jM
@batmat This should fix the issue with the PR #1058 (or at least is what I hope)

Github repository of plugins/components

* https://github.com/jenkinsci/dtkit-plugin/
* https://github.com/jenkinsci/libdtkit/

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)