### PR TITLE
 Add myself as uploader for the lockable-resources-plugin 

### DIFF
--- a/permissions/plugin-lockable-resources.yml
+++ b/permissions/plugin-lockable-resources.yml
@@ -6,4 +6,5 @@ paths:
 developers:
 - "abayer"
 - "amuniz"
+- "tgr"
 - "robinjarry"


### PR DESCRIPTION
# Description

See https://github.com/jenkinsci/lockable-resources-plugin

@oleg-nenashev approved my request as maintainer in https://groups.google.com/forum/#!topic/jenkinsci-dev/RvFoN3mL9f0. @haithir and @amuniz also gave their okay.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
