### PR TITLE
Add resource-disposer

### DIFF
--- a/permissions/plugin-resource-disposer.yml
+++ b/permissions/plugin-resource-disposer.yml
@@ -1,0 +1,7 @@
+---
+name: "resource-disposer"
+github: "jenkinsci/resource-disposer-plugin"
+paths:
+- "org/jenkins-ci/plugins/resource-disposer"
+developers:
+- "olivergondza"


### PR DESCRIPTION
@olivergondza has been using his release officer super powers to release this plugin, which means there was no need for this metadata file. Creating it just to have it (and perhaps allow for incrementals and such).

https://github.com/jenkinsci/resource-disposer-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [n/a] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
