### PR TITLE
Xooa plugin yaml file

### DIFF
--- a/permissions/plugin-xooa.yml
+++ b/permissions/plugin-xooa.yml
@@ -4,8 +4,7 @@ github: "jenkinsci/xooa-plugin"
 paths:
 - "io/jenkins/plugins/xooa"
 developers:
-- "vinay"
-- "kavi"
+- "vinay_bagul"
 security:
   contacts:
     jira: vinay_bagul

--- a/permissions/plugin-xooa.yml
+++ b/permissions/plugin-xooa.yml
@@ -1,0 +1,12 @@
+---
+name: "xooa"
+github: "jenkinsci/xooa-plugin"
+paths:
+- "io/jenkins/plugins/xooa"
+developers:
+- "vinay"
+- "kavi"
+security:
+  contacts:
+    jira: vinay_bagul
+    email: vinay.bagul@xooa.com


### PR DESCRIPTION
# Description

New permissions for xooa-plugin hosted in this repository: https://github.com/jenkinsci/xooa-plugin

Hosting issue link: https://issues.jenkins-ci.org/browse/HOSTING-770
# Submitter checklist for changing permissions
### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
