### PR TITLE
Grant @oleg-nenashev permissions to release the Credentials Plugin

### DIFF
--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -8,3 +8,4 @@ developers:
 - "kohsuke"
 - "stephenconnolly"
 - "dnusbaum"
+- "oleg_nenashev"


### PR DESCRIPTION
I would like to release https://github.com/jenkinsci/credentials-plugin/pull/114 in order to unblock a JCasC 1.18 release with a fix for configuration exports in https://github.com/jenkinsci/configuration-as-code-plugin/issues/902 . Also the JCasC 1.18 release would remove need in the JCasC: Support plugin which we cannot safely use on our instances

I request permissions to do only a single release, I do not plan to take full ownership of plugin and to do new releases/merges without going through the current maintainers

CC @jglick @stephenc @dwnusbaum 
