### PR TITLE
Add other JCasC maintainers to be able to release

### DIFF
--- a/permissions/component-snakeyaml-shaded-configuration-as-code.yml
+++ b/permissions/component-snakeyaml-shaded-configuration-as-code.yml
@@ -6,6 +6,8 @@ paths:
 developers:
 - "praqma"
 - "casz"
+- "oleg_nenashev"
+- "timja"
 security:
   contacts:
     jira: "ewel"

--- a/permissions/plugin-configuration-as-code-integrations.yml
+++ b/permissions/plugin-configuration-as-code-integrations.yml
@@ -6,6 +6,8 @@ paths:
 developers:
 - "praqma"
 - "casz"
+- "oleg_nenashev"
+- "timja"
 security:
   contacts:
     jira: "ewel"

--- a/permissions/plugin-configuration-as-code-parent.yml
+++ b/permissions/plugin-configuration-as-code-parent.yml
@@ -6,6 +6,8 @@ paths:
 developers:
 - "praqma"
 - "casz"
+- "oleg_nenashev"
+- "timja"
 security:
   contacts:
     jira: "ewel"

--- a/permissions/plugin-configuration-as-code.yml
+++ b/permissions/plugin-configuration-as-code.yml
@@ -7,6 +7,8 @@ paths:
 developers:
 - "praqma"
 - "casz"
+- "oleg_nenashev"
+- "timja"
 security:
   contacts:
     jira: "ewel"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
https://github.com/jenkinsci/configuration-as-code-plugin
@ewelinawilkosz @casz

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [na] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [na] Make sure the file is created in `permissions/` directory
- [na] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [na] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [na] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
