### PR TITLE
add aliyun oss uploader plugin

### DIFF
--- a/permissions/plugin-aliyun-oss-uploader.yml
+++ b/permissions/plugin-aliyun-oss-uploader.yml
@@ -1,0 +1,7 @@
+---
+name: "aliyun-oss-uploader"
+github: "jenkinsci/aliyun-oss-uploader-plugin"
+paths:
+- "io.jenkins.plugins"
+developers:
+- "raylax"

--- a/permissions/plugin-aliyun-oss-uploader.yml
+++ b/permissions/plugin-aliyun-oss-uploader.yml
@@ -2,6 +2,6 @@
 name: "aliyun-oss-uploader"
 github: "jenkinsci/aliyun-oss-uploader-plugin"
 paths:
-- "io.jenkins.plugins"
+- "io/jenkins/plugins"
 developers:
 - "raylax"


### PR DESCRIPTION
# Description
[jenkinsci/aliyun-oss-uploader-plugin](https://github.com/jenkinsci/aliyun-oss-uploader-plugin)
 
 [HOSTING-782](https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-782)

# Submitter checklist for changing permissions
### Always
* [x]  Add link to plugin/component Git repository in description above

### For a newly hosted plugin only
* [x]  Add link to resolved HOSTING issue in description above

### For a new permissions file only
* [x]  Make sure the file is created in `permissions/` directory
* [x]  `artifactId` (pom.xml) is used for `name` (permissions YAML file).
* [x]  [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
* [x]  Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)
* [x]  [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
* [x]  Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
* [x]  [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

