### PR TITLE
Added jglick to kubernetes

### DIFF
--- a/permissions/plugin-kubernetes.yml
+++ b/permissions/plugin-kubernetes.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "csanchez"
 - "vlatombe"
+- "jglick"


### PR DESCRIPTION
# Description

I do not actually care about releasing this plugin (would leave that to @carlossg & @Vlatombe), but I would like write permission to the repository, if for no other reason than to be able to actually test `Jenkinsfile` changes as for example in https://github.com/jenkinsci/kubernetes-plugin/pull/461#discussion_r292676590.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
