### PR TITLE
Add plugin alauda-devops-credentials-provider

### DIFF
--- a/permissions/plugin-alauda-devops-credentials-provider.yml
+++ b/permissions/plugin-alauda-devops-credentials-provider.yml
@@ -1,0 +1,7 @@
+---
+name: "alauda-devops-credentials-provider"
+github: "jenkinsci/alauda-devops-credentials-provider-plugin"
+paths:
+- "io/alauda/jenkins/plugins/alauda-devops-credentials-provider"
+developers:
+- "surenpi"


### PR DESCRIPTION
# Description

[Host request was resolved](https://issues.jenkins-ci.org/browse/HOSTING-786)

[alauda-devops-credentials-provider-plugin](https://github.com/jenkinsci/alauda-devops-credentials-provider-plugin)

# Submitter checklist for changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)