### PR TITLE
adding Marky Jackson as maintainer for Amazon ECS plugin

### DIFF
--- a/permissions/plugin-amazon-ecs.yml
+++ b/permissions/plugin-amazon-ecs.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "webrat"
 - "pgarbe"
+- "jequals5"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

as agreed with @pgarbe @markyjackson-taulia will be added as a maintainer to the ECS plugin
Please also add him in github at https://github.com/jenkinsci/amazon-ecs-plugin

@markyjackson-taulia please confirm that i took the right ldap username

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
