### PR TITLE
Add plugin alauda-kubernetes-support

### DIFF
--- a/permissions/alauda-kubernetes-support.yml
+++ b/permissions/alauda-kubernetes-support.yml
@@ -1,0 +1,7 @@
+---
+name: "alauda-kubernetes-support"
+github: "jenkinsci/alauda-kubernetes-support-plugin"
+paths:
+- "io/alauda/jenkins/plugins/alauda-kubernetes-support"
+developers:
+- "surenpi"


### PR DESCRIPTION
# Description

[Host request was resolved](https://issues.jenkins-ci.org/browse/HOSTING-785)

[alauda-kubernetes-support-plugin](https://github.com/jenkinsci/alauda-kubernetes-support-plugin) was forked into jenkinsci.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)