### PR TITLE
Replace dnusbaum with jvz in credentials plugin

### DIFF
--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -7,5 +7,5 @@ developers:
 - "jglick"
 - "kohsuke"
 - "stephenconnolly"
-- "dnusbaum"
 - "oleg_nenashev"
+- "jvz"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Replace @dwnusbaum with @jvz in https://github.com/jenkinsci/credentials-plugin. Approved by myself.

I originally sought release permissions for this plugin as they were related to my work, but I have since transferred to a new team and do not anticipate working on this plugin. When I originally received release permissions, @stephenc  asked that any changes to the public API of the plugin be reviewed by him, so please respect that request.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
