### PR TITLE
[HOSTING-777] Update paths for release

### DIFF
--- a/permissions/component-plugin-installation-manager-tool-cli.yml
+++ b/permissions/component-plugin-installation-manager-tool-cli.yml
@@ -2,7 +2,7 @@
 name: "plugin-management-cli"
 github: "jenkinsci/plugin-installation-manager-tool"
 paths:
-- "io/jenkins/plugin-management-cli"
+- "io/jenkins/plugin-management/plugin-management-cli"
 developers:
 - "stopalopa"
 - "oleg_nenashev"

--- a/permissions/component-plugin-installation-manager-tool-lib.yml
+++ b/permissions/component-plugin-installation-manager-tool-lib.yml
@@ -2,7 +2,7 @@
 name: "plugin-management-library"
 github: "jenkinsci/plugin-installation-manager-tool"
 paths:
-- "io/jenkins/plugin-management-library"
+- "io/jenkins/plugin-management/plugin-management-library"
 developers:
 - "stopalopa"
 - "oleg_nenashev"

--- a/permissions/pom-plugin-installation-manager-tool-parent-pom.yml
+++ b/permissions/pom-plugin-installation-manager-tool-parent-pom.yml
@@ -2,7 +2,7 @@
 name: "jenkins-plugin-management-parent-pom"
 github: "jenkinsci/plugin-installation-manager-tool"
 paths:
-- "io/jenkins/plugin-management/jenkins-plugin-management-parent-pom
+- "io/jenkins/plugin-management/jenkins-plugin-management-parent-pom"
 developers:
 - "stopalopa"
 - "oleg_nenashev"

--- a/permissions/pom-plugin-installation-manager-tool-parent-pom.yml
+++ b/permissions/pom-plugin-installation-manager-tool-parent-pom.yml
@@ -1,8 +1,8 @@
 ---
-name: "parent-pom"
+name: "jenkins-plugin-management-parent-pom"
 github: "jenkinsci/plugin-installation-manager-tool"
 paths:
-- "io/jenkins/plugin-installation-manager-tool/parent-pom"
+- "io/jenkins/plugin-management/jenkins-plugin-management-parent-pom
 developers:
 - "stopalopa"
 - "oleg_nenashev"


### PR DESCRIPTION
# Description
Updated the permission files since artifactIds have since changed. Original hosting request:
https://issues.jenkins-ci.org/browse/HOSTING-777
Repository: https://github.com/jenkinsci/plugin-installation-manager-tool


# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x ] Add link to plugin/component Git repository in description above


### For a new permissions file only

- [x ] Make sure the file is created in `permissions/` directory
- [ x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)

