### PR TITLE
Add more developers for alauda-kubernetes-support-plugin

### DIFF
--- a/permissions/alauda-kubernetes-support.yml
+++ b/permissions/alauda-kubernetes-support.yml
@@ -5,3 +5,5 @@ paths:
 - "io/alauda/jenkins/plugins/alauda-kubernetes-support"
 developers:
 - "surenpi"
+- "danielfbm"
+- "chengjingtao"

--- a/permissions/alauda-kubernetes-support.yml
+++ b/permissions/alauda-kubernetes-support.yml
@@ -7,3 +7,4 @@ developers:
 - "surenpi"
 - "danielfbm"
 - "chengjingtao"
+- "cizezsy"


### PR DESCRIPTION
# Description
https://github.com/alauda/alauda-kubernetes-support-plugin

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
