### PR TITLE
Updated permissions for GCP cloud graphite team change

### DIFF
--- a/permissions/plugin-google-compute-engine.yml
+++ b/permissions/plugin-google-compute-engine.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "evanbrown"
 - "stephenshank"
+- "craigbarber"

--- a/permissions/plugin-google-compute-engine.yml
+++ b/permissions/plugin-google-compute-engine.yml
@@ -6,4 +6,3 @@ paths:
 developers:
 - "evanbrown"
 - "stephenshank"
-- "rachelyen"

--- a/permissions/plugin-google-storage-plugin.yml
+++ b/permissions/plugin-google-storage-plugin.yml
@@ -6,5 +6,4 @@ paths:
 developers:
 - "craigbarber"
 - "evanbrown"
-- "rachelyen"
 - "stephenshank"


### PR DESCRIPTION
# Description

Updating plugin permission to reflect recent team changes at GCP.

Plugin URLs: 
https://github.com/jenkinsci/google-compute-engine-plugin
https://github.com/jenkinsci/google-storage-plugin

# Submitter checklist for changing permissions


### Always

- [ X] Add link to plugin/component Git repository in description above