### PR TITLE
Add security contact for plugins where I am maintainer: jaxb, support-core and variant

### DIFF
--- a/permissions/plugin-jaxb.yml
+++ b/permissions/plugin-jaxb.yml
@@ -7,3 +7,6 @@ developers:
 - "kohsuke"
 - "oleg_nenashev"
 - "batmat"
+security:
+  contacts:
+    jira: "foundation_security_members"

--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -13,3 +13,6 @@ developers:
 - "escoem"
 - "dnusbaum"
 - "egutierrez"
+security:
+  contacts:
+    jira: "foundation_security_members"

--- a/permissions/plugin-variant.yml
+++ b/permissions/plugin-variant.yml
@@ -7,3 +7,6 @@ developers:
 - "kohsuke"
 - "andresrc"
 - "batmat"
+security:
+  contacts:
+    jira: "foundation_security_members"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

Adding security contact for plugins where I am already a maintainer.
So I am approving this by definition, but I would like someone to double check and merge.

Thanks!

Plugins:
* https://github.com/jenkinsci/jaxb-plugin
* https://github.com/jenkinsci/support-core-plugin
* https://github.com/jenkinsci/variant-plugin

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
