### PR TITLE
Add collaborator for gcloud-sdk plugin

### DIFF
--- a/permissions/plugin-gcloud-sdk.yml
+++ b/permissions/plugin-gcloud-sdk.yml
@@ -5,3 +5,4 @@ paths:
 - "com/byclosure/jenkins/plugins/gcloud-sdk"
 developers:
 - "jrluis"
+- "jhansche"


### PR DESCRIPTION
Email threads:
* https://groups.google.com/d/topic/jenkinsci-dev/5LUZT6_kU7E/discussion
* https://groups.google.com/d/topic/jenkinsci-dev/xxGlx_8KNdg/discussion

# Description

Github repo: https://github.com/jenkinsci/gcloud-sdk-plugin
Jira component: https://issues.jenkins-ci.org/projects/JENKINS?selectedItem=com.atlassian.jira.jira-projects-plugin:components-page&contains=gcloud-sdk
Original maintainer: @jrluis, CC'ed in the above threads and responded with no objections on June 19

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
   (they are the same, `jhansche`, in both)
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
