### PR TITLE
Plugin release permissions for enhanced-old-build-discarder

### DIFF
--- a/permissions/plugin-enhanced-old-build-discarder.yml
+++ b/permissions/plugin-enhanced-old-build-discarder.yml
@@ -3,4 +3,5 @@ name: "enhanced-old-build-discarder"
 github: "jenkinsci/enhanced-old-build-discarder-plugin"
 paths:
 - "org/jenkins-ci/plugins/enhanced-old-build-discarder"
-developers: [bbeggs]
+developers:
+- "bbeggs"

--- a/permissions/plugin-enhanced-old-build-discarder.yml
+++ b/permissions/plugin-enhanced-old-build-discarder.yml
@@ -1,6 +1,6 @@
 ---
 name: "enhanced-old-build-discarder"
-github: "jenkinsci/enhanced-old-build-discarder"
+github: "jenkinsci/enhanced-old-build-discarder-plugin"
 paths:
 - "org/jenkins-ci/plugins/enhanced-old-build-discarder"
-developers: []
+developers: [bbeggs]


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I have recently been developing an update to this plugin (https://github.com/jenkinsci/enhanced-old-build-discarder-plugin) and will be soon preparing a new public release of it. I have been listed as a Collaborator by the original developer on the repository and have master merge write access.

The original plugin developer @taksan is not listed with permissions for plugin release because of the age of the last release (5+ years ago).

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)