### PR TITLE
updated maintainer of deploy-plugin

### DIFF
--- a/permissions/plugin-deploy.yml
+++ b/permissions/plugin-deploy.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/deploy-plugin"
 paths:
 - "org/jenkins-ci/plugins/deploy"
 developers:
-- "kohsuke"
+- "jansohn"


### PR DESCRIPTION
# Description

I'm taking over as a maintainer for the plugin https://github.com/jenkinsci/deploy-plugin as the old maintainer (@frekele) has abandoned the plugin (see also mailing list topic https://groups.google.com/forum/#!topic/jenkinsci-dev/Z35x2qyFHDg). @oleg-nenashev can confirm this, too.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo. (I don't have write access yet)
