### PR TITLE
Fast Track plugin added

### DIFF
--- a/permissions/plugin-fast-track.yml
+++ b/permissions/plugin-fast-track.yml
@@ -1,0 +1,7 @@
+---
+name: "fast-track"
+github: "jenkinsci/fast-track-plugin"
+paths:
+- "nl/arnom/jenkins/fast-track"
+developers:
+- "arnom"


### PR DESCRIPTION


# Description
Adding Fast Track plugin (see https://github.com/jenkinsci/fast-track-plugin ), now that HOSTING-809 (see https://issues.jenkins-ci.org/browse/HOSTING-809 ) is resolved.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only
- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)