### PR TITLE
adding joseblas as developer

### DIFF
--- a/permissions/plugin-github-branch-source.yml
+++ b/permissions/plugin-github-branch-source.yml
@@ -14,6 +14,7 @@ developers:
 - "carroll"
 - "bitwiseman"
 - "kshultz"
+- "joseblas"
 security:
   contacts:
     jira: "pipeline_security_members"


### PR DESCRIPTION
# Description

adding joseblas as developer
 repo: http://github.com/jenkinsci/github-branch-source-plugin/
@car-roll @dwnusbaum @bitwiseman

# Submitter checklist for changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.