### PR TITLE
Update plugin-installation-tool parent pom name

### DIFF
--- a/permissions/pom-plugin-installation-manager-tool-parent-pom.yml
+++ b/permissions/pom-plugin-installation-manager-tool-parent-pom.yml
@@ -1,5 +1,5 @@
 ---
-name: "jenkins-plugin-management-parent-pom"
+name: "plugin-management-parent-pom"
 github: "jenkinsci/plugin-installation-manager-tool"
 paths:
 - "io/jenkins/plugin-management/plugin-management-parent-pom"


### PR DESCRIPTION
# Description

Fixes an issue where the artifact id was renamed but the name in the permissions yaml wasn't updated (https://github.com/jenkins-infra/repository-permissions-updater/pull/1243)

https://github.com/jenkinsci/plugin-installation-manager-tool


# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ na] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [na ] Make sure the file is created in `permissions/` directory
- [ x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ na] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [na ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ na] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ na] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ na] Check this if newly added person also needs to be given merge permission to the GitHub repo.
