### PR TITLE
Create plugin-atlassian-bitbucket-server-integration.yml 

### DIFF
--- a/permissions/plugin-atlassian-bitbucket-server-integration.yml
+++ b/permissions/plugin-atlassian-bitbucket-server-integration.yml
@@ -4,8 +4,4 @@ github: "jenkinsci/atlassian-bitbucket-server-integration-plugin"
 paths:
 - "io/jenkins/plugins/atlassian-bitbucket-server-integration"
 developers:
-- "dkjellin"
-- "mhenschke_atlassian"
-- "khughes"
-- "justinskariah_atl"
-- "gjoshi"
+- "atlassian_bbs"

--- a/permissions/plugin-atlassian-bitbucket-server-integration.yml
+++ b/permissions/plugin-atlassian-bitbucket-server-integration.yml
@@ -1,0 +1,11 @@
+---
+name: "atlassian-bitbucket-server-integration"
+github: "jenkinsci/atlassian-bitbucket-server-integration-plugin"
+paths:
+- "io/jenkins/plugins/atlassian-bitbucket-server-integration"
+developers:
+- "dkjellin"
+- "mhenschke_atlassian"
+- "khughes"
+- "justinskariah_atl"
+- "gjoshi"


### PR DESCRIPTION
# Description

Repository:
https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin
Hosting request:
https://issues.jenkins-ci.org/browse/HOSTING-812

Contributors:
@atlassian-bbs

Has been made a collaborator to the repository

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
