### PR TITLE
Update existing (ldap) users GithubID and add a new one

### DIFF
--- a/permissions/plugin-tricentis-ci.yml
+++ b/permissions/plugin-tricentis-ci.yml
@@ -6,4 +6,4 @@ paths:
 developers:
 - "tricentis"
 - "sergey_oplavin"
-- "AgileAOTeam"
+- "trimg"

--- a/permissions/plugin-tricentis-ci.yml
+++ b/permissions/plugin-tricentis-ci.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "tricentis"
 - "sergey_oplavin"
+- "AgileAOTeam"


### PR DESCRIPTION
# Description

I would need to add a new account to the [tricentis-ci-plugin](https://github.com/jenkinsci/tricentis-ci-plugin) repository.
Here the original hosting request which is already approved: [HOSTING-624](https://issues.jenkins-ci.org/browse/HOSTING-624)
On the Jenkins Accounts User Profile for UserID 'tricentis' I updated the GitHubID from "tricentis" to "agileaoteam" (which is the one I am currently using for this PR) since I got no direct access to the 'tricentis' account atm. 
Since I actually changed my github ID could you apply full (ideally admin-) permissions to the plugin repo for githubID 'agileaoteam' since this account is from now on the main maintainer for this plugin.

(hopefully it's enough for verification to see the newly linked githubID for maintainer 'tricentis' to be @agileaoteam )

The pullrequest additionally adds a new maintainer trimg to the plugin ( @ManuelGrolitschTricentis ). Please give that account committing and merging rights as well as for @agileaoteam so both accounts are able to commit, push and accept PRs. 

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
