### PR TITLE
Update hpaaat component with the new owners

### DIFF
--- a/permissions/plugin-hp-application-automation-tools-plugin.yml
+++ b/permissions/plugin-hp-application-automation-tools-plugin.yml
@@ -4,5 +4,5 @@ github: "jenkinsci/hpe-application-automation-tools-plugin"
 paths:
 - "org/jenkins-ci/plugins/hp-application-automation-tools-plugin"
 developers:
+- "NarcisaMGalan"        
 - "gront"
-- "yafim_kazak"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always
https://github.com/jenkinsci/hpe-application-automation-tools-plugin
- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)
  I can't @ her because she is not on the list. 
- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
Is it okay that they are the same?
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
Do you mean the plugin repo?
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
