### PR TITLE
Added pjdarton as developer to hudson-wsclean-plugin

### DIFF
--- a/permissions/plugin-hudson-wsclean-plugin.yml
+++ b/permissions/plugin-hudson-wsclean-plugin.yml
@@ -5,3 +5,4 @@ paths:
 - "de/jamba/hudson/plugin/wsclean/hudson-wsclean-plugin"
 developers:
 - "aheritier"
+- "pjdarton"


### PR DESCRIPTION
# Description

Add `pjdarton` as a developer on the `hudson-wsclean-plugin`.

Please also grant `pjdarton` push/merge access to https://github.com/jenkinsci/wsclean-plugin

FYI @aheritier [asked](https://issues.jenkins-ci.org/browse/JENKINS-43269?focusedCommentId=373311&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-373311) @pjdarton to be a maintainer of the `hudson-wsclean-plugin`


# Checklist
- [x] Add link to plugin/component Git repository in description above
  - Done.
- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
  - @aheritier has already [given approval](https://issues.jenkins-ci.org/browse/JENKINS-43269?focusedCommentId=373311&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-373311).
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
  - Username is `pjdarton` in both.
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
  - Done.
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
  - This is also needed; pjdarton does not have merge/push access to https://github.com/jenkinsci/wsclean-plugin