### PR TITLE
Add new ATH admins

### DIFF
--- a/permissions/component-acceptance-test-harness.yml
+++ b/permissions/component-acceptance-test-harness.yml
@@ -11,4 +11,5 @@ developers:
 - "rsandell"
 - "vlatombe"
 - "batmat"
-
+- "amuniz"
+- "vilacides"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Add two new admins for https://github.com/jenkinsci/acceptance-test-harness

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

---

As a component maintainer, I am asking for adding two more folks to have the permissions. I have looked up the names in JIRA presuming it ensure those are correct and used at least ones. Github permission already granted by myself.

@amuniz, @vilacides
