### PR TITLE
Add jthompson to credentials, plain-credentials, and ssh-credentials.

### DIFF
--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -9,3 +9,4 @@ developers:
 - "stephenconnolly"
 - "oleg_nenashev"
 - "jvz"
+- "jthompson"

--- a/permissions/plugin-plain-credentials.yml
+++ b/permissions/plugin-plain-credentials.yml
@@ -6,3 +6,5 @@ paths:
 developers:
 - "jglick"
 - "stephenconnolly"
+- "jthompson"
+  

--- a/permissions/plugin-plain-credentials.yml
+++ b/permissions/plugin-plain-credentials.yml
@@ -7,4 +7,3 @@ developers:
 - "jglick"
 - "stephenconnolly"
 - "jthompson"
-  

--- a/permissions/plugin-ssh-credentials.yml
+++ b/permissions/plugin-ssh-credentials.yml
@@ -8,3 +8,4 @@ developers:
 - "stephenconnolly"
 - "oleg_nenashev"
 - "jvz"
+- "jthompson"


### PR DESCRIPTION
Add jthompson (on jenkins.io, also known as jeffret-b on github) to maintainer on 
plain-credentials-plugin  : https://github.com/jenkinsci/plain-credentials-plugin
ssh-credentials-plugin : https://github.com/jenkinsci/ssh-credentials-plugin
credentials-plugin : https://github.com/jenkinsci/credentials-plugin

@jvz : For credentials and ssh-credentials
@jglick : For all three: plain-credentials, credentials, and ssh-credentials

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
