### PR TITLE
Add basil to jquery

### DIFF
--- a/permissions/plugin-jquery.yml
+++ b/permissions/plugin-jquery.yml
@@ -4,4 +4,5 @@ github: "jenkinsci/jquery-plugin"
 paths:
 - "org/jenkins-ci/plugins/jquery"
 developers:
+- "basil"
 - "kohsuke"


### PR DESCRIPTION
# Description

I would like to be able to release jenkinsci/jquery-plugin#6, which is needed for jenkinsci/bom#68.

The permissions list currently only contains @kohsuke, though @jglick was the last to cut a release.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
