### PR TITLE
Change maintainer for Robot Framework plugin

### DIFF
--- a/permissions/plugin-robot.yml
+++ b/permissions/plugin-robot.yml
@@ -6,4 +6,4 @@ paths:
 - "org/jvnet/hudson/plugins/robot"
 developers:
 - "jpiironen"
-- "jussi_malinen"
+- "aleksisimell"


### PR DESCRIPTION
Add myself as a maintainer to Robot Framework plugin and remove Jussi Malinen from the list of maintainers as he is no longer maintaining the plugin.

https://github.com/jenkinsci/robot-plugin

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.
