### PR TITLE
Taking over as maintainer

### DIFF
--- a/permissions/plugin-gitlab-plugin.yml
+++ b/permissions/plugin-gitlab-plugin.yml
@@ -6,3 +6,4 @@ paths:
 - "org/jenkins-ci/plugins/gitlab-plugin"
 developers:
 - "owenmehegan"
+- "jequals5"


### PR DESCRIPTION
Taking over as maintainer.
cc: @omehegan 

# Description

[Jenkins Jira:](https://issues.jenkins-ci.org/browse/JENKINS-59269)

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [] Check this if newly added person also needs to be given merge permission to the GitHub repo.