### PR TITLE
Add maintainer for docker-swarm

### DIFF
--- a/permissions/plugin-docker-swarm.yml
+++ b/permissions/plugin-docker-swarm.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/docker-swarm"
 developers:
 - "surya548"
+- "roemer"


### PR DESCRIPTION
# Description
Add myself as maintainer as discussed with @suryagaddipati for https://github.com/jenkinsci/docker-swarm-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
