### PR TITLE
Grant @oleg-nenashev permissions in the Extended Read Plugin

### DIFF
--- a/permissions/plugin-extended-read-permission.yml
+++ b/permissions/plugin-extended-read-permission.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jvnet/hudson/plugins/extended-read-permission"
 developers:
 - "batmat"
+- "oleg_nenashev"


### PR DESCRIPTION
I would like to release https://github.com/jenkinsci/extended-read-permission-plugin/pull/4 and https://github.com/jenkinsci/extended-read-permission-plugin/pull/3 so that we have a refreshed of the plugin for instances using newer core versions.

I am not sure whether it is fine to bother @batmat w.r.t releases, so raising this pull request just in case he wants to share ownership
