### PR TITLE
Build History Manager Plugin

### DIFF
--- a/permissions/plugin-build-history-manager.yml
+++ b/permissions/plugin-build-history-manager.yml
@@ -1,0 +1,7 @@
+---
+name: "build-history-manager"
+github: "jenkinsci/build-history-manager-plugin"
+paths:
+- "pl/damianszczepanik/build-history-manager"
+developers:
+- "dszczepanik"


### PR DESCRIPTION
Request: https://issues.jenkins-ci.org/browse/HOSTING-838

# Description

https://github.com/jenkinsci/build-history-manager-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
