### PR TITLE
Add aheritier as maintainer of cloudbees-jenkins-advisor

### DIFF
--- a/permissions/plugin-cloudbees-jenkins-advisor.yml
+++ b/permissions/plugin-cloudbees-jenkins-advisor.yml
@@ -7,4 +7,5 @@ developers:
 - "owood"
 - "kwhetstone"
 - "kohsuke"
+- "aheritier"
 


### PR DESCRIPTION

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I'm actively working on Advisor server in my daily job at CloudBees, I would like to be able to maintain the plugin too [jenkinsci/cloudbees-jenkins-advisor-plugin](https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/).

I'm asking to have the admin role on the repository + the permission to upload/release the plugin

I suppose that @Evildethow , @kwhetstone  and even @kohsuke will confirm

Thanks

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
