### PR TITLE
Add Permissions for Ranorex User

### DIFF
--- a/permissions/plugin-ranorex-integration.yml
+++ b/permissions/plugin-ranorex-integration.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/ranorex-integration"
 developers: 
 - "mstoegerer"
+- "ranorex"


### PR DESCRIPTION
# Description
The company decided to create a second user with upload permission for https://github.com/jenkinsci/ranorex-integration-plugin

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.
