### PR TITLE
Add Bobby and Fran to git and git client plugins

### DIFF
--- a/permissions/plugin-git-client.yml
+++ b/permissions/plugin-git-client.yml
@@ -6,3 +6,5 @@ paths:
 - "org/jenkinsci/plugins/git-client"
 developers:
 - "markewaite"
+- "rsandell"
+- "fcojfernandez"

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -9,3 +9,5 @@ developers:
 - "jglick"
 - "markewaite"
 - "stephenconnolly"
+- "rsandell"
+- "fcojfernandez"


### PR DESCRIPTION
# Description

Adding Bobby (@rsandell) and Fran (@fcojfernandez) to [git-plugin](https://github.com/jenkinsci/git-plugin) and [git-client-plugin](https://github.com/jenkinsci/git-client-plugin) as suggested by @MarkEWaite 
We will do our utmost to try and adhere to the same level of quality as Mark is showing.


# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [X] Check this if newly added person also needs to be given merge permission to the GitHub repo.
