### PR TITLE
Add myself as the developer of oic-auth plugin

### DIFF
--- a/permissions/plugin-oic-auth.yml
+++ b/permissions/plugin-oic-auth.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/oic-auth"
 developers:
 - "mbischoff"
+- "surenpi"


### PR DESCRIPTION
# Description

As the subject, I'm the another maintaner of [oic-auth](https://github.com/jenkinsci/oic-auth-plugin/).
The adopt email thread can found from [here](https://groups.google.com/d/msgid/jenkinsci-dev/d9f3af03-7ef7-49e4-a552-3e0284e9af00%40googlegroups.com?utm_medium=email&utm_source=footer).

@mjmbischoff agree with that putting me as another maintainer. And thanks @oleg-nenashev to help me do the transfer.

# Submitter checklist for changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.