### PR TITLE
New plugin request: mac

### DIFF
--- a/permissions/plugin-mac.yml
+++ b/permissions/plugin-mac.yml
@@ -1,0 +1,7 @@
+---
+name: "mac"
+github: "jenkinsci/mac-plugin"
+paths:
+- "fr/edf/jenkins/plugins/mac"
+developers:
+- "mat1e"


### PR DESCRIPTION
Description
Submitter checklist for changing permissions

Hi!

The link to our repo: https://github.com/jenkinsci/mac-plugin
HOSTING ticket: https://issues.jenkins-ci.org/browse/HOSTING-847

I'm also a committer in the mac-plugin repo.
Always

- [x] Add link to plugin/component Git repository in description above

For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

For a new permissions file only

- [x] Make sure the file is created in permissions/ directory
- [x] artifactId (pom.xml) is used for name (permissions YAML file). 
- [x] groupId / artifactId (pom.xml) are correctly represented in path (permissions YAML file)
- [x] Check that the file is named plugin-${artifactId}.yml for plugins

When adding new uploaders (this includes newly created permissions files)

- [x] Make sure to @mention an existing maintainer to confirm the permissions request, if applicable
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] All newly added users have logged in to Artifactory at least once    

Merge permission to GitHub repository

- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.