### PR TITLE
Add basil to timestamper

### DIFF
--- a/permissions/plugin-timestamper.yml
+++ b/permissions/plugin-timestamper.yml
@@ -5,5 +5,6 @@ paths:
 - "org/jenkins-ci/plugins/timestamper"
 - "org/jvnet/hudson/plugins/timestamper"
 developers:
+- "basil"
 - "stevengbrown"
 - "jglick"


### PR DESCRIPTION
# Description

See conversation with @jglick in [jenkinsci/timestamper-plugin#31 (comment)](https://github.com/jenkinsci/timestamper-plugin/pull/31#issuecomment-545036789).

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.