### PR TITLE
Add viglesias as google-source-plugin developer

### DIFF
--- a/permissions/plugin-google-source-plugin.yml
+++ b/permissions/plugin-google-source-plugin.yml
@@ -6,3 +6,4 @@ developers:
 - "astroilov"
 - "gunan"
 - "tcnghia"
+- "viglesias"


### PR DESCRIPTION
# Description

As per the following issue GitHub and thread user viglesiasce has been added as a maintainer to [google-source-plugin](https://github.com/jenkinsci/google-source-plugin):
https://groups.google.com/g/jenkinsci-dev/c/sGitrmkjgR8
https://github.com/jenkinsci/google-source-plugin/issues/10

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)