### PR TITLE
lighthouse-report not lighthouse-reporter

### DIFF
--- a/permissions/plugin-lighthouse-report.yml
+++ b/permissions/plugin-lighthouse-report.yml
@@ -1,0 +1,7 @@
+---
+name: "lighthouse-report"
+github: "jenkinsci/lighthouse-report-plugin"
+paths:
+- "io/jenkins/plugins/lighthouse-report"
+developers:
+- "halkeye"

--- a/permissions/plugin-lighthouse-reporter.yml
+++ b/permissions/plugin-lighthouse-reporter.yml
@@ -1,7 +1,0 @@
----
-name: "lighthouse-reporter"
-github: "jenkinsci/lighthouse-reporter-plugin"
-paths:
-- "io/jenkins/plugins/lighthouse-reporter"
-developers:
-- "halkeye"


### PR DESCRIPTION
I typo'd the original request

CC @halkeye (me) as the maintainer on file

HOSTING-845


<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->


<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->


<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->


- [ ] Add link to plugin/component Git repository in description above


- [ ] Add link to resolved HOSTING issue in description above


- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins


- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.