### PR TITLE
Update plugin-downstream-build-cache.yml

### DIFF
--- a/permissions/plugin-downstream-build-cache.yml
+++ b/permissions/plugin-downstream-build-cache.yml
@@ -5,3 +5,4 @@ paths:
 - "com/axis/system/jenkins/plugins/downstream/downstream-build-cache"
 developers:
 - "gustafl"
+- "jons"


### PR DESCRIPTION
Adding myself so that I have permission to upload releases of the plugin. I'm admin in the plugin repo (https://github.com/jenkinsci/downstream-build-cache-plugin), if that isn't enough @GLundh can sign of on that I should have release access as well.


# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.
