### PR TITLE
Update name for plugin manager tool library and cli

### DIFF
--- a/permissions/component-plugin-installation-manager-tool-cli.yml
+++ b/permissions/component-plugin-installation-manager-tool-cli.yml
@@ -1,5 +1,5 @@
 ---
-name: "jenkins-plugin-management-cli"
+name: "plugin-management-cli"
 github: "jenkinsci/plugin-installation-manager-tool"
 paths:
 - "io/jenkins/plugin-management/plugin-management-cli"

--- a/permissions/component-plugin-installation-manager-tool-lib.yml
+++ b/permissions/component-plugin-installation-manager-tool-lib.yml
@@ -1,5 +1,5 @@
 ---
-name: "jenkins-plugin-management-library"
+name: "plugin-management-library"
 github: "jenkinsci/plugin-installation-manager-tool"
 paths:
 - "io/jenkins/plugin-management/plugin-management-library"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Changed the names in permission files so that they accurately reflect the artifact Ids in the pom files.

https://github.com/jenkinsci/plugin-installation-manager-tool

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.
