### PR TITLE
Add basil to throttle-concurrents

### DIFF
--- a/permissions/plugin-throttle-concurrents.yml
+++ b/permissions/plugin-throttle-concurrents.yml
@@ -6,4 +6,5 @@ paths:
 - "org/jvnet/hudson/plugins/throttle-concurrents"
 developers:
 - "abayer"
+- "basil"
 - "oleg_nenashev"


### PR DESCRIPTION
# Description

I would like to become a maintainer of `throttle-concurrents`, at minimum to release jenkinsci/throttle-concurrent-builds-plugin#57 and jenkinsci/throttle-concurrent-builds-plugin#58.

CC'ing existing maintainers @abayer and @oleg-nenashev as well as @dwnusbaum (who has reviewed some changes in this repository recently).

I realize this plugin has a large number of users and has not been maintained in a while. Therefore there is some degree of risk associated with any change. I have the following plan to mitigate this risk:

- First, I will get the plugin's CI builds into shape by doing any relevant tooling updates: bumping the plugin parent POM to the latest version, ensuring that the `Jenkinsfile` uses `buildPlugin.recommendedConfigurations()`, etc.
- Next, I will set up Release Drafter and migrate the documentation from the wiki to GitHub.
- Next I will merge any new tests being added in the two PRs mentioned above. If the tests pass in the existing code, I will not mark them with `@Ignore`. If the tests fail in the existing code, I will mark them with `@Ignore`. This provides us with a baseline to ensure that the changes in the PRs don't cause any regressions.
- Then I will merge the fixes in the two PRs mentioned above. If they cause any `@Ignore`d tests to start passing, I will remove the `@Ignore` annotation. Each PR has been running on the corresponding author's Jenkins instance for several months without any issues, which helps to mitigate the risk. I will not take in any additional fixes for the initial release.
- Then I will cut the release. I will monitor Jira and ensure I am available to deal with any possible regressions that are introduced. I will not set up Dependabot or merge any new PRs until several weeks or months have passed by with no regressions. At that point, we can consider _slowly_ doing additional changes to the plugin, as necessary, until it reaches a stable state again.

I am happy to work with any existing maintainers throughout the above process.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.