### PR TITLE
Add bitwiseman to github-api-plugin maintainters

### DIFF
--- a/permissions/plugin-github-api.yml
+++ b/permissions/plugin-github-api.yml
@@ -5,9 +5,11 @@ paths:
 - "org/jenkins-ci/plugins/github-api"
 developers:
 - "andresrc"
+- "bitwiseman"
 - "integer"
 - "kohsuke"
 - "ohtake_tomohiro"
 - "recena"
 - "surya548"
 - "stephenconnolly"
+


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I'm a maintainer for [github-api](https://github.com/github-api/github-api) and multiple scm plugins such as [github-branch-source-plugin](https://github.com/jenkinsci/github-branch-source-plugin).

I need *maintainer* and publish rights this plugin/repository:
https://github.com/jenkinsci/github-api-plugin

@oleg-nenashev @kohsuke 

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo. Important: I need *maintainer* permissions.  

