### PR TITLE
add files to deploy https://github.com/jenkinsci/convert-to-declarative

### DIFF
--- a/permissions/component-convert-to-declarative-api.yml
+++ b/permissions/component-convert-to-declarative-api.yml
@@ -1,0 +1,18 @@
+---
+name: "convert-to-declarative-api"
+github: "jenkinsci/convert-to-declarative"
+paths:
+- "org/jenkins-ci/plugins/convert-to-declarative/convert-to-declarative-api"
+developers:
+  - "abayer"
+  - "dnusbaum"
+  - "jglick"
+  - "rsandell"
+  - "carroll"
+  - "bitwiseman"
+  - "kshultz"
+  - "olamy"
+security:
+  contacts:
+    jira: "pipeline_security_members"
+

--- a/permissions/plugin-convert-to-declarative.yml
+++ b/permissions/plugin-convert-to-declarative.yml
@@ -1,0 +1,17 @@
+---
+name: "convert-to-declarative"
+github: "jenkinsci/convert-to-declarative"
+paths:
+  - "org/jenkins-ci/plugins/convert-to-declarative/convert-to-declarative"
+developers:
+  - "abayer"
+  - "dnusbaum"
+  - "jglick"
+  - "rsandell"
+  - "carroll"
+  - "bitwiseman"
+  - "kshultz"
+  - "olamy"
+security:
+  contacts:
+    jira: "pipeline_security_members"

--- a/permissions/pom-convert-to-declarative-parent.yml
+++ b/permissions/pom-convert-to-declarative-parent.yml
@@ -1,0 +1,18 @@
+---
+name: "convert-to-declarative-parent"
+github: "jenkinsci/convert-to-declarative"
+paths:
+- "org/jenkins-ci/plugins/convert-to-declarative/convert-to-declarative-parent"
+developers:
+  - "abayer"
+  - "dnusbaum"
+  - "jglick"
+  - "rsandell"
+  - "carroll"
+  - "bitwiseman"
+  - "kshultz"
+  - "olamy"
+security:
+  contacts:
+    jira: "pipeline_security_members"
+


### PR DESCRIPTION
Signed-off-by: olivier lamy <olamy@apache.org>

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

permissions for deploying https://github.com/jenkinsci/convert-to-declarative

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.
