### PR TITLE
Remove mtgibbs from developers on FoD Uploader

### DIFF
--- a/permissions/plugin-fortify-on-demand-uploader.yml
+++ b/permissions/plugin-fortify-on-demand-uploader.yml
@@ -5,6 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/fortify-on-demand-uploader"
 developers:
 - "ryanblack"
-- "mtgibbs"
 - "tsotack"
 - "vodriemf"


### PR DESCRIPTION
# Description

Remove user `mtgibbs` from the developers group on [Fortify on Demand Uploader](https://github.com/jenkinsci/fortify-on-demand-uploader-plugin).

This is just an MR to remove myself from the project as I am no longer participating in the maintenance of the project so that there are no open permissions or security concerns with my ability to publish when not being involved with Fortify.