### PR TITLE
[HOSTING-860] Publish perms for SCM Filter Jervis YAML plugin

### DIFF
--- a/permissions/plugin-scm-filter-jervis.yml
+++ b/permissions/plugin-scm-filter-jervis.yml
@@ -1,0 +1,7 @@
+---
+name: "scm-filter-jervis"
+github: "jenkinsci/scm-filter-jervis-plugin"
+paths:
+- "io/jenkins/plugins/scm-filter-jervis"
+developers:
+- "sag47"


### PR DESCRIPTION
# Description

Allows me to push the first release for this plugin to the Jenkins plugin
registry.

See also:

- [HOSTING-860][HOSTING-860] New plugin SCM Filter Jervis YAML plugin
- https://github.com/jenkinsci/scm-filter-jervis-plugin

[HOSTING-860]: https://issues.jenkins-ci.org/browse/HOSTING-860

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] ~~[Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)~~ N/A
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] ~~Check this if newly added person also needs to be given merge permission to the GitHub repo.~~ N/A I'm already an admin because it's a new plugin.
