### PR TITLE
varyvol and alecharp to adopt oauth-credentials plugin

### DIFF
--- a/permissions/plugin-oauth-credentials.yml
+++ b/permissions/plugin-oauth-credentials.yml
@@ -1,7 +1,12 @@
 ---
 name: "oauth-credentials"
-github: "jenkinsci/oauth-credentials"
+github: "jenkinsci/oauth-credentials-plugin"
 paths:
 - "org/jenkins-ci/plugins/oauth-credentials"
 developers:
 - "mattmoor"
+- "alecharp"
+- "egutierrez"
+security:
+ contacts:
+   jira: "foundation_security_members"


### PR DESCRIPTION
@varyvol and I wish to adopt the plugin

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

The OAuth Credentials plugin was not released in over 5years, even if some commits were made after the last release. @varyvol and I want to help @mattmoor to maintain this plugin.

The plugin is located here: [jenkinsci/oauth-credentials-plugin](https://github.com/jenkinsci/oauth-credentials-plugin)

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
