### PR TITLE
Grant alecharp maintainer permission on Google Metadata plugin

### DIFF
--- a/permissions/plugin-google-metadata-plugin.yml
+++ b/permissions/plugin-google-metadata-plugin.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/google-metadata-plugin"
 developers:
 - "tcnghia"
+- "alecharp"

--- a/permissions/plugin-google-metadata-plugin.yml
+++ b/permissions/plugin-google-metadata-plugin.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/google-metadata-plugin"
 paths:
 - "org/jenkins-ci/plugins/google-metadata-plugin"
 developers:
-- "tcnghia"
 - "alecharp"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
I ask on the [mailing list](https://groups.google.com/d/msg/jenkinsci-dev/h6DVUIGxA_s/fVqPbAAbBQAJ) to become a maintainer on the [Google Metadata plugin](https://github.com/jenkinsci/google-metadata-plugin).

I also pinged @tcnghia to make sure this request didn't go un-noticed by the current maintainer of the plugin.

I also would need to get merge permission on the repository.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
