### PR TITLE
[INFRA-2347] Shorten plugin name

### DIFF
--- a/permissions/plugin-declarative-pipeline-migration-assistant.yml
+++ b/permissions/plugin-declarative-pipeline-migration-assistant.yml
@@ -2,7 +2,7 @@
 name: "declarative-pipeline-migration-assistant-plugin"
 github: "jenkinsci/declarative-pipeline-migration-assistant-plugin"
 paths:
-  - "org/jenkins-ci/plugins/to-declarative/declarative-pipeline-migration-assistant-plugin"
+  - "org/jenkins-ci/plugins/to-declarative/declarative-pipeline-migration-assistant"
 developers:
   - "abayer"
   - "dnusbaum"


### PR DESCRIPTION
This plugin caused [INFRA-2347](https://issues.jenkins-ci.org/browse/INFRA-2347) due to a path length limitation. I worked around that in https://github.com/jenkins-infra/update-center2/pull/314 by blacklisting the old plugin ID.

As the plugin name violates the [naming convention](https://jenkins.io/doc/developer/publishing/style-guides/#artifact-id) anyway, work around that limitation by shortening it.

FYI @olamy 