### PR TITLE
[INFRA-2353] Host JenkinsPipelineUnit library

### DIFF
--- a/permissions/component-jenkins-pipeline-unit.yml
+++ b/permissions/component-jenkins-pipeline-unit.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/JenkinsPipelineUnit"
 paths:
   - "com/lesfurets/jenkins-pipeline-unit"
 developers:
-  - "oleg-nenashev"
+  - "oleg_nenashev"
   - "stchar"
-  - "ozangunalp"
 

--- a/permissions/component-jenkins-pipeline-unit.yml
+++ b/permissions/component-jenkins-pipeline-unit.yml
@@ -1,0 +1,10 @@
+---
+name: "jenkins-pipeline-unit"
+github: "jenkinsci/JenkinsPipelineUnit"
+paths:
+  - "com/lesfurets/jenkins-pipeline-unit"
+developers:
+  - "oleg-nenashev"
+  - "stchar"
+  - "ozangunalp"
+

--- a/permissions/component-jenkins-pipeline-unit.yml
+++ b/permissions/component-jenkins-pipeline-unit.yml
@@ -6,4 +6,5 @@ paths:
 developers:
   - "oleg_nenashev"
   - "stchar"
+  - "ozangunalp"
 


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
@oleg-nenashev  @ozangunalp

Hi, I'm a kindly new maintainer of https://github.com/jenkinsci/JenkinsPipelineUnit
It's a library to create unit-tests for jenkins-pipelines. I'd like to host it at repo.jenkins-ci.org.

I've created a https://issues.jenkins-ci.org/browse/HOSTING-729 a while ago where I was told to create a pull request here. So I'm also linking it to https://issues.jenkins-ci.org/browse/INFRA-2353

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins 


### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo.
