### PR TITLE
Add permissions for plugin-util-api.yml.

### DIFF
--- a/permissions/plugin-plugin-util-api.yml
+++ b/permissions/plugin-plugin-util-api.yml
@@ -1,0 +1,7 @@
+---
+name: "plugin-util-api"
+github: "jenkinsci/plugin-util-api-plugin"
+paths:
+- "io/jenkins/plugins/plugin-util-api"
+developers:
+- "drulli"

--- a/permissions/plugin-util-api.yml
+++ b/permissions/plugin-util-api.yml
@@ -1,0 +1,7 @@
+---
+name: "plugin-util-api"
+github: "jenkinsci/plugin-util-api-plugin"
+paths:
+- "io/jenkins/plugins/plugin-util-api"
+developers:
+- "drulli"

--- a/permissions/plugin-util-api.yml
+++ b/permissions/plugin-util-api.yml
@@ -1,7 +1,0 @@
----
-name: "plugin-util-api"
-github: "jenkinsci/plugin-util-api-plugin"
-paths:
-- "io/jenkins/plugins/plugin-util-api"
-developers:
-- "drulli"


### PR DESCRIPTION
# Description

This Jenkins plug-in provides utility classes that can be used to accelerate plugin development,  it is hosted as [jenkinsci/plugin-util-api-plugin](https://github.com/jenkinsci/plugin-util-api-plugin), see [HOSTING-868](https://issues.jenkins-ci.org/browse/HOSTING-868) for details.

# Submitter checklist for changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo.
