### PR TITLE
Add upload permissions for configuration-as-code-test-harness

### DIFF
--- a/permissions/component-configuration-as-code-test-harness.yml
+++ b/permissions/component-configuration-as-code-test-harness.yml
@@ -1,8 +1,8 @@
 ---
-name: "snakeyaml"
+name: "test-harness"
 github: "jenkinsci/configuration-as-code-plugin"
 paths:
-- "io/jenkins/configuration-as-code/snakeyaml"
+- "io/jenkins/configuration-as-code/test-harness"
 developers:
 - "praqma"
 - "casz"
@@ -10,4 +10,4 @@ developers:
 - "timja"
 security:
   contacts:
-    jira: "casz"
+    jira: "casZ"

--- a/permissions/component-configuration-as-code-test-harness.yml
+++ b/permissions/component-configuration-as-code-test-harness.yml
@@ -10,4 +10,4 @@ developers:
 - "timja"
 security:
   contacts:
-    jira: "casZ"
+    jira: "casz"


### PR DESCRIPTION
# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
Add permissions for new test-harness for configuration-as-code-plugin: https://github.com/jenkinsci/configuration-as-code-plugin/pull/1215

And update @casz to be security contact for snakeyaml component (he's the contact for all other configuration-as-code component's, this one was missed in the update.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)



