### PR TITLE
[HOSTING-878] plugin-build-health-cache-updater

### DIFF
--- a/permissions/plugin-build-health-cache-updater.yml
+++ b/permissions/plugin-build-health-cache-updater.yml
@@ -1,0 +1,9 @@
+---
+name: "build-health-cache-updater"
+github: "jenkinsci/build-health-cache-updater-plugin"
+paths:
+- "io/jenkins/plugins/build-health-cache-updater"
+developers:
+- "rsandell"
+- "varyvol"
+- "alecharp"

--- a/permissions/plugin-build-health-cache-updater.yml
+++ b/permissions/plugin-build-health-cache-updater.yml
@@ -5,5 +5,5 @@ paths:
 - "io/jenkins/plugins/build-health-cache-updater"
 developers:
 - "rsandell"
-- "varyvol"
+- "egutierrez"
 - "alecharp"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/build-health-cache-updater-plugin

See https://issues.jenkins-ci.org/projects/HOSTING/issues/HOSTING-878

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo. If needed, it can be done using an [IRC bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management). Make sure to check that the `$pluginId Developers` team has `Write` permissions or above while granting the access.
