### PR TITLE
Remove redundant security contact email addresses

### DIFF
--- a/permissions/plugin-acunetix-360-scan.yml
+++ b/permissions/plugin-acunetix-360-scan.yml
@@ -5,6 +5,3 @@ paths:
 - "org/jenkins-ci/plugins/acunetix-360-scan"
 developers:
 - "acunetix360"
-security:
-  contacts:
-    email: 360@acunetix.com

--- a/permissions/plugin-myappci.yml
+++ b/permissions/plugin-myappci.yml
@@ -8,4 +8,3 @@ developers:
 security:
   contacts:
     jira: carstenmuellerlemberg
-    email: carsten.mueller.lemberg@gmail.com

--- a/permissions/plugin-xooa.yml
+++ b/permissions/plugin-xooa.yml
@@ -8,4 +8,3 @@ developers:
 security:
   contacts:
     jira: vinay_bagul
-    email: vinay.bagul@xooa.com


### PR DESCRIPTION
We do not, in general, accept email security contacts. As going through email rather than Jira involves quite a bit of overhead, I want to limit this to large organizations. So far, AWS Security are the only ones we do this for. This is also documented in this repo's readme.

In all of these cases, the email address backing the maintainer Jira account is the same as the account specified as security contact, so it is even redundant and can be removed without adverse effects as long as email notifications from Jira aren't deleted unread.

FYI @acunetix360support @vinayxooa @carstenmuellerlemberg 