### PR TITLE
Create plugin-redeploy-rancher2-workload.yml

### DIFF
--- a/permissions/plugin-redeploy-rancher2-workload.yml
+++ b/permissions/plugin-redeploy-rancher2-workload.yml
@@ -2,6 +2,6 @@
 name: "redeploy-rancher2-workload"
 github: "jenkinsci/redeploy-rancher2-workload-plugin"
 paths:
-- "org/jenkins-ci/plugins/redeploy-rancher2-workload-plugin"
+- "org/jenkins-ci/plugins/redeploy-rancher2-workload"
 developers:
 - "feg545"

--- a/permissions/plugin-redeploy-rancher2-workload.yml
+++ b/permissions/plugin-redeploy-rancher2-workload.yml
@@ -2,6 +2,6 @@
 name: "redeploy-rancher2-workload"
 github: "jenkinsci/redeploy-rancher2-workload-plugin"
 paths:
-- "org/jenkins-ci/plugins/redeploy-rancher2-workload"
+- "io/jenkins/plugins/redeploy-rancher2-workload"
 developers:
 - "feg545"

--- a/permissions/plugin-redeploy-rancher2-workload.yml
+++ b/permissions/plugin-redeploy-rancher2-workload.yml
@@ -1,0 +1,7 @@
+---
+name: "redeploy-rancher2-workload"
+github: "jenkinsci/redeploy-rancher2-workload-plugin"
+paths:
+- "org/jenkins-ci/plugins/redeploy-rancher2-workload-plugin"
+developers:
+- "feg545"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
Github repository: https://github.com/jenkinsci/redeploy-rancher2-workload-plugin
Hosting request ticket: https://issues.jenkins-ci.org/browse/HOSTING-876
Committers: [@feg545](https://github.com/feg545) 

https://github.com/jenkinsci/redeploy-rancher2-workload-plugin
# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo. If needed, it can be done using an [IRC bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management). Make sure to check that the `$pluginId Developers` team has `Write` permissions or above while granting the access.
