### PR TITLE
Added permissions file for osf-builder-suite-for-sfcc-run-job-plugin

### DIFF
--- a/permissions/plugin-osf-builder-suite-for-sfcc-run-job.yml
+++ b/permissions/plugin-osf-builder-suite-for-sfcc-run-job.yml
@@ -2,6 +2,6 @@
 name: "osf-builder-suite-for-sfcc-run-job"
 github: "jenkinsci/osf-builder-suite-for-sfcc-run-job-plugin"
 paths:
-  - "org/jenkins-ci/plugins/osf-builder-suite-for-sfcc-run-job"
+  - "io/jenkins/plugins/osf-builder-suite-for-sfcc-run-job"
 developers:
   - "danechitoaie"

--- a/permissions/plugin-osf-builder-suite-for-sfcc-run-job.yml
+++ b/permissions/plugin-osf-builder-suite-for-sfcc-run-job.yml
@@ -1,0 +1,7 @@
+---
+name: "osf-builder-suite-for-sfcc-run-job"
+github: "jenkinsci/osf-builder-suite-for-sfcc-run-job-plugin"
+paths:
+  - "org/jenkins-ci/plugins/osf-builder-suite-for-sfcc-run-job"
+developers:
+  - "danechitoaie"


### PR DESCRIPTION
# Description
This plugin adds a build step that will allow you to trigger a job from a Salesforce Commerce Cloud instance and monitor it's execution until complete. This will allow to trigger custom reindex, clear cache, etc jobs after code or data is deployed.

https://github.com/jenkinsci/osf-builder-suite-for-sfcc-run-job-plugin
https://issues.jenkins-ci.org/browse/HOSTING-880

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins