### PR TITLE
update dingding-notifications plugin's permission

### DIFF
--- a/permissions/plugin-dingding-notifications.yml
+++ b/permissions/plugin-dingding-notifications.yml
@@ -2,6 +2,6 @@
 name: "dingding-notifications"
 github: "jenkinsci/dingding-notifications-plugin"
 paths:
-  - "org/jenkins-ci/plugins/dingding-notifications"
+  - "io/jenkins/plugins/dingding-notifications"
 developers:
   - "liuweigl"

--- a/permissions/plugin-dingding-notifications.yml
+++ b/permissions/plugin-dingding-notifications.yml
@@ -2,6 +2,6 @@
 name: "dingding-notifications"
 github: "jenkinsci/dingding-notifications-plugin"
 paths:
-- "com/ztbsuper/dingding-notifications"
+  - "org/jenkins-ci/plugins/dingding-notifications"
 developers:
-- "ztbsuper"
+  - "liuweigl"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
Adopt plugin @ztbsuper

Related link: https://groups.google.com/forum/?nomobile=true#!topic/jenkinsci-dev/hqN3-o5ZFF8


# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above


### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

#### Merge permission to GitHub repository
- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo. If needed, it can be done using an [IRC bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management). Make sure to check that the `$pluginId Developers` team has `Write` permissions or above while granting the access.
