### PR TITLE
Adoptions of appspider-build-scanner-plugin

### DIFF
--- a/permissions/plugin-jenkinsci-appspider-plugin.yml
+++ b/permissions/plugin-jenkinsci-appspider-plugin.yml
@@ -4,5 +4,5 @@ github: "jenkinsci/appspider-build-scanner-plugin"
 paths:
 - "com/rapid7/jenkinsci-appspider-plugin"
 developers:
-- "tmoreland-r7"
-- "rgrimley-r7"
+- "tmoreland"
+- "rgrimley"

--- a/permissions/plugin-jenkinsci-appspider-plugin.yml
+++ b/permissions/plugin-jenkinsci-appspider-plugin.yml
@@ -4,5 +4,5 @@ github: "jenkinsci/appspider-build-scanner-plugin"
 paths:
 - "com/rapid7/jenkinsci-appspider-plugin"
 developers:
-- "tmoreland"
 - "rgrimley"
+- "tmoreland"

--- a/permissions/plugin-jenkinsci-appspider-plugin.yml
+++ b/permissions/plugin-jenkinsci-appspider-plugin.yml
@@ -4,6 +4,5 @@ github: "jenkinsci/appspider-build-scanner-plugin"
 paths:
 - "com/rapid7/jenkinsci-appspider-plugin"
 developers:
-- "tsmoreland"
 - "tmoreland-r7"
 - "rgrimley-r7"

--- a/permissions/plugin-jenkinsci-appspider-plugin.yml
+++ b/permissions/plugin-jenkinsci-appspider-plugin.yml
@@ -4,4 +4,6 @@ github: "jenkinsci/appspider-build-scanner-plugin"
 paths:
 - "com/rapid7/jenkinsci-appspider-plugin"
 developers:
-- "nbugash"
+- "tsmoreland"
+- "tmoreland-r7"
+- "rgrimley-r7"


### PR DESCRIPTION
# Description

Adoption of https://github.com/jenkinsci/appspider-build-scanner-plugin previously developed by @nbugash but since abandoned as he no longer works for Rapid7.  Adoption request submitted via my personal account terry.s.moreland@gmail.com as my corporate account does not have permissions to join google groups and as such couldn't submit the request. 

This change is to take ownership of the repository for myself (@tmoreland-r7) as well as @rgrimley-r7 so that there isn't just one developer associated with the plugin with the aim of preventing a repeat of what left us in this state.  I've left out my personal account @tsmoreland as ownership of the repository should be with my work account (or other such work accounts) despite my personal account being used to submit the adoption request.
