### PR TITLE
Add identified maintainers for stapler.

### DIFF
--- a/permissions/component-stapler-groovy.yml
+++ b/permissions/component-stapler-groovy.yml
@@ -4,4 +4,8 @@ name: "stapler-groovy"
 github: "stapler/stapler"
 paths:
 - "org/kohsuke/stapler/stapler-groovy"
-developers: []
+developers: 
+- "jglick"
+- "danielbeck"
+- "jthompson"
+

--- a/permissions/component-stapler-jelly.yml
+++ b/permissions/component-stapler-jelly.yml
@@ -4,4 +4,8 @@ name: "stapler-jelly"
 github: "stapler/stapler"
 paths:
 - "org/kohsuke/stapler/stapler-jelly"
-developers: []
+developers: 
+- "jglick"
+- "danielbeck"
+- "jthompson"
+

--- a/permissions/component-stapler-jrebel.yml
+++ b/permissions/component-stapler-jrebel.yml
@@ -4,4 +4,8 @@ name: "stapler-jrebel"
 github: "stapler/stapler"
 paths:
 - "org/kohsuke/stapler/stapler-jrebel"
-developers: []
+developers: 
+- "jglick"
+- "danielbeck"
+- "jthompson"
+

--- a/permissions/component-stapler-jruby.yml
+++ b/permissions/component-stapler-jruby.yml
@@ -4,4 +4,7 @@ name: "stapler-jruby"
 github: "stapler/stapler"
 paths:
 - "org/kohsuke/stapler/stapler-jruby"
-developers: []
+developers: 
+- "jglick"
+- "danielbeck"
+- "jthompson"

--- a/permissions/component-stapler-jsp.yml
+++ b/permissions/component-stapler-jsp.yml
@@ -4,4 +4,7 @@ name: "stapler-jsp"
 github: "stapler/stapler"
 paths:
 - "org/kohsuke/stapler/stapler-jsp"
-developers: []
+developers: 
+- "jglick"
+- "danielbeck"
+- "jthompson"

--- a/permissions/component-stapler.yml
+++ b/permissions/component-stapler.yml
@@ -4,4 +4,8 @@ name: "stapler"
 github: "stapler/stapler"
 paths:
 - "org/kohsuke/stapler/stapler"
-developers: []
+developers: 
+- "jglick"
+- "danielbeck"
+- "jthompson"
+

--- a/permissions/pom-stapler-parent.yml
+++ b/permissions/pom-stapler-parent.yml
@@ -4,4 +4,7 @@ name: "stapler-parent"
 github: "stapler/stapler"
 paths:
 - "org/kohsuke/stapler/stapler-parent"
-developers: []
+developers:
+- "jglick"
+- "danielbeck"
+- "jthompson"


### PR DESCRIPTION
# Description

It looks like stapler has been added into the repository permissions updater but doesn't have anyone registered as maintainer. We need people identified to merge and release it. I'm not sure if something additional needs to be done for us to have permissions to merge and deploy.

https://github.com/stapler/stapler/

@jglick, do you want to be added here? As a "recent maintainer" do you approve this PR?

@daniel-beck, confirm you want to be added.

My GH user is "jeffret-b" but on jenkins.io it is "jthompson".

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [n/a] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [n/a] Make sure the file is created in `permissions/` directory
- [n/a] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [n/a] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [n/a] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
