### PR TITLE
Adopt thin backup plugin

### DIFF
--- a/permissions/plugin-thinBackup.yml
+++ b/permissions/plugin-thinBackup.yml
@@ -2,7 +2,6 @@
 name: "thinBackup"
 github: "jenkinsci/thin-backup-plugin"
 paths:
-- "org/jenkins-ci/plugins/thin-backup-plugin"
 - "org/jvnet/hudson/plugins/thinBackup"
 developers: 
 - "tofuatjava"

--- a/permissions/plugin-thinBackup.yml
+++ b/permissions/plugin-thinBackup.yml
@@ -2,6 +2,8 @@
 name: "thinBackup"
 github: "jenkinsci/thin-backup-plugin"
 paths:
+- "org/jenkins-ci/plugins/thin-backup-plugin"
 - "org/jvnet/hudson/plugins/thinBackup"
 developers: 
 - "tofuatjava"
+- "jeffpearce"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
The [thin backup plugin](https://github.com/jenkinsci/thin-backup-plugin) is listed as up for adoption. I'd like to adopt it. I started the process awhile ago [see thread](https://groups.google.com/forum/#!searchin/jenkinsci-dev/thin$20backup%7Csort:date/jenkinsci-dev/hMi8XPTfwwQ/KD11pMTSCAAJl) and would like to start looking at the PRs piling up

cc'ing @tofuatjava

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
