### PR TITLE
Add a maintainer to CodeDeploy plugin

### DIFF
--- a/permissions/plugin-codedeploy.yml
+++ b/permissions/plugin-codedeploy.yml
@@ -10,6 +10,7 @@ developers:
 - "yubangxi"
 - "feverlu"
 - "q13117god"
+- "alena"
 security:
   contacts:
     email: "aws-security@amazon.com"


### PR DESCRIPTION
# Description
Add a maintainer to https://github.com/jenkinsci/aws-codedeploy-plugin. @yubangxi please add a comment you approve the change.
LDAP account name `alena` is corresponding to github account @Helen1987

# Submitter checklist for changing permissions
### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
