### PR TITLE
Add github link & update developers for plugin-environment-dashboard

### DIFF
--- a/permissions/plugin-environment-dashboard.yml
+++ b/permissions/plugin-environment-dashboard.yml
@@ -1,8 +1,8 @@
 ---
 name: "environment-dashboard"
-github: "jenkinsci/js-libs"
+github: "jenkinsci/environment-dashboard-plugin"
 paths:
-- "org/jenkins-ci/plugins/environment-dashboard"
+- "io/jenkins/plugins/environment-dashboard"
 developers:
 - "vipinsthename"
 - "willwh"

--- a/permissions/plugin-environment-dashboard.yml
+++ b/permissions/plugin-environment-dashboard.yml
@@ -1,6 +1,8 @@
 ---
 name: "environment-dashboard"
+github: "jenkinsci/js-libs"
 paths:
 - "org/jenkins-ci/plugins/environment-dashboard"
 developers:
 - "vipinsthename"
+- "willwh"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/environment-dashboard-plugin has migrated to `jenkinsci`
See: https://issues.jenkins-ci.org/browse/HOSTING-808

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it