### PR TITLE
Added aliaandersen to plugin-contrast-continuous-application-security.yml

### DIFF
--- a/permissions/plugin-contrast-continuous-application-security.yml
+++ b/permissions/plugin-contrast-continuous-application-security.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "gsmoore"
 - "bryanateoan"
+- "aliaandersen"


### PR DESCRIPTION
Added aliaandersen to plugin-contrast-continuous-application-security.yml

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Grant @aliaandersen permission to deploy contrast-continuous-application-security

cc @gmoore 

https://github.com/jenkinsci/contrast-continuous-application-security-plugin

# Submitter checklist for changing permissions
### Always
 - [x] Add link to plugin/component Git repository in description above
- [x] Make sure to @mention an existing maintainer to confirm the permissions request, if applicable
- [x]  Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to @mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] All newly added users have logged in to Artifactory at least once