### PR TITLE
Create plugin-wallarm-fast.yml

### DIFF
--- a/permissions/plugin-wallarm-fast.yml
+++ b/permissions/plugin-wallarm-fast.yml
@@ -2,6 +2,6 @@
 name: "wallarm-fast"
 github: "jenkinsci/wallarm-fast-plugin"
 paths:
-- "org/jenkins-ci/plugins/wallarm-fast"
+- "io/jenkins/plugins/wallarm-fast"
 developers:
 - "mkirichenko"

--- a/permissions/plugin-wallarm-fast.yml
+++ b/permissions/plugin-wallarm-fast.yml
@@ -1,0 +1,7 @@
+---
+name: "wallarm-fast"
+github: "jenkinsci/wallarm-fast-plugin"
+paths:
+- "org/jenkins-ci/plugins/wallarm-fast"
+developers:
+- "mkirichenko"


### PR DESCRIPTION
# Description
Hosting request: https://issues.jenkins-ci.org/browse/HOSTING-863
Plugin repository: https://github.com/jenkinsci/wallarm-fast-plugin

# Submitter checklist for changing permissions

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
