### PR TITLE
Permissions for new maintainer for offlineonfailure plugin

### DIFF
--- a/permissions/plugin-offlineonfailure-plugin.yml
+++ b/permissions/plugin-offlineonfailure-plugin.yml
@@ -3,4 +3,5 @@ name: "offlineonfailure-plugin"
 github: "jenkinsci/offlineonfailure-plugin"
 paths:
 - "org/jenkins-ci/plugins/offlineonfailure-plugin"
-developers: []
+developers:
+- "johnlengeling"


### PR DESCRIPTION
# Description
Add permissions for new maintainer for the offlineonfailure plugin.  The new maintainer:

GitHub: @johnl2323
JIRA/Artifactory: johnlengeling

https://github.com/jenkinsci/offlineonfailure-plugin

Discussion on request for maintaining offlineonfailure plugin:

https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-dev/TW3PjGMHu5A/wo0c3ttuGQAJ

# Submitter checklist for changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
