### PR TITLE
new plugin kubesphere-extension

### DIFF
--- a/permissions/plugin-kubesphere-extension.yml
+++ b/permissions/plugin-kubesphere-extension.yml
@@ -1,0 +1,8 @@
+---
+name: "kubesphere-extension"
+github: "jenkinsci/kubesphere-extension-plugin"
+paths:
+  - "io/jenkins/kubesphere/plugins/kubesphere-extension"
+developers:
+  - "runzexia"
+  - "zhuxiaoyang"


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
As a developer of new plugin, I also want to add @soulseen access to the github repository.
github user name: @soulseen
jenkins LDAP: zhuxiaoyang
### Always

- [X] Add link to plugin/component Git repository in description above
https://github.com/jenkinsci/kubesphere-extension-plugin

### For a newly hosted plugin only

- [X] Add link to resolved HOSTING issue in description above
https://issues.jenkins-ci.org/browse/HOSTING-836
### For a new permissions file only

- [X] Make sure the file is created in `permissions/` directory
- [X] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [X] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [X] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
