### PR TITLE
[INFRA-2507] rename username from casz to jetersen

### DIFF
--- a/permissions/component-configuration-as-code-test-harness.yml
+++ b/permissions/component-configuration-as-code-test-harness.yml
@@ -5,9 +5,9 @@ paths:
 - "io/jenkins/configuration-as-code/test-harness"
 developers:
 - "praqma"
-- "casz"
+- "jetersen"
 - "oleg_nenashev"
 - "timja"
 security:
   contacts:
-    jira: "casz"
+    jira: "jetersen"

--- a/permissions/component-snakeyaml-shaded-configuration-as-code.yml
+++ b/permissions/component-snakeyaml-shaded-configuration-as-code.yml
@@ -5,9 +5,9 @@ paths:
 - "io/jenkins/configuration-as-code/snakeyaml"
 developers:
 - "praqma"
-- "casz"
+- "jetersen"
 - "oleg_nenashev"
 - "timja"
 security:
   contacts:
-    jira: "casz"
+    jira: "jetersen"

--- a/permissions/plugin-accurev.yml
+++ b/permissions/plugin-accurev.yml
@@ -4,5 +4,5 @@ github: "jenkinsci/accurev-plugin"
 paths:
 - "org/jenkins-ci/plugins/accurev"
 developers:
-- "casz"
+- "jetersen"
 - "poojavishal"

--- a/permissions/plugin-cloudbees-bitbucket-branch-source.yml
+++ b/permissions/plugin-cloudbees-bitbucket-branch-source.yml
@@ -9,4 +9,4 @@ developers:
 - "abayer"
 - "svanoort"
 - "rsandell"
-- "casz"
+- "jetersen"

--- a/permissions/plugin-configuration-as-code-integrations.yml
+++ b/permissions/plugin-configuration-as-code-integrations.yml
@@ -5,9 +5,9 @@ paths:
 - "io/jenkins/configuration-as-code/integrations"
 developers:
 - "praqma"
-- "casz"
+- "jetersen"
 - "oleg_nenashev"
 - "timja"
 security:
   contacts:
-    jira: "casz"
+    jira: "jetersen"

--- a/permissions/plugin-configuration-as-code-parent.yml
+++ b/permissions/plugin-configuration-as-code-parent.yml
@@ -5,9 +5,9 @@ paths:
 - "io/jenkins/configuration-as-code/parent"
 developers:
 - "praqma"
-- "casz"
+- "jetersen"
 - "oleg_nenashev"
 - "timja"
 security:
   contacts:
-    jira: "casz"
+    jira: "jetersen"

--- a/permissions/plugin-configuration-as-code-support.yml
+++ b/permissions/plugin-configuration-as-code-support.yml
@@ -5,7 +5,7 @@ paths:
 - "io/jenkins/configuration-as-code/configuration-as-code-support"
 developers:
 - "praqma"
-- "casz"
+- "jetersen"
 security:
   contacts:
-    jira: "casz"
+    jira: "jetersen"

--- a/permissions/plugin-configuration-as-code.yml
+++ b/permissions/plugin-configuration-as-code.yml
@@ -6,9 +6,9 @@ paths:
 - "io/jenkins/configuration-as-code"
 developers:
 - "praqma"
-- "casz"
+- "jetersen"
 - "oleg_nenashev"
 - "timja"
 security:
   contacts:
-    jira: "casz"
+    jira: "jetersen"

--- a/permissions/plugin-confluence-publisher.yml
+++ b/permissions/plugin-confluence-publisher.yml
@@ -5,4 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/confluence-publisher"
 developers:
 - "jhansche"
-- "casz"
+- "jetersen"

--- a/permissions/plugin-dotcoverrunner.yml
+++ b/permissions/plugin-dotcoverrunner.yml
@@ -4,5 +4,5 @@ github: "jenkinsci/dotcoverrunner-plugin"
 paths:
 - "io/jenkins/plugins/dotcoverrunner"
 developers:
-- "casz"
+- "jetersen"
 - "rasmusjelsgaard"

--- a/permissions/plugin-gitlab-api.yml
+++ b/permissions/plugin-gitlab-api.yml
@@ -6,6 +6,6 @@ paths:
 developers:
 - "baymac"
 - "surenpi"
-- "casz"
+- "jetersen"
 - "jeffpearce"
 - "justinharringa"

--- a/permissions/plugin-gitlab-branch-source.yml
+++ b/permissions/plugin-gitlab-branch-source.yml
@@ -7,5 +7,5 @@ developers:
 - "baymac"
 - "jequals5"
 - "justinharringa"
-- "casz"
+- "jetersen"
 - "surenpi"

--- a/permissions/plugin-handy-uri-templates-2-api.yml
+++ b/permissions/plugin-handy-uri-templates-2-api.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/handy-uri-templates-2-api-plugin"
 paths:
 - "org/jenkins-ci/plugins/handy-uri-templates-2-api"
 developers:
-- "casz"
+- "jetersen"

--- a/permissions/plugin-hashicorp-vault-plugin.yml
+++ b/permissions/plugin-hashicorp-vault-plugin.yml
@@ -5,4 +5,4 @@ paths:
 - "com/datapipe/jenkins/plugins/hashicorp-vault-plugin"
 developers:
 - "ptierno"
-- "casz"
+- "jetersen"

--- a/permissions/plugin-kotlin-v1-stdlib-jdk8.yml
+++ b/permissions/plugin-kotlin-v1-stdlib-jdk8.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/kotlin-v1-stdlib-jdk8-plugin"
 paths:
 - "org/jenkins-ci/plugins/kotlin/kotlin-v1-stdlib-jdk8"
 developers:
-- "casz"
+- "jetersen"

--- a/permissions/plugin-mstest.yml
+++ b/permissions/plugin-mstest.yml
@@ -5,4 +5,4 @@ paths:
 - "org/jvnet/hudson/plugins/mstest"
 developers:
 - "nilleb"
-- "casz"
+- "jetersen"

--- a/permissions/plugin-slack.yml
+++ b/permissions/plugin-slack.yml
@@ -9,4 +9,4 @@ developers:
 - "sag47"
 - "gurumaia"
 - "timja"
-- "casz"
+- "jetersen"

--- a/permissions/plugin-vstestrunner.yml
+++ b/permissions/plugin-vstestrunner.yml
@@ -6,4 +6,4 @@ paths:
 developers:
 - "egoughnour"
 - "yasu_s"
-- "casz"
+- "jetersen"

--- a/permissions/pom-kotlin-plugin.yml
+++ b/permissions/pom-kotlin-plugin.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/kotlin-plugin-pom"
 paths:
 - "org/jenkins-ci/plugins/kotlin-plugin"
 developers:
-- "casz"
+- "jetersen"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

[INFRA-2507](https://issues.jenkins-ci.org/browse/INFRA-2507)

`@casz` @Jetersen 🤝

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
