### PR TITLE
Create plugin-compuware-strobe-measurement.yml

### DIFF
--- a/permissions/plugin-compuware-strobe-measurement.yml
+++ b/permissions/plugin-compuware-strobe-measurement.yml
@@ -1,0 +1,8 @@
+---
+name: "compuware-strobe-measurement"
+github: "jenkinsci/compuware-strobe-measurement-plugin"
+paths:
+- "com/compuware/jenkins/compuware-strobe-measurement"
+developers:
+- "VinceCapodanno"
+- "pfhjgd0"


### PR DESCRIPTION
New yml file for a new plugin.

# Description

New .yml file for a newly hosted plugin.
The hosting request: https://issues.jenkins-ci.org/browse/HOSTING-911
The hosted repo: https://github.com/jenkinsci/compuware-strobe-measurement-plugin
The two developers listed in this file are the one who opened the hosting jira and me, who is in that jira as well as listed as the developer in the pom.xml.
The user pfhjgd0 does not need GitHub merge access, as he is only being added to have the permission to release the plugin, not make code changes.

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Maintainer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it