### PR TITLE
Modernize tool

### DIFF
--- a/plugin-qualys-cs.yml
+++ b/plugin-qualys-cs.yml
@@ -1,7 +1,0 @@
----
-name: "qualys-cs"
-github: "jenkinsci/qualys-cs-plugin"
-paths:
-- "com/qualys/plugins/qualys-cs"
-developers:
-- "qualys"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.36</version>
+        <version>1.55</version>
     </parent>
 
     <groupId>io.jenkins.infra</groupId>
@@ -50,7 +50,7 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                         <phase>package</phase>
                         <configuration>
@@ -66,28 +66,35 @@
 
     <properties>
         <main.class>io.jenkins.infra.repository_permissions_updater.ArtifactoryPermissionsUpdater</main.class>
+        <java.level>8</java.level>
+        <jackson.version>2.11.0</jackson.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.11</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.8.11</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.19</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.0.2</version>
         </dependency>
     </dependencies>
 
@@ -106,7 +113,7 @@
     </pluginRepositories>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkins-infra/upload-permissions-updater.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkins-infra/upload-permissions-updater.git</developerConnection>
+        <connection>scm:git:git://github.com/jenkins-infra/repository-permissions-updater.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkins-infra/repository-permissions-updater.git</developerConnection>
     </scm>
 </project>


### PR DESCRIPTION
* Use SHA-256 instead of MD5 to shorten file names (doesn't matter but good hygiene)
* [INFRA-2594](https://issues.jenkins-ci.org/browse/INFRA-2594): Add support for new Gradle versions
* Remove stray top-level permissions file
* General dependency modernization, subsumes #1447