### PR TITLE
fixed a type introduced to plugin-bitbucket-kubernetes-credentials.yml in #1535

### DIFF
--- a/permissions/plugin-bitbucket-kubernetes-credentials.yml
+++ b/permissions/plugin-bitbucket-kubernetes-credentials.yml
@@ -2,6 +2,6 @@
 name: "bitbucket-kubernetes-credentials"
 github: "jenkinsci/bitbucket-kubernetes-credentials-plugin"
 paths:
-- "io/jenkins/plugin/bitbucket-kubernetes-credentials"
+- "io/jenkins/plugins/bitbucket-kubernetes-credentials"
 developers:
 - "johnrowl"


### PR DESCRIPTION
This PR fixes a typo that I introduced in #1535 where I had the path set to `- "io/jenkins/plugin/bitbucket-kubernetes-credentials"` instead of `- "io/jenkins/plugins/bitbucket-kubernetes-credentials"`