### PR TITLE
Adding new plugin worktile.yml file

### DIFF
--- a/permissions/plugin-worktile.yml
+++ b/permissions/plugin-worktile.yml
@@ -12,3 +12,4 @@ developers:
   - "luodongjia"
   - "sunjingyun"
   - "cheerfyt"
+  - "light2cloud"

--- a/permissions/plugin-worktile.yml
+++ b/permissions/plugin-worktile.yml
@@ -7,9 +7,8 @@ path:
   - "io.jenkins.plugins.worktile"
 
 developers:
-  - "TerryLee"
   - "shaunxu"
   - "luodongjia"
   - "sunjingyun"
   - "cheerfyt"
-  - "light2cloud"
+  - "13111179550"

--- a/permissions/plugin-worktile.yml
+++ b/permissions/plugin-worktile.yml
@@ -1,0 +1,14 @@
+---
+name: worktile
+
+github: jenkinsci/worktile-plugin
+
+path:
+  - "io.jenkins.plugins.worktile"
+
+developers:
+  - "TerryLee"
+  - "shaunxu"
+  - "luodongjia"
+  - "sunjingyun"
+  - "cheerfyt"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Updater permission request for a newly hosted plugin,
Github repository: https://github.com/jenkinsci/worktile-plugin
Hosting request: https://issues.jenkins-ci.org/browse/HOSTING-955

maintainers:
@luodongjia
@cheerfyt
@sunjingyun


<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
