### PR TITLE
More meaningful error when checking YAML names

### DIFF
--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -139,7 +139,7 @@ public class ArtifactoryPermissionsUpdater {
 
         yamlSourceDirectory.eachFile { file ->
             if (!file.name.endsWith('.yml')) {
-                throw new IOException("Unexpected file: ${file.name}")
+                throw new IOException("Unexpected file: `${file.name}`. YAML files must end with `.yml`")
             }
 
             Definition definition


### PR DESCRIPTION
Better error message when checking if file name ends with `.yml`