### PR TITLE
Fix the sideex permission file

### DIFF
--- a/permissions/plugin-sideex.yml
+++ b/permissions/plugin-sideex.yml
@@ -2,6 +2,6 @@
 name: "sideex"
 github: "jenkinsci/sideex-plugin"
 paths:
-- "io/jenkinsi/plugins/sideex"
+- "io/jenkins/plugins/sideex"
 developers:
 - "sideexteam"


### PR DESCRIPTION
It is a follow-up to the issue reported by the SideEx team in private. CC @kiam123 .
Release attempts fail due to the wrong path in the file.
