### PR TITLE
Update info on "Jenkins community account"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains both the definitions for Artifactory upload permissions
 Requesting Permissions
 ----------------------
 
-**Prerequisite**: You need to have logged in once to [Artifactory](https://repo.jenkins-ci.org/) with your Jenkins community account before you can be added to a permissions target.
+**Prerequisite**: You need to have logged in once to [Artifactory](https://repo.jenkins-ci.org/) with your Jenkins community account (this is the same as the account you would use to login to Jira) before you can be added to a permissions target.
 
 To request upload permissions to an artifact (typically a plugin), [file a PR](https://help.github.com/articles/creating-a-pull-request/) editing the appropriate YAML file, and provide a reference that shows you have commit permissions, or have an existing committer to the plugin comment on your PR, approving it.
 See [this page](https://jenkins.io/doc/developer/plugin-governance/managing-permissions/) for more information.


### PR DESCRIPTION
# Description

During the hosting process, I have helped a few people with upload permissions issues. They were not aware that the "Jenkins community account" is the same as the one they might login to Jira with. I just added a short blurb about this to the description to hopefully reduce this confusion.


