### PR TITLE
Replace security contact for BlueOcean plugins with pipeline_security_members

### DIFF
--- a/permissions/plugin-blueocean-bitbucket-pipeline.yml
+++ b/permissions/plugin-blueocean-bitbucket-pipeline.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-commons.yml
+++ b/permissions/plugin-blueocean-commons.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-config.yml
+++ b/permissions/plugin-blueocean-config.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-dashboard.yml
+++ b/permissions/plugin-blueocean-dashboard.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-events.yml
+++ b/permissions/plugin-blueocean-events.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -21,4 +21,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-git-pipeline.yml
+++ b/permissions/plugin-blueocean-git-pipeline.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-github-pipeline.yml
+++ b/permissions/plugin-blueocean-github-pipeline.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-i18n.yml
+++ b/permissions/plugin-blueocean-i18n.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-jira.yml
+++ b/permissions/plugin-blueocean-jira.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-jwt.yml
+++ b/permissions/plugin-blueocean-jwt.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-personalization.yml
+++ b/permissions/plugin-blueocean-personalization.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-pipeline-api-impl.yml
+++ b/permissions/plugin-blueocean-pipeline-api-impl.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-pipeline-editor.yml
+++ b/permissions/plugin-blueocean-pipeline-editor.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-pipeline-scm-api.yml
+++ b/permissions/plugin-blueocean-pipeline-scm-api.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-rest-impl.yml
+++ b/permissions/plugin-blueocean-rest-impl.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-rest.yml
+++ b/permissions/plugin-blueocean-rest.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean-web.yml
+++ b/permissions/plugin-blueocean-web.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-blueocean.yml
+++ b/permissions/plugin-blueocean.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-jenkins-design-language.yml
+++ b/permissions/plugin-jenkins-design-language.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/plugin-sse-gateway.yml
+++ b/permissions/plugin-sse-gateway.yml
@@ -21,4 +21,4 @@ developers:
 - "halkeye"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"

--- a/permissions/pom-blueocean-parent.yml
+++ b/permissions/pom-blueocean-parent.yml
@@ -20,4 +20,4 @@ developers:
 - "tscherler"
 security:
   contacts:
-    jira: "blueocean_security_members"
+    jira: "pipeline_security_members"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

`blueocean_security_members` is defunct. Everyone working on Blue Ocean who would handle security fixes is part of `pipeline_security_members`, but not vice-versa, so we should just switch to using `pipeline_security_members`.

Affects all plugins in https://github.com/jenkinsci/blueocean-plugin as well as https://github.com/jenkinsci/sse-gateway-plugin and https://github.com/jenkinsci/jenkins-design-language.

CC @olamy who is I think the only active user currently part of `blueocean_security_members` (he is also part of `pipeline_security_members`) and @daniel-beck as the security officer.

# Submitter checklist for changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
