### PR TITLE
Clarify when the PR template needs to be filled out

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 <!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->
 
-# Submitter checklist for changing permissions
+# Submitter checklist for adding or changing permissions
 
 <!--
 Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.


### PR DESCRIPTION
A new plugin owner was confused as to whether they should fill out the PR template for a completely new plugin. This small addition should hopefully clarify that a little more.

