### PR TITLE
Add release permissions for Commons HttpClient Lib fork

### DIFF
--- a/permissions/component-commons-httpclient.yml
+++ b/permissions/component-commons-httpclient.yml
@@ -1,0 +1,10 @@
+---
+name: "commons-httpclient"
+github: "jenkinsci/lib-commons-httpclient"
+paths:
+- "commons-httpclient/commons-httpclient"
+developers:
+- "oleg_nenashev"
+- "olivergondza"
+- "timja"
+- "markewaite"


### PR DESCRIPTION
Grants the active Jenkins release team members permissions to release https://github.com/jenkinsci/lib-commons-httpclient . I need these permissions to release https://github.com/jenkinsci/lib-commons-httpclient/pull/2 . 

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
