### PR TITLE
Fix path for perfecto-plugin

### DIFF
--- a/permissions/plugin-perfecto.yml
+++ b/permissions/plugin-perfecto.yml
@@ -2,7 +2,7 @@
 name: "perfecto-plugin"
 github: "jenkinsci/perfecto-plugin"
 paths:
-- "org/jenkins-ci/plugins/perfecto"
+- "io/jenkins/plugins/perfecto"
 developers:
 - "perfectojenkins"
 - "genesisthomas"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Fix the path for the perfecto-plugin based on the pom.xml groupId (https://github.com/jenkinsci/perfecto-plugin/blob/master/pom.xml#L20)

https://github.com/jenkinsci/perfecto-plugin
https://issues.jenkins-ci.org/browse/HOSTING-1004

@genesisthomas @timja


# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above