### PR TITLE
updated correct name for perfecto plugin

### DIFF
--- a/permissions/plugin-perfecto.yml
+++ b/permissions/plugin-perfecto.yml
@@ -1,5 +1,5 @@
---- 
-name: "perfecto-plugin"
+---
+name: "perfecto"
 github: "jenkinsci/perfecto-plugin"
 paths:
 - "io/jenkins/plugins/perfecto"


### PR DESCRIPTION
# Description

Fix the name for the perfecto-plugin based on the pom.xml artifactId (https://github.com/jenkinsci/perfecto-plugin/blob/master/pom.xml#L21)

https://github.com/jenkinsci/perfecto-plugin
https://issues.jenkins-ci.org/browse/HOSTING-1004

# Submitter checklist for adding or changing permissions`

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
