### PR TITLE
Adding file-changes-build-strategy plugin

### DIFF
--- a/permissions/plugin-file-changes-build-strategy.yml
+++ b/permissions/plugin-file-changes-build-strategy.yml
@@ -2,6 +2,6 @@
 name: "file-changes-build-strategy"
 github: "jenkinsci/file-changes-build-strategy-plugin"
 paths:
-- "org/jenkins-ci/plugins/file-changes-build-strategy"
+- "io/jenkins/plugins/file-changes-build-strategy"
 developers:
 - "michelzanini"

--- a/permissions/plugin-file-changes-build-strategy.yml
+++ b/permissions/plugin-file-changes-build-strategy.yml
@@ -1,0 +1,7 @@
+---
+name: "file-changes-build-strategy"
+github: "jenkinsci/file-changes-build-strategy-plugin"
+paths:
+- "org/jenkins-ci/plugins/file-changes-build-strategy"
+developers:
+- "michelzanini"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

Adding permissions for file-changes-build-strategy-plugin.
GitHub repo: https://github.com/jenkinsci/file-changes-build-strategy-plugin
HOSTING: https://issues.jenkins-ci.org/browse/HOSTING-1010

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins
