### PR TITLE
add mdaugherty6 as contributor to gcp credentials provider plugin

### DIFF
--- a/permissions/plugin-gcp-secrets-manager-credentials-provider.yml
+++ b/permissions/plugin-gcp-secrets-manager-credentials-provider.yml
@@ -1,0 +1,7 @@
+---
+name: "gcp-secrets-manager-credentials-provider"
+github: "jenkinsci/gcp-secrets-manager-credentials-provider-plugin"
+paths:
+- "io/jenkins/plugins/gcp-secrets-manager-credentials-provider"
+developers:
+- "mdaugherty6"


### PR DESCRIPTION
# Description

This pull request gives permissions to mdaugherty6 to upload the [gcp-secrets-manager-credentials-provider-plugin](https://github.com/jenkinsci/gcp-secrets-manager-credentials-provider-plugin). 

[Hosting request](https://issues.jenkins-ci.org/browse/HOSTING-1017)

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
