### PR TITLE
Add plugin-material-theme.yml and allow timbrown5 permissions

### DIFF
--- a/permissions/plugin-material-theme.yml
+++ b/permissions/plugin-material-theme.yml
@@ -1,0 +1,7 @@
+---
+name: "material-theme"
+github: "jenkinsci/material-theme-plugin"
+paths:
+- "io/jenkins/plugins/materialtheme"
+developers:
+- "timbrown5"

--- a/permissions/plugin-material-theme.yml
+++ b/permissions/plugin-material-theme.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/material-theme-plugin"
 paths:
 - "io/jenkins/plugins/materialtheme"
 developers:
-- "timbrown5"
+- "canuck1987"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
GitHub Repo: https://github.com/jenkinsci/material-theme-plugin
Hosting request: https://issues.jenkins-ci.org/browse/HOSTING-1032

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins