### PR TITLE
plugin-material-theme - update path to material-theme

### DIFF
--- a/permissions/plugin-material-theme.yml
+++ b/permissions/plugin-material-theme.yml
@@ -2,6 +2,6 @@
 name: "material-theme"
 github: "jenkinsci/material-theme-plugin"
 paths:
-- "io/jenkins/plugins/materialtheme"
+- "io/jenkins/plugins/material-theme"
 developers:
 - "canuck1987"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
I think my original path was wrong (as I am getting 403s when trying to upload - which I am guessing is becase it's uploading to `material-theme`, when I have permissions to `materialtheme`). This updates it to the artifactID, not the plugin namespace (which is `io/jenkins/plugins/materialtheme`).
https://github.com/jenkinsci/material-theme-plugin
# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
