### PR TITLE
Add basil to email-ext and emailext-template

### DIFF
--- a/permissions/plugin-email-ext.yml
+++ b/permissions/plugin-email-ext.yml
@@ -5,6 +5,7 @@ paths:
 - "org/jenkins-ci/plugins/email-ext"
 - "org/jvnet/hudson/plugins/email-ext"
 developers:
+- "basil"
 - "davidvanlaatum"
 security:
   contacts:

--- a/permissions/plugin-emailext-template.yml
+++ b/permissions/plugin-emailext-template.yml
@@ -3,4 +3,5 @@ name: "emailext-template"
 github: "jenkinsci/emailext-template-plugin"
 paths:
 - "org/jenkinsci/plugins/emailext-template"
-developers: []
+developers:
+- "basil"


### PR DESCRIPTION
# Description

I saw that these plugins were recently marked for adoption and wanted to help out. I've been a user of `email-ext` since 2016. Thanks to the efforts of the previous maintainer, it has always "just worked" and I never had to submit any PRs for it. Hopefully I can keep it that way. I maintain a few other Jenkins plugins and am familiar with the general process of bug triage, processing PRs, updating plugin POMs, cutting releases, etc.

- https://github.com/jenkinsci/email-ext-plugin
- https://github.com/jenkinsci/emailext-template-plugin

CC'ing @slide as the previous maintainer.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)