### PR TITLE
Removing myself of reverse-proxy-auth

### DIFF
--- a/permissions/plugin-reverse-proxy-auth-plugin.yml
+++ b/permissions/plugin-reverse-proxy-auth-plugin.yml
@@ -6,5 +6,3 @@ paths:
 developers:
 - "wilder_rodrigues"
 - "oleg_nenashev"
-- "wfollonier"
-


### PR DESCRIPTION
Removing myself from the maintainers of reverse-proxy-auth as I did not touch the code since that introduction and am only looking at it from far distance (with a stick?).

- https://github.com/jenkinsci/reverse-proxy-auth-plugin

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
