### PR TITLE
Removing myself from maintainer list

### DIFF
--- a/permissions/plugin-docker-workflow.yml
+++ b/permissions/plugin-docker-workflow.yml
@@ -7,7 +7,6 @@ developers:
 - "jglick"
 - "oleg_nenashev"
 - "abayer"
-- "esmalling"
 - "svanoort"
 - "dnusbaum"
 - "carroll"


### PR DESCRIPTION
I haven't been involved with this plugin in several years (and no longer work at Docker, FYI)

https://github.com/jenkinsci/docker-workflow-plugin

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
