### PR TITLE
Add jglick to reverse-proxy-auth-plugin

### DIFF
--- a/permissions/plugin-reverse-proxy-auth-plugin.yml
+++ b/permissions/plugin-reverse-proxy-auth-plugin.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "wilder_rodrigues"
 - "oleg_nenashev"
+- "jglick"


### PR DESCRIPTION
# Description

After @Wadeck left in #1733, only @oleg-nenashev and @wilderrodrigues have access here, but https://github.com/jenkinsci/reverse-proxy-auth-plugin/pull/40 is going to be critical after JEP-227, so I would like to cut an emergency release. I do not intend to maintain the plugin in other respects.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
