### PR TITLE
Add plugin kubesphere-token-auth

### DIFF
--- a/permissions/plugin-kubesphere-token-auth.yml
+++ b/permissions/plugin-kubesphere-token-auth.yml
@@ -1,0 +1,10 @@
+---
+name: "kubesphere-token-auth"
+github: "jenkinsci/kubesphere-token-auth-plugin"
+paths:
+- "io/jenkins/plugins/kubesphere-token-auth"
+developers:
+  - "shaowenchen"
+  - "zhuxiaoyang"
+  - "surenpi"
+  


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in the description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

This plugin is part of [Kubesphere](https://github.com/kubesphere) DevOps. If you want to know more details, please check out [here](https://github.com/kubesphere).

The git repository of this plugin is https://github.com/jenkinsci/kubesphere-token-auth-plugin/. The [host request ticket](https://issues.jenkins.io/browse/HOSTING-1044) was resolved.

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add a link to plugin/component Git repository in the description above

### For a newly hosted plugin only

- [x] Add a link to the resolved HOSTING issue in the description above

### For new permission file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
