### PR TITLE
add alibabacloud-ecs

### DIFF
--- a/permissions/plugin-alibabacloud-ecs.yml
+++ b/permissions/plugin-alibabacloud-ecs.yml
@@ -1,0 +1,8 @@
+---
+name: "alibabacloud-ecs"
+github: "jenkinsci/alibabacloud-ecs-plugin"
+paths:
+  - "com/alibabacloud/jenkins/alibabacloud-ecs"
+developers:
+  - "kunlun"
+  - "xhpy2009"


### PR DESCRIPTION
### The address of Git repository is as follows:
https://github.com/jenkinsci/alibabacloud-ecs-plugin

- the file is created in `permissions/` directory
- `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- `groupId` / `artifactId` (pom.xml) are correctly represented in `path`
- the file is named plugin-${artifactId}.yml for the plugin
- use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- the existing maintainer has confirmed the permission request
- the existing users have been ensured to know their GitHub account names when they need GitHub merge access
- all newly added users have logged in to Artifactory at least once
