### PR TITLE
add new maintainer of accurev-plugin

### DIFF
--- a/permissions/plugin-accurev.yml
+++ b/permissions/plugin-accurev.yml
@@ -6,3 +6,4 @@ paths:
 developers:
 - "jetersen"
 - "poojavishal"
+- "isaacchou"


### PR DESCRIPTION
This PR is to add myself (@isaacchou) to be a maintainer of the Jenkins AccuRev plugin.

### Description
Link to the plugin: https://plugins.jenkins.io/accurev/
Link to code in GitHub: https://github.com/jenkinsci/accurev-plugin/

cc: @jetersen @slide @isaacchou

---
### Submitter checklist for adding or changing permissions

### Always

 - [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x]  Make sure to @mention an existing maintainer to confirm the permissions request, if applicable
- [x]  Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x]  Make sure to @mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x]  All newly added users have logged in to Artifactory at least once

---
### Reviewer checklist (not for requesters!)

- [ ]  Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an IRC Bot command
- [ ]  Check that the $pluginId Developers team has Admin permissions while granting the access.
- [ ]  In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ]  If security contacts are changed (this includes add/remove), ping the security officer (currently @daniel-beck) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.

