### PR TITLE
Update plugin-hp-application-automation-tools-plugin.yml

### DIFF
--- a/permissions/plugin-hp-application-automation-tools-plugin.yml
+++ b/permissions/plugin-hp-application-automation-tools-plugin.yml
@@ -4,6 +4,5 @@ github: "jenkinsci/hpe-application-automation-tools-plugin"
 paths:
 - "org/jenkins-ci/plugins/hp-application-automation-tools-plugin"
 developers:
-- "NarcisaMGalan"        
+- "ptofan"   
 - "gront"
-- "ptofan"


### PR DESCRIPTION
# Description

I would like to change this because Maria is no longer in our company and Daniel is not handling the plugin anymore.
This is related to this repository: https://github.com/jenkinsci/hpe-application-automation-tools-plugin
PS: I am ptofan

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
