### PR TITLE
[JEP-229] Fix Jenkinsfile to provide credentials; enable CD for log-cli

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,10 @@ node('java') {
                         name: 'Validation',
                         title: 'All checks passed'
             } else {
-                withCredentials([usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                withCredentials([
+                        usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME'),
+                        usernamePassword(credentialsId: 'jenkins-infra-bot-github-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
+                ]) {
                     sh '${JAVA_HOME}/bin/java ' + javaArgs
                 }
             }

--- a/permissions/plugin-log-cli.yml
+++ b/permissions/plugin-log-cli.yml
@@ -1,6 +1,8 @@
 ---
 name: "log-cli"
 github: "jenkinsci/log-cli-plugin"
+cd:
+  enabled: true
 paths:
 - "org/jenkins-ci/plugins/log-cli"
 developers:

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -263,12 +263,13 @@ class ArtifactoryPermissionsUpdater {
             def username = ArtifactoryAPI.toTokenUsername((String) repo)
             def groupName = ArtifactoryAPI.getInstance().toGeneratedGroupName((String) repo)
             def validFor = TimeUnit.MINUTES.toSeconds(Integer.getInteger('artifactoryTokenMinutesValid', 240))
+            def token
             try {
                 if (DRY_RUN_MODE) {
                     LOGGER.log(Level.INFO, "Skipped creation of token for GitHub repo: '${repo}', Artifactory user: '${username}', group name: '${groupName}', valid for ${validFor} seconds")
                     return
                 }
-                def token = ArtifactoryAPI.getInstance().generateTokenForGroup(username, groupName, validFor)
+                token = ArtifactoryAPI.getInstance().generateTokenForGroup(username, groupName, validFor)
             } catch (Exception ex) {
                 LOGGER.log(Level.WARNING, "Failed to generate token for ${repo}", ex)
                 return

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -286,16 +286,15 @@ class ArtifactoryPermissionsUpdater {
             def encryptedToken = CryptoUtil.encryptSecret(token, publicKey.key)
             LOGGER.log(Level.INFO, "Encrypted secrets are username:${encryptedUsername}; token:${encryptedToken}")
 
-            def secretPrefixOverride =
             GitHubAPI.getInstance().createOrUpdateRepositorySecret(System.getProperty('gitHubSecretNamePrefix', DEVELOPMENT ? 'DEV_MAVEN_' : 'MAVEN_') + 'USERNAME', encryptedUsername, (String) repo, publicKey.keyId)
             GitHubAPI.getInstance().createOrUpdateRepositorySecret(System.getProperty('gitHubSecretNamePrefix', DEVELOPMENT ? 'DEV_MAVEN_' : 'MAVEN_') + 'TOKEN', encryptedToken, (String) repo, publicKey.keyId)
         }
     }
 
     static void main(String[] args) throws IOException {
-        for (Handler h : java.util.logging.Logger.getLogger("").getHandlers()) {
+        for (Handler h : Logger.getLogger("").getHandlers()) {
             if (h instanceof ConsoleHandler) {
-                ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());
+                ((ConsoleHandler) h).setFormatter(new SupportLogFormatter())
             }
         }
 

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -226,6 +226,7 @@ class ArtifactoryPermissionsUpdater {
      */
     private static void removeExtraArtifactoryObjects(File payloadsDir, String kind, Closure lister, Closure deleter) {
         if (!payloadsDir.exists() || !payloadsDir.isDirectory()) {
+            // TODO this will not remove objects if there would not be any left
             LOGGER.log(Level.INFO, "${payloadsDir} does not exist or is not a directory, skipping extra ${kind}s removal")
             return
         }


### PR DESCRIPTION
Follow up on https://github.com/jenkins-infra/repository-permissions-updater/pull/1747 with some unfinished WIP I had forgotten about 😢 

Anyway, this seems to work now, tested by switching the job on trusted.ci over to this origin branch (and back again).

@jglick clearly is fine with `log-cli` being CD enabled, so that's why I set that up here already.