### PR TITLE
Replace plugin permissions.

### DIFF
--- a/permissions/plugin-insightappsec.yml
+++ b/permissions/plugin-insightappsec.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/insightappsec-plugin"
 paths:
 - "io/jenkins/plugins/insightappsec"
 developers:
-- "ias_developer"
+- "ckearneyr7"


### PR DESCRIPTION
# Description

Replacing existing Jenkins community user for plugin release with my own user. 

The plugin code is located here https://github.com/jenkinsci/insightappsec-plugin
The plugin listing is located here https://plugins.jenkins.io/insightappsec/

I am a maintainer/admin of the previously mentioned repository.

# Submitter checklist for adding or changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
