### PR TITLE
Add issue tracker support, add output as issues.index.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,60 @@ Either of `jira` and `email` is optional.
 Please note that we generally reject email contacts due to the additional overhead in reaching out via email.
 Unless you represent a large organization with dedicated security team that needs to be involved in the coordination of a release, but is not otherwise part of plugin maintenance, please refrain from requesting to be contacted via email.
 
+Managing Issue Trackers
+-----------------------
+
+The YAML metadata files in this repository also hold information about issue trackers.
+This is used to make issue trackers more accessible, e.g. by adding them to the UI of Jenkins or on https://plugins.jenkins.io.
+
+### Declaring Issue Trackers
+
+The top-level `issues` key contains a sorted list of issue tracker references in descending order of preference.
+
+For GitHub issues, a GitHub repository must be specified as the value for the `github` key, and the value must start with `jenkinsci/`, followed by the repository name.
+For Jira, a component name or ID must be specified as the value for the `jira` key.
+The component name is easier to read, while the component ID is resilient in case of component renames.
+
+Either kind of issue tracker supports the `report:` boolean value that controls whether new issues should be reported in this issue tracker.
+The default is `true`.
+
+A complete example with two trackers:
+
+```yaml
+issues:
+  - github: 'jenkinsci/configuration-as-code-plugin' # The preferred issue tracker
+  - jira: 'configuration-as-code-plugin' # A secondary issue tracker is the Jira component 'configuration-as-code-plugin'
+    report: no # No new issues should be reported here
+```
+
+When GitHub Issues is used, there would be some duplicated content in the file (between `github` and `issues` entries) which can be resolved by using a YAML reference.
+Example:
+
+```yaml
+github: &GH 'jenkinsci/configuration-as-code-plugin' # Declare a reference
+issues:
+  - github: *GH # Use the reference
+```
+
+### Consuming Issue Trackers
+
+A file `issues.index.json` is generated when the tool is executed, containing a map from component names to a list of issue trackers.
+Only plugins are expected to specify an issue tracker here.
+
+If a plugin does not have a corresponding key in this map, the tool did not consider it for inclusion.
+If a plugin has a corresponding key in this map but an empty list of issue trackers, no issue trackers are known or supported.
+
+Each issue tracker entry will have the following keys:
+
+* `type`: Currently `jira` (meaning issues.jenkins.io) or `github` (meaning GitHub issues)
+* `reference` contains a `type`-specific identifier string that provides additional information how issues are tracked; for Jira it is the component name or ID and for GitHub Issues it is the `orgname/reponame` String.
+* `viewUrl` is a URL to a human-readable overview page. This value may not exist if no valid URL could be determined.
+* `reportUrl` is a URL where users can report issues. This value may not exist if no valid URL could be determined, or new issues should not be reported in this tracker.
+
+The list is sorted in descending order of preference.
+The first issue tracker in the list with a `reportUrl` should be presented as the primary (or only) option for reporting issues.
+Further issue trackers are mostly provided as a reference, e.g. when listing existing issues, although a different issue tracker with `reportUrl` can be linked if users provide a preference for a specific kind of issue tracker.
+
 Usage
 -----
 

--- a/permissions/plugin-configuration-as-code.yml
+++ b/permissions/plugin-configuration-as-code.yml
@@ -1,6 +1,6 @@
 ---
 name: "configuration-as-code"
-github: "jenkinsci/configuration-as-code-plugin"
+github: &GH jenkinsci/configuration-as-code-plugin
 paths:
 - "org/jenkins-ci/plugins/configuration-as-code"
 - "io/jenkins/configuration-as-code"
@@ -12,3 +12,7 @@ developers:
 security:
   contacts:
     jira: "jetersen"
+issues:
+  - github: *GH
+  - jira: 23170 # configuration-as-code-plugin
+    report: no

--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -5,3 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/matrix-auth"
 developers:
 - "danielbeck"
+issues:
+  - jira: 'matrix-auth-plugin'

--- a/pom.xml
+++ b/pom.xml
@@ -67,24 +67,13 @@
     <properties>
         <main.class>io.jenkins.infra.repository_permissions_updater.ArtifactoryPermissionsUpdater</main.class>
         <java.level>8</java.level>
-        <jackson.version>2.11.0</jackson.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.27</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/JiraAPI.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/JiraAPI.groovy
@@ -1,0 +1,66 @@
+package io.jenkins.infra.repository_permissions_updater
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import groovy.json.JsonSlurper
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+@SuppressFBWarnings("LI_LAZY_INIT_STATIC") // Something related to Groovy
+abstract class JiraAPI implements Definition.IssueTracker.JiraComponentSource {
+    public static final Logger LOGGER = Logger.getLogger(JiraAPI.class.getName())
+    /**
+     * URL to Jira
+     */
+    private static final String JIRA_URL = System.getProperty('jiraUrl', 'https://issues.jenkins.io')
+    /**
+     * URL to Jira components API
+     */
+    private static final String JIRA_COMPONENTS_URL = JIRA_URL + '/rest/api/2/project/JENKINS/components'
+
+    abstract String getComponentId(String componentName);
+
+    /* Singleton support */
+    private static JiraAPI INSTANCE = null
+    static synchronized JiraAPI getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new JiraImpl()
+        }
+        return INSTANCE
+    }
+
+    private static class JiraImpl extends JiraAPI {
+
+        private Map<String, String> componentNamesToIds;
+
+        @SuppressFBWarnings("SE_NO_SERIALVERSIONID")
+        private void ensureDataLoaded() {
+            if (componentNamesToIds == null) {
+                componentNamesToIds = new HashMap<>();
+
+                LOGGER.log(Level.INFO, "Retrieving components from Jira...")
+                URL url = new URL(JIRA_COMPONENTS_URL)
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection()
+
+                conn.setRequestMethod('GET')
+                conn.connect()
+                String text = conn.getInputStream().getText()
+
+                def json = new JsonSlurper().parseText(text)
+
+                json.each {
+                    def id = it.id
+                    def name = it.name
+                    LOGGER.log(Level.FINE, "Identified Jira component with ID '${id}' and name '${name}'")
+                    componentNamesToIds.put(name, id)
+                }
+            }
+        }
+
+        @Override
+        String getComponentId(String componentName) {
+            ensureDataLoaded()
+            return componentNamesToIds.get(componentName)
+        }
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -2,14 +2,138 @@ package io.jenkins.infra.repository_permissions_updater;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 @SuppressFBWarnings("UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD")
 public class Definition {
+
     public static class CD {
         public boolean enabled;
     }
+
+    public static class Security {
+        public SecurityContacts contacts;
+    }
+
+    public static class SecurityContacts {
+        public String email;
+        public String jira;
+    }
+
+    /**
+     * Holds issue tracker information and provides a simple API to create issue tracker references.
+     *
+     * Call {@link #isJira()} and/or {@link #isGitHubIssues()} to determine the kind of tracker.
+     * Some invalid input may result in both returning {@code false}, in that case other methods will throw exceptions.
+     */
+    public static class IssueTracker {
+        public interface JiraComponentSource {
+            String getComponentId(String componentName);
+        }
+
+        private static final Logger LOGGER = Logger.getLogger(IssueTracker.class.getName());
+
+        public String jira;
+        public String github;
+        public boolean report = true;
+
+        public boolean isJira() {
+            if (jira == null) {
+                return false;
+            }
+            if (!jira.matches("[a-zA-Z0-9_.-]+")) {
+                LOGGER.log(Level.INFO, "Unexpected Jira component name, skipping: " + jira);
+                return false;
+            }
+            return true;
+        }
+
+        public boolean isGitHubIssues() {
+            if (github == null) {
+                return false;
+            }
+            if (!github.startsWith("jenkinsci/")) {
+                LOGGER.log(Level.INFO, "Unexpected GitHub repo for issue tracker, skipping: " + jira);
+                return false;
+            }
+            return true;
+        }
+
+        private String loadComponentId(JiraComponentSource source) {
+            String jiraComponentId = jira;
+            if (!jira.matches("[0-9]+")) {
+                // CreateIssueDetails needs the numeric Jira component ID
+                jiraComponentId = source.getComponentId(jira);
+                if (jiraComponentId == null) {
+                    LOGGER.warning("Failed to determine Jira component ID for '" + jira + "', the component may not exist");
+                    return null;
+                }
+            }
+            return jiraComponentId;
+        }
+
+        public String getViewUrl(JiraComponentSource source) {
+            if (isJira()) {
+                final String id = loadComponentId(source);
+                if (id != null) {
+                    return "https://issues.jenkins.io/issues/?jql=component=" + id;
+                }
+                return null;
+            }
+            if (isGitHubIssues()) {
+                return "https://github.com/" + github + "/issues";
+            }
+            throw new IllegalStateException("Invalid issue tracker: " + github + " / " + jira);
+        }
+
+        public String getReportUrl(JiraComponentSource source) {
+            if (!report) {
+                return null;
+            }
+            if (isJira()) {
+                final String id = loadComponentId(source);
+                if (id != null) {
+                    return "https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10172&issuetype=1&components=" + id;
+                }
+                return null;
+            }
+            if (isGitHubIssues()) {
+                return "https://github.com/" + github + "/issues/new/choose"; // The 'choose' URL works even when there are no issue templates
+            }
+            throw new IllegalStateException("Invalid issue tracker: " + github + " / " + jira);
+        }
+
+        /**
+         * Returns the characteristic reference for the issue tracker of this component.
+         * For GitHub Issues, this is the 'orgname/reponame', for Jira, it's the component name or ID.
+         * @return the characteristic reference for the issue tracker of this component
+         */
+        public String getReference() {
+            if (isJira()) {
+                return jira;
+            }
+            if (isGitHubIssues()) {
+                return github;
+            }
+            throw new IllegalStateException("Invalid issue tracker: " + github + " / " + jira);
+        }
+
+        public String getType() {
+            if (isJira()) {
+                return "jira";
+            }
+            if (isGitHubIssues()) {
+                return "github";
+            }
+            throw new IllegalStateException("Invalid issue tracker: " + github + " / " + jira);
+        }
+    }
+
     private String name = "";
     private String[] paths = new String[0];
     private String[] developers = new String[0];
+    private IssueTracker[] issues = new IssueTracker[0];
 
     private String github;
 
@@ -22,7 +146,7 @@ public class Definition {
     }
 
     private CD cd;
-    private Object security; // unused, just metadata for Jenkins security team
+    private Security security; // unused, just metadata for Jenkins security team
 
     public String getName() {
         return name;
@@ -40,6 +164,14 @@ public class Definition {
         this.paths = paths.clone();
     }
 
+    public IssueTracker[] getIssues() {
+        return issues.clone();
+    }
+
+    public void setIssues(IssueTracker[] paths) {
+        this.issues = paths.clone();
+    }
+
     public String[] getDevelopers() {
         return developers.clone();
     }
@@ -52,11 +184,14 @@ public class Definition {
         this.github = github;
     }
 
-    public void setSecurity(Object security) {
+    public void setSecurity(Security security) {
         this.security = security;
     }
 
     public String getGithub() {
-        return github;
+        if (github != null && github.startsWith("jenkinsci/")) {
+            return github;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This is mostly the tool support side of things, with two files changed thrown in to demonstrate the effect (@timja to check whether I got the metadata correct for JCasC).

I switched from Jackson to SnakeYAML because the former does not support YAML references. Those make it less painful to deal with the "duplicated" GitHub URL without custom syntax, see README for explicit example.

Previously discussed in:

- https://gist.github.com/daniel-beck/a1a3fe34e2e5f27d56d64fee1de11c0e
- https://groups.google.com/g/jenkinsci-dev/c/LnvX3mX5Gek

Output created by the "sample" metadata changes included here:

```
$ cat json/issues.index.json 
{
    "configuration-as-code": [
        {
            "type": "github",
            "reference": "jenkinsci/configuration-as-code-plugin",
            "viewUrl": "https://github.com/jenkinsci/configuration-as-code-plugin/issues",
            "reportUrl": "https://github.com/jenkinsci/configuration-as-code-plugin/issues/new/choose"
        },
        {
            "type": "jira",
            "reference": "23170",
            "viewUrl": "https://issues.jenkins.io/issues/?jql=component=23170"
        }
    ],
    "matrix-auth": [
        {
            "type": "jira",
            "reference": "matrix-auth-plugin",
            "viewUrl": "https://issues.jenkins.io/issues/?jql=component=18131",
            "reportUrl": "https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10172&issuetype=1&components=18131"
        }
    ]
}
```

Both the configuration (YAML) and downstream consumption (JSON) formats are specified in the README, please review these definitions to ensure nothing is missing or ambiguous.

This file would be created in https://ci.jenkins.io/job/Infra/job/repository-permissions-updater/job/master/lastSuccessfulBuild/artifact/json/ but we probably want to add it to `reports.jenkins.io` from `trusted.ci` `Jenkinsfile` execution as a final canonical location.

FWIW there are very few conditions that cause failures here: E.g. if a Jira component is specified and that gets renamed, this tool shouldn't fail IMO.