### PR TITLE
Allow incrementals publishing for Stapler

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -189,7 +189,7 @@ public class Definition {
     }
 
     public String getGithub() {
-        if (github != null && github.startsWith("jenkinsci/")) {
+        if (github != null && (github.startsWith("jenkinsci/") || github.startsWith("stapler/"))) {
             return github;
         }
         return null;


### PR DESCRIPTION
See [stapler/stapler#209 (comment)](https://github.com/stapler/stapler/pull/209#issuecomment-772621968). Stapler incrementals publishing regressed because `github.index.json` no longer has an entry for `stapler/stapler` (caused by #1806). I ensured that with this change `github.index.json` again contains an entry for `stapler/stapler`.