### PR TITLE
Takeover maintenance of gearman plugin

### DIFF
--- a/permissions/plugin-gearman-plugin.yml
+++ b/permissions/plugin-gearman-plugin.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/gearman-plugin"
 paths:
 - "org/jenkins-ci/plugins/gearman-plugin"
 developers:
-- "openstackjenkins"
+- "hashar"


### PR DESCRIPTION
# Description

The Gearman plugin ( https://github.com/jenkinsci/gearman-plugin/ ) has originally been created for the OpenStack CI infrastructure (now OpenDev), they however no more rely on Jenkins nowadays.  The primary author was @zaro0508 .

I have raised the issue to the OpenDev team:
http://lists.zuul-ci.org/pipermail/zuul-discuss/2020-May/001236.html

There is consensus to use the jenkinsci GitHub organization for
maintenance:
http://lists.zuul-ci.org/pipermail/zuul-discuss/2020-May/001238.html

I have been granted admin rights on the repository by the original author (@zaro0508) and started pushed a few commits notably to support Java 11.

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

_Not needed, already hosted_

~~- [ ] Add link to resolved HOSTING issue in description above~~

### For a new permissions file only

_Not needed it is an edit_

~~- [ ] Make sure the file is created in `permissions/` directory~~
~~- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).~~
~~- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)~~
~~- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins~~

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
