### PR TITLE
Enable continuous delivery for platformlabeler

### DIFF
--- a/permissions/plugin-platformlabeler.yml
+++ b/permissions/plugin-platformlabeler.yml
@@ -3,6 +3,8 @@ name: "platformlabeler"
 github: "jenkinsci/platformlabeler-plugin"
 paths:
 - "org/jvnet/hudson/plugins/platformlabeler"
+cd:
+  enabled: true
 developers:
 - "markewaite"
 - "timja"


### PR DESCRIPTION
## Move platformlabeler to JEP-229 delivery

Move the [platformlabeler plugin](https://github.com/jenkinsci/platformlabeler-plugin/pull/283) from `mvn release:prepare release:perform` to [JEP-229 continuous delivery](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc).  See [PR-283](https://github.com/jenkinsci/platformlabeler-plugin/pull/283) for the changes proposed to platformlabeler plugin.

### Checklist

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [x] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [x] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [x] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [x] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
