### PR TITLE
Allow JEP-229 CD on jenkins-test-harness

### DIFF
--- a/permissions/component-jenkins-test-harness.yml
+++ b/permissions/component-jenkins-test-harness.yml
@@ -1,6 +1,8 @@
 ---
 name: "jenkins-test-harness"
 github: "jenkinsci/jenkins-test-harness"
+cd:
+  enabled: true
 paths:
 - "org/jenkins-ci/main/jenkins-test-harness"
 developers:


### PR DESCRIPTION
# Description

We had [discussed in the contributor summit](https://docs.google.com/document/d/1AnwVFpxZUsIwD_d_JiB2rhAKpAAmEzQim4X9FYV6iCw) that it would be good to start trying to use JEP-229 from some “core components”. Not sure if JTH counts technically (`test` scope rather than bundled), but may be a good place to start.

@oleg-nenashev @timja 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
