### PR TITLE
Throw an exception before we get to #setAuthenticator not working

### DIFF
--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryAPI.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryAPI.groovy
@@ -164,6 +164,10 @@ abstract class ArtifactoryAPI {
                     throw new IllegalStateException("ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD must be provided unless dry-run mode is used")
                 }
             } else {
+                if (System.getProperty("java.version").startsWith("1.")) {
+                    // HttpUrlConnection#setAuthenticator exists since Java 9
+                    throw new IllegalStateException("You need at least Java 9 to run this unless dry-run mode is used")
+                }
                 AUTHENTICATOR = new Authenticator() {
                     protected PasswordAuthentication getPasswordAuthentication() {
                         return new PasswordAuthentication(username, password.toCharArray())


### PR DESCRIPTION
Otherwise, there will be less helpful exceptions and the program continues, which can be confusing during development:

```
groovy.lang.MissingMethodException: No signature of method: sun.net.www.protocol.https.HttpsURLConnectionImpl.setAuthenticator() is applicable for argument types: (io.jenkins.infra.repository_permissions_updater.ArtifactoryAPI$ArtifactoryImpl$1) values: [io.jenkins.infra.repository_permissions_updater.ArtifactoryAPI$ArtifactoryImpl$1@5629510]
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:71)
        at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:128)
        at io.jenkins.infra.repository_permissions_updater.ArtifactoryAPI$ArtifactoryImpl$__clinit__closure1.doCall(ArtifactoryAPI.groovy:283)
…