### PR TITLE
[WEBSITE-658] Add maintainers index

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ node('java') {
             archiveArtifacts 'json/*.json'
             if (infra.isTrusted()) {
                 dir('json') {
-                    publishReports ([ 'issues.index.json' ])
+                    publishReports ([ 'issues.index.json', 'maintainers.index.json' ])
                 }
             }
         }


### PR DESCRIPTION
See [WEBSITE-658](https://issues.jenkins.io/browse/WEBSITE-658)

By consuming this file, update-center2 will be able to provide up-to-date maintainer information based on actual upload permissions, rather than the usually very badly maintained information from the `pom.xml` file.

Selected sample output:

```
{
    "org.jenkins-ci.plugins:matrix-auth": [
        "danielbeck"
    ],
    "org.jenkins-ci.plugins:strict-crumb-issuer": [
        "danielbeck",
        "wfollonier"
    ]
}
```

(Accidental origin branch, sorry about that. Please delete on merge.)