### PR TITLE
Fix obsolete object (permission target, groups) deletion

### DIFF
--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -283,10 +283,12 @@ class ArtifactoryPermissionsUpdater {
         LOGGER.log(Level.INFO, "Removing extra ${kind}s from Artifactory...")
         def objects = []
         try {
-            lister.call()
+            objects = lister.call()
         } catch (Exception ex) {
             LOGGER.log(Level.WARNING, "Failed listing ${kind}s from Artifactory", ex)
         }
+
+        LOGGER.log(Level.INFO, "Discovered ${objects.size()} ${kind}s")
 
         objects.each { object ->
             if (!new File(payloadsDir, object + '.json').exists()) {

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -287,16 +287,17 @@ class ArtifactoryPermissionsUpdater {
         } catch (Exception ex) {
             LOGGER.log(Level.WARNING, "Failed listing ${kind}s from Artifactory", ex)
         }
+        if (objects != null) {
+            LOGGER.log(Level.INFO, "Discovered ${objects.size()} ${kind}s")
 
-        LOGGER.log(Level.INFO, "Discovered ${objects.size()} ${kind}s")
-
-        objects.each { object ->
-            if (!new File(payloadsDir, object + '.json').exists()) {
-                LOGGER.log(Level.INFO, "${kind.capitalize()} ${object} has no corresponding file, deleting...")
-                try {
-                    deleter.call(object)
-                } catch (Exception ex) {
-                    LOGGER.log(Level.WARNING, "Failed to delete ${kind} ${object} from Artifactory", ex)
+            objects.each { object ->
+                if (!new File(payloadsDir, object + '.json').exists()) {
+                    LOGGER.log(Level.INFO, "${kind.capitalize()} ${object} has no corresponding file, deleting...")
+                    try {
+                        deleter.call(object)
+                    } catch (Exception ex) {
+                        LOGGER.log(Level.WARNING, "Failed to delete ${kind} ${object} from Artifactory", ex)
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://github.com/jenkins-infra/repository-permissions-updater/pull/1747 refactored the code quite a bit, and it looks like I messed this up at some point. We don't use the value returns here, so obsolete objects aren't getting deleted.

Based on the diff I don't think this has had any impact, but it might in the future.

Real diff: https://github.com/jenkins-infra/repository-permissions-updater/pull/1883/files?w=1