### PR TITLE
Update git plugin maintainer list

### DIFF
--- a/permissions/plugin-git-client.yml
+++ b/permissions/plugin-git-client.yml
@@ -6,6 +6,7 @@ paths:
 - "org/jenkinsci/plugins/git-client"
 developers:
 - "markewaite"
+- "mramonleon"
 - "rsandell"
 security:
     contacts:

--- a/permissions/plugin-git-client.yml
+++ b/permissions/plugin-git-client.yml
@@ -7,7 +7,6 @@ paths:
 developers:
 - "markewaite"
 - "rsandell"
-- "fcojfernandez"
 security:
     contacts:
       jira: "foundation_security_members"

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -8,7 +8,6 @@ paths:
 developers:
 - "markewaite"
 - "rsandell"
-- "fcojfernandez"
 security:
     contacts:
       jira: "foundation_security_members"

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -7,6 +7,7 @@ paths:
 - "org/jvnet/hudson/plugins/git"
 developers:
 - "markewaite"
+- "mramonleon"
 - "rsandell"
 security:
     contacts:


### PR DESCRIPTION
# Update [git](https://github.com/jenkinsci/git-plugin) and [git client](https://github.com/jenkinsci/git-client-plugin) plugin maintainer list

- Remove fcojfernandez from git client and git plugins
- Add Ramon Leon as a git and git client plugin maintainer

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
