### PR TITLE
Add timja to co-maintained azure plugins and enable CD

### DIFF
--- a/permissions/component-azure-commons-core.yml
+++ b/permissions/component-azure-commons-core.yml
@@ -6,3 +6,4 @@ developers:
 - "chenkennt"
 - "arieshout"
 - "azure_devops"
+- "timja"

--- a/permissions/plugin-azure-ad.yml
+++ b/permissions/plugin-azure-ad.yml
@@ -3,8 +3,11 @@ name: "azure-ad"
 github: "jenkinsci/azure-ad-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-ad"
+cd:
+  enabled: true
 developers:
 - "chenkennt"
 - "arieshout"
 - "raphaelyu"
 - "azure_devops"
+- "timja"

--- a/permissions/plugin-azure-artifact-manager.yml
+++ b/permissions/plugin-azure-artifact-manager.yml
@@ -3,5 +3,8 @@ name: "azure-artifact-manager"
 github: "jenkinsci/azure-artifact-manager-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-artifact-manager"
+cd:
+  enabled: true
 developers:
 - "azure_devops"
+- "timja"

--- a/permissions/plugin-azure-commons.yml
+++ b/permissions/plugin-azure-commons.yml
@@ -3,7 +3,10 @@ name: "azure-commons"
 github: "jenkinsci/azure-commons-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-commons"
+cd:
+  enabled: true
 developers:
 - "chenkennt"
 - "arieshout"
 - "azure_devops"
+- "timja"

--- a/permissions/plugin-azure-container-agents.yml
+++ b/permissions/plugin-azure-container-agents.yml
@@ -3,7 +3,10 @@ name: "azure-container-agents"
 github: "jenkinsci/azure-container-agents-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-container-agents"
+cd:
+  enabled: true
 developers:
 - "chenkennt"
 - "arieshout"
 - "azure_devops"
+- "timja"

--- a/permissions/plugin-azure-credentials.yml
+++ b/permissions/plugin-azure-credentials.yml
@@ -3,9 +3,12 @@ name: "azure-credentials"
 github: "jenkinsci/azure-credentials-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-credentials"
+cd:
+  enabled: true
 developers:
 - "clguiman"
 - "arroyc_microsoft"
 - "chenkennt"
 - "arieshout"
 - "azure_devops"
+- "timja"

--- a/permissions/plugin-azure-keyvault.yml
+++ b/permissions/plugin-azure-keyvault.yml
@@ -3,5 +3,7 @@ name: "azure-keyvault"
 github: "jenkinsci/azure-keyvault-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-keyvault"
+cd:
+  enabled: true
 developers:
 - "timja"

--- a/permissions/plugin-azure-vm-agents.yml
+++ b/permissions/plugin-azure-vm-agents.yml
@@ -3,9 +3,12 @@ name: "azure-vm-agents"
 github: "jenkinsci/azure-vm-agents-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-vm-agents"
+cd:
+  enabled: true
 developers:
 - "clguiman"
 - "arroyc_microsoft"
 - "chenkennt"
 - "arieshout"
 - "azure_devops"
+- "timja"

--- a/permissions/plugin-jenkins-infra-test.yml
+++ b/permissions/plugin-jenkins-infra-test.yml
@@ -3,7 +3,8 @@ name: "jenkins-infra-test"
 github: "jenkinsci/jenkins-infra-test-plugin"
 paths:
 - "io/jenkins/plugins/jenkins-infra-test"
+cd:
+  enabled: true
 developers:
 - "timja"
 - "olblak"
-

--- a/permissions/plugin-windows-azure-storage.yml
+++ b/permissions/plugin-windows-azure-storage.yml
@@ -3,6 +3,8 @@ name: "windows-azure-storage"
 github: "jenkinsci/windows-azure-storage-plugin"
 paths:
 - "org/jenkins-ci/plugins/windows-azure-storage"
+cd:
+  enabled: true
 developers:
 - "snallami"
 - "clguiman"
@@ -10,3 +12,4 @@ developers:
 - "chenkennt"
 - "arieshout"
 - "azure_devops"
+- "timja"

--- a/permissions/pom-azure-commons-parent.yml
+++ b/permissions/pom-azure-commons-parent.yml
@@ -6,3 +6,4 @@ developers:
 - "chenkennt"
 - "arieshout"
 - "azure_devops"
+- "timja"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

 jenkinsci/azure-container-agents-plugin
 jenkinsci/azure-vm-agents-plugin
 jenkinsci/azure-ad-plugin
 jenkinsci/azure-commons-plugin
 jenkinsci/windows-azure-storage-plugin
 jenkinsci/azure-artifact-manager-plugin
 jenkinsci/azure-credentials-plugin
 jenkinsci/azure-keyvault-plugin

 jenkinsci/jenkins-infra-test-plugin - I plan to use this to experiment with the GH action first

@xuzhang3 for approval

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
