### PR TITLE
Cleanup Azure permissions

### DIFF
--- a/permissions/component-azure-commons-core.yml
+++ b/permissions/component-azure-commons-core.yml
@@ -3,7 +3,5 @@ name: "azure-commons-core"
 paths:
 - "org/jenkins-ci/plugins/azure-commons-core"
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/plugin-azure-acs.yml
+++ b/permissions/plugin-azure-acs.yml
@@ -4,6 +4,4 @@ github: "jenkinsci/azure-acs-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-acs"
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"

--- a/permissions/plugin-azure-ad.yml
+++ b/permissions/plugin-azure-ad.yml
@@ -6,8 +6,5 @@ paths:
 cd:
   enabled: true
 developers:
-- "chenkennt"
-- "arieshout"
-- "raphaelyu"
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/plugin-azure-app-service.yml
+++ b/permissions/plugin-azure-app-service.yml
@@ -4,6 +4,4 @@ github: "jenkinsci/azure-app-service-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-app-service"
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"

--- a/permissions/plugin-azure-artifact-manager.yml
+++ b/permissions/plugin-azure-artifact-manager.yml
@@ -6,5 +6,5 @@ paths:
 cd:
   enabled: true
 developers:
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/plugin-azure-commons.yml
+++ b/permissions/plugin-azure-commons.yml
@@ -6,7 +6,5 @@ paths:
 cd:
   enabled: true
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/plugin-azure-container-agents.yml
+++ b/permissions/plugin-azure-container-agents.yml
@@ -6,7 +6,5 @@ paths:
 cd:
   enabled: true
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/plugin-azure-container-registry-tasks.yml
+++ b/permissions/plugin-azure-container-registry-tasks.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/azure-container-registry-tasks-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-container-registry-tasks"
 developers:
-- "azure_devops"
+- "zooopx"

--- a/permissions/plugin-azure-credentials.yml
+++ b/permissions/plugin-azure-credentials.yml
@@ -6,9 +6,5 @@ paths:
 cd:
   enabled: true
 developers:
-- "clguiman"
-- "arroyc_microsoft"
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/plugin-azure-dev-spaces.yml
+++ b/permissions/plugin-azure-dev-spaces.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/azure-dev-spaces-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-dev-spaces"
 developers:
-- "azure_devops"
+- "zooopx"

--- a/permissions/plugin-azure-function.yml
+++ b/permissions/plugin-azure-function.yml
@@ -4,6 +4,4 @@ github: "jenkinsci/azure-function-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-function"
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"

--- a/permissions/plugin-azure-vm-agents.yml
+++ b/permissions/plugin-azure-vm-agents.yml
@@ -6,9 +6,5 @@ paths:
 cd:
   enabled: true
 developers:
-- "clguiman"
-- "arroyc_microsoft"
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/plugin-azure-vmss.yml
+++ b/permissions/plugin-azure-vmss.yml
@@ -4,6 +4,4 @@ github: "jenkinsci/azure-vmss-plugin"
 paths:
 - "org/jenkins-ci/plugins/azure-vmss"
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"

--- a/permissions/plugin-kubernetes-cd.yml
+++ b/permissions/plugin-kubernetes-cd.yml
@@ -4,6 +4,4 @@ github: "jenkinsci/kubernetes-cd-plugin"
 paths:
 - "org/jenkins-ci/plugins/kubernetes-cd"
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"

--- a/permissions/plugin-windows-azure-storage.yml
+++ b/permissions/plugin-windows-azure-storage.yml
@@ -6,10 +6,5 @@ paths:
 cd:
   enabled: true
 developers:
-- "snallami"
-- "clguiman"
-- "arroyc_microsoft"
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"
 - "timja"

--- a/permissions/pom-azure-commons-parent.yml
+++ b/permissions/pom-azure-commons-parent.yml
@@ -3,7 +3,5 @@ name: "azure-commons-parent"
 paths:
 - "org/jenkins-ci/plugins/azure-commons-parent"
 developers:
-- "chenkennt"
-- "arieshout"
-- "azure_devops"
+- "zooopx"
 - "timja"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

> Hi Tim,
 
> Do you know where the plugin main page sync from? The  maintainer list is incorrect. There should  be only you and me in the maintainer list but so are Claudiu, Arjun etc. old team members. Most importantly, Azure DevOps is still included.
> All the 7 plugin’s main page have been changed recently:
> Windows Azure Storage
> Azure Credentials 
> Azure Commons
> Azure VM Agents
> Azure Container Agents
> Azure Artifact Manager
> Azure AD

Xu asked me if I could update the maintainers list to the actual ones. 2 of the plugins are retired but I've changed it to Xu in case a release is needed for EOL for whatever reason

cc @xuzhang3 for approval

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
