### PR TITLE
Remove Stephen Connolly from components he no longer maintains

### DIFF
--- a/permissions/component-executable-war.yml
+++ b/permissions/component-executable-war.yml
@@ -5,6 +5,5 @@ paths:
 - "org/jenkins-ci/executable-war"
 developers:
 - "kohsuke"
-- "stephenconnolly"
 - "oleg_nenashev"
 - "batmat"

--- a/permissions/component-instance-identity.yml
+++ b/permissions/component-instance-identity.yml
@@ -6,6 +6,5 @@ paths:
 developers:
 - "jglick"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "batmat"
 - "timja"

--- a/permissions/component-jenkins-test-harness.yml
+++ b/permissions/component-jenkins-test-harness.yml
@@ -11,7 +11,6 @@ developers:
 - "jglick"
 - "kohsuke"
 - "olivergondza"
-- "stephenconnolly"
 - "svanoort"
 - "tfennelly"
 - "olamy"

--- a/permissions/component-jnr-ffi.yml
+++ b/permissions/component-jnr-ffi.yml
@@ -2,5 +2,4 @@
 name: "jnr-ffi"
 paths:
 - "com/github/jnr/jnr-ffi"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/component-literate-api.yml
+++ b/permissions/component-literate-api.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/literate-api"
 paths:
 - "org/jenkins-ci/literate/literate-api"
 developers:
-- "stephenconnolly"
 - "vlatombe"

--- a/permissions/component-maven-hpi-plugin.yml
+++ b/permissions/component-maven-hpi-plugin.yml
@@ -7,7 +7,6 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
-- "stephenconnolly"
 - "olamy"
 - "oleg_nenashev"
 - "batmat"

--- a/permissions/component-optional-plugin-helper.yml
+++ b/permissions/component-optional-plugin-helper.yml
@@ -3,5 +3,4 @@ name: "optional-plugin-helper"
 github: "jenkinsci/optional-plugin-helper-module"
 paths:
 - "org/jenkins-ci/modules/optional-plugin-helper"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/component-pipeline-model-json-shaded.yml
+++ b/permissions/component-pipeline-model-json-shaded.yml
@@ -6,5 +6,4 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "rsandell"

--- a/permissions/component-sshd-core.yml
+++ b/permissions/component-sshd-core.yml
@@ -2,5 +2,4 @@
 name: "sshd-core"
 paths:
 - "org/apache/sshd/sshd-core"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/component-sshd-pam.yml
+++ b/permissions/component-sshd-pam.yml
@@ -2,5 +2,4 @@
 name: "sshd-pam"
 paths:
 - "org/apache/sshd/sshd-pam"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/component-sshd-sftp.yml
+++ b/permissions/component-sshd-sftp.yml
@@ -2,5 +2,4 @@
 name: "sshd-sftp"
 paths:
 - "org/apache/sshd/sshd-sftp"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/component-support-log-formatter.yml
+++ b/permissions/component-support-log-formatter.yml
@@ -7,4 +7,3 @@ developers:
 - "batmat"
 - "jglick"
 - "oleg_nenashev"
-- "stephenconnolly"

--- a/permissions/component-symbol-annotation.yml
+++ b/permissions/component-symbol-annotation.yml
@@ -7,7 +7,6 @@ developers:
 - "jglick"
 - "kohsuke"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "abayer"
 - "svanoort"
 - "dnusbaum"

--- a/permissions/component-trilead-ssh2.yml
+++ b/permissions/component-trilead-ssh2.yml
@@ -6,6 +6,5 @@ paths:
 - "org/jvnet/hudson/trilead-ssh2"
 developers:
 - "kohsuke"
-- "stephenconnolly"
 - "mc1arke"
 - "ifernandezcalvo"

--- a/permissions/component-version-number.yml
+++ b/permissions/component-version-number.yml
@@ -7,6 +7,5 @@ developers:
 - "batmat"
 - "jglick"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "kohsuke"
 - "timja"

--- a/permissions/plugin-active-directory.yml
+++ b/permissions/plugin-active-directory.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "fbelzunc"
 - "kohsuke"
-- "stephenconnolly"
 - "alecharp"
 - "batmat"
 - "egutierrez"

--- a/permissions/plugin-async-http-client.yml
+++ b/permissions/plugin-async-http-client.yml
@@ -11,7 +11,6 @@ developers:
 - "fcojfernandez"
 - "mramonleon"
 - "rsandell"
-- "stephenconnolly"
 security:
   contacts:
     jira: "foundation_security_members"

--- a/permissions/plugin-authentication-tokens.yml
+++ b/permissions/plugin-authentication-tokens.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/authentication-tokens-plugin"
 paths:
 - "org/jenkins-ci/plugins/authentication-tokens"
 developers:
-- "stephenconnolly"
 - "alecharp"
 - "batmat"
 - "egutierrez"

--- a/permissions/plugin-basic-branch-build-strategies.yml
+++ b/permissions/plugin-basic-branch-build-strategies.yml
@@ -4,6 +4,5 @@ github: "jenkinsci/basic-branch-build-strategies-plugin"
 paths:
 - "org/jenkins-ci/plugins/basic-branch-build-strategies"
 developers:
-- "stephenconnolly"
 - "rsandell"
 - "bitwiseman"

--- a/permissions/plugin-bouncycastle-api.yml
+++ b/permissions/plugin-bouncycastle-api.yml
@@ -5,6 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/bouncycastle-api"
 developers:
 - "alobato"
-- "stephenconnolly"
 - "dnusbaum"
 - "jthompson"

--- a/permissions/plugin-branch-api.yml
+++ b/permissions/plugin-branch-api.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "jglick"
 - "recena"
-- "stephenconnolly"
 - "abayer"
 - "svanoort"
 - "rsandell"

--- a/permissions/plugin-build-token-trigger.yml
+++ b/permissions/plugin-build-token-trigger.yml
@@ -3,5 +3,4 @@ name: "build-token-trigger"
 github: "jenkinsci/build-token-trigger-plugin"
 paths:
 - "org/jenkins-ci/plugins/build-token-trigger"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-chaos-butler.yml
+++ b/permissions/plugin-chaos-butler.yml
@@ -2,5 +2,4 @@
 name: "chaos-butler"
 paths:
 - "org/jenkins-ci/plugins/chaos-butler"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-cloudbees-bitbucket-branch-source.yml
+++ b/permissions/plugin-cloudbees-bitbucket-branch-source.yml
@@ -10,6 +10,5 @@ developers:
 - "carroll"
 - "dnusbaum"
 - "rsandell"
-- "stephenconnolly"
 - "svanoort"
 - "jtaboada"

--- a/permissions/plugin-cloudbees-deployer-plugin.yml
+++ b/permissions/plugin-cloudbees-deployer-plugin.yml
@@ -3,5 +3,4 @@ name: "cloudbees-deployer-plugin"
 github: "jenkinsci/cloudbees-deployer-plugin"
 paths:
 - "org/jenkins-ci/plugins/cloudbees-deployer-plugin"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-cloudbees-enterprise-plugins.yml
+++ b/permissions/plugin-cloudbees-enterprise-plugins.yml
@@ -5,4 +5,3 @@ paths:
 - "org/jenkins-ci/plugins/cloudbees-enterprise-plugins"
 developers:
 - "jglick"
-- "stephenconnolly"

--- a/permissions/plugin-cloudbees-folder.yml
+++ b/permissions/plugin-cloudbees-folder.yml
@@ -8,7 +8,6 @@ developers:
 - "kohsuke"
 - "oleg_nenashev"
 - "recena"
-- "stephenconnolly"
 - "dnusbaum"
 - "rsandell"
 - "fcojfernandez"

--- a/permissions/plugin-cloudbees-plugin-gateway.yml
+++ b/permissions/plugin-cloudbees-plugin-gateway.yml
@@ -3,5 +3,4 @@ name: "cloudbees-plugin-gateway"
 github: "jenkinsci/cloudbees-plugin-gateway"
 paths:
 - "org/jenkins-ci/plugins/cloudbees-plugin-gateway"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-credentials-binding.yml
+++ b/permissions/plugin-credentials-binding.yml
@@ -5,6 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/credentials-binding"
 developers:
 - "jglick"
-- "stephenconnolly"
 - "jvz"
 - "wfollonier"

--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "jglick"
 - "kohsuke"
-- "stephenconnolly"
 - "oleg_nenashev"
 - "jvz"
 - "jthompson"

--- a/permissions/plugin-dashboard-view.yml
+++ b/permissions/plugin-dashboard-view.yml
@@ -6,7 +6,6 @@ paths:
 - "org/jvnet/hudson/plugins/dashboard-view"
 developers:
 - "olivergondza"
-- "stephenconnolly"
 - "tgr"
 - "vandyev"
 security:

--- a/permissions/plugin-deployer-framework.yml
+++ b/permissions/plugin-deployer-framework.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/deployer-framework-plugin"
 paths:
 - "org/jenkins-ci/plugins/deployer-framework"
 developers:
-- "stephenconnolly"
 - "jvz"
 - "alecharp"
 - "batmat"

--- a/permissions/plugin-display-url-api.yml
+++ b/permissions/plugin-display-url-api.yml
@@ -8,7 +8,6 @@ developers:
 - "michaelneale"
 - "vivek"
 - "imeredith"
-- "stephenconnolly"
 - "abayer"
 - "carroll"
 - "dnusbaum"

--- a/permissions/plugin-github-api.yml
+++ b/permissions/plugin-github-api.yml
@@ -11,7 +11,6 @@ developers:
 - "ohtake_tomohiro"
 - "recena"
 - "surya548"
-- "stephenconnolly"
 security:
   contacts:
     jira: "foundation_security_members"

--- a/permissions/plugin-github-branch-source.yml
+++ b/permissions/plugin-github-branch-source.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "jglick"
 - "recena"
-- "stephenconnolly"
 - "abayer"
 - "svanoort"
 - "rsandell"

--- a/permissions/plugin-github-organization-folder.yml
+++ b/permissions/plugin-github-organization-folder.yml
@@ -7,4 +7,3 @@ developers:
 - "jglick"
 - "kohsuke"
 - "recena"
-- "stephenconnolly"

--- a/permissions/plugin-greenballs.yml
+++ b/permissions/plugin-greenballs.yml
@@ -6,5 +6,4 @@ paths:
 - "org/jvnet/hudson/plugins/greenballs"
 developers:
 - "asgeirn"
-- "stephenconnolly"
 - "nfalco"

--- a/permissions/plugin-impersonation.yml
+++ b/permissions/plugin-impersonation.yml
@@ -3,5 +3,4 @@ name: "impersonation"
 github: "jenkinsci/impersonation-plugin"
 paths:
 - "org/jenkins-ci/plugins/impersonation"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-jackson2-api.yml
+++ b/permissions/plugin-jackson2-api.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/jackson2-api-plugin"
 paths:
 - "org/jenkins-ci/plugins/jackson2-api"
 developers:
-- "stephenconnolly"
 - "oleg_nenashev"
 - "dnusbaum"
 - "jvz"

--- a/permissions/plugin-jsoup.yml
+++ b/permissions/plugin-jsoup.yml
@@ -3,5 +3,4 @@ name: "jsoup"
 github: "jenkinsci/jsoup-plugin"
 paths:
 - "org/jenkins-ci/plugins/jsoup"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-ldap.yml
+++ b/permissions/plugin-ldap.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "andresrc"
 - "kohsuke"
-- "stephenconnolly"
 - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-literate.yml
+++ b/permissions/plugin-literate.yml
@@ -5,4 +5,3 @@ paths:
 - "org/jenkins-ci/plugins/literate"
 developers:
 - "jglick"
-- "stephenconnolly"

--- a/permissions/plugin-mansion-cloud.yml
+++ b/permissions/plugin-mansion-cloud.yml
@@ -6,5 +6,4 @@ paths:
 developers:
 - "michaelneale"
 - "recampbell"
-- "stephenconnolly"
 - "ydubreuil"

--- a/permissions/plugin-mapdb-api.yml
+++ b/permissions/plugin-mapdb-api.yml
@@ -3,5 +3,4 @@ name: "mapdb-api"
 github: "jenkinsci/mapdb-api-plugin"
 paths:
 - "org/jenkins-ci/plugins/mapdb-api"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -6,7 +6,6 @@ paths:
 - "org/jvnet/hudson/plugins/mercurial"
 developers:
 - "jglick"
-- "stephenconnolly"
 - "alecharp"
 - "batmat"
 - "egutierrez"

--- a/permissions/plugin-metrics-diskusage.yml
+++ b/permissions/plugin-metrics-diskusage.yml
@@ -3,5 +3,4 @@ name: "metrics-diskusage"
 github: "jenkinsci/metrics-diskusage-plugin"
 paths:
 - "org/jenkins-ci/plugins/metrics-diskusage"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-metrics-ganglia.yml
+++ b/permissions/plugin-metrics-ganglia.yml
@@ -3,5 +3,4 @@ name: "metrics-ganglia"
 github: "jenkinsci/metrics-ganglia-plugin"
 paths:
 - "org/jenkins-ci/plugins/metrics-ganglia"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-metrics-graphite.yml
+++ b/permissions/plugin-metrics-graphite.yml
@@ -3,5 +3,4 @@ name: "metrics-graphite"
 github: "jenkinsci/metrics-graphite-plugin"
 paths:
 - "org/jenkins-ci/plugins/metrics-graphite"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-metrics.yml
+++ b/permissions/plugin-metrics.yml
@@ -5,7 +5,6 @@ paths:
 - "org/jenkins-ci/plugins/metrics"
 developers:
 - "kohsuke"
-- "stephenconnolly"
 - "sbadger"
 - "alecharp"
 - "mramonleon"

--- a/permissions/plugin-mock-load-builder.yml
+++ b/permissions/plugin-mock-load-builder.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/mock-load-builder-plugin"
 paths:
 - "org/jenkins-ci/plugins/mock-load-builder"
 developers:
-- "stephenconnolly"
 - "vlatombe"

--- a/permissions/plugin-mock-security-realm.yml
+++ b/permissions/plugin-mock-security-realm.yml
@@ -5,5 +5,4 @@ paths:
 - "org/jenkins-ci/plugins/mock-security-realm"
 developers:
 - "jglick"
-- "stephenconnolly"
 - "rarabaolaza"

--- a/permissions/plugin-node-iterator-api.yml
+++ b/permissions/plugin-node-iterator-api.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/node-iterator-api-plugin"
 paths:
 - "org/jenkins-ci/plugins/node-iterator-api"
 developers:
-- "stephenconnolly"
 - "alecharp"
 - "batmat"
 - "egutierrez"

--- a/permissions/plugin-nodenamecolumn.yml
+++ b/permissions/plugin-nodenamecolumn.yml
@@ -3,5 +3,4 @@ name: "nodenamecolumn"
 github: "jenkinsci/nodenamecolumn-plugin"
 paths:
 - "org/jenkins-ci/plugins/nodenamecolumn"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-openid4java.yml
+++ b/permissions/plugin-openid4java.yml
@@ -3,5 +3,4 @@ name: "openid4java"
 github: "jenkinsci/openid4java-plugin"
 paths:
 - "org/jenkins-ci/plugins/openid4java"
-developers:
-- "stephenconnolly"
+developers: []

--- a/permissions/plugin-pam-auth.yml
+++ b/permissions/plugin-pam-auth.yml
@@ -6,5 +6,4 @@ paths:
 developers:
 - "danielbeck"
 - "recena"
-- "stephenconnolly"
 - "jvz"

--- a/permissions/plugin-pipeline-github-lib.yml
+++ b/permissions/plugin-pipeline-github-lib.yml
@@ -5,7 +5,6 @@ paths:
 - "org/jenkins-ci/plugins/pipeline-github-lib"
 developers:
 - "jglick"
-- "stephenconnolly"
 - "abayer"
 - "dnusbaum"
 - "rsandell"

--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "rsandell"
 - "svanoort"
 - "bitwiseman"

--- a/permissions/plugin-pipeline-model-declarative-agent.yml
+++ b/permissions/plugin-pipeline-model-declarative-agent.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "rsandell"
 - "bitwiseman"
 - "dnusbaum"

--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "rsandell"
 - "svanoort"
 - "bitwiseman"

--- a/permissions/plugin-pipeline-model-extensions.yml
+++ b/permissions/plugin-pipeline-model-extensions.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "rsandell"
 - "svanoort"
 - "bitwiseman"

--- a/permissions/plugin-pipeline-stage-tags-metadata.yml
+++ b/permissions/plugin-pipeline-stage-tags-metadata.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "rsandell"
 - "svanoort"
 - "bitwiseman"

--- a/permissions/plugin-plain-credentials.yml
+++ b/permissions/plugin-plain-credentials.yml
@@ -5,6 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/plain-credentials"
 developers:
 - "jglick"
-- "stephenconnolly"
 - "jthompson"
 - "wfollonier"

--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -8,7 +8,6 @@ developers:
 - "dnozay"
 - "jglick"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "wolfs"
 - "dnusbaum"
 - "teilo"

--- a/permissions/plugin-publish-over-ssh.yml
+++ b/permissions/plugin-publish-over-ssh.yml
@@ -6,4 +6,3 @@ paths:
 - "org/jvnet/hudson/plugins/publish-over-ssh"
 developers:
 - "r2b2_nz"
-- "stephenconnolly"

--- a/permissions/plugin-purge-job-history.yml
+++ b/permissions/plugin-purge-job-history.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/purge-job-history-plugin"
 paths:
 - "org/jenkins-ci/plugins/purge-job-history"
 developers:
-- "stephenconnolly"
 - "aytuncbeken"
 security:
   contacts:

--- a/permissions/plugin-random-job-builder.yml
+++ b/permissions/plugin-random-job-builder.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/random-job-builder-plugin"
 paths:
 - "org/jenkins-ci/plugins/random-job-builder"
 developers:
-- "stephenconnolly"
 - "svanoort"

--- a/permissions/plugin-scm-api.yml
+++ b/permissions/plugin-scm-api.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "jglick"
 - "recena"
-- "stephenconnolly"
 - "abayer"
 - "svanoort"
 - "rsandell"

--- a/permissions/plugin-ssh-agent.yml
+++ b/permissions/plugin-ssh-agent.yml
@@ -7,7 +7,6 @@ developers:
 - "jglick"
 - "kohsuke"
 - "recena"
-- "stephenconnolly"
 - "alecharp"
 - "batmat"
 - "egutierrez"

--- a/permissions/plugin-ssh-credentials.yml
+++ b/permissions/plugin-ssh-credentials.yml
@@ -5,7 +5,6 @@ paths:
 - "org/jenkins-ci/plugins/ssh-credentials"
 developers:
 - "jglick"
-- "stephenconnolly"
 - "oleg_nenashev"
 - "jvz"
 - "jthompson"

--- a/permissions/plugin-ssh-slaves.yml
+++ b/permissions/plugin-ssh-slaves.yml
@@ -7,7 +7,6 @@ developers:
 - "andresrc"
 - "jglick"
 - "kohsuke"
-- "stephenconnolly"
 - "oleg_nenashev"
 - "ifernandezcalvo"
 security:

--- a/permissions/plugin-structs.yml
+++ b/permissions/plugin-structs.yml
@@ -7,7 +7,6 @@ developers:
 - "jglick"
 - "kohsuke"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "abayer"
 - "svanoort"
 - "dnusbaum"

--- a/permissions/plugin-subversion.yml
+++ b/permissions/plugin-subversion.yml
@@ -9,7 +9,6 @@ developers:
 - "kutzi"
 - "recena"
 - "schristou"
-- "stephenconnolly"
 - "oleg_nenashev"
 - "ifernandezcalvo"
 - "timja"

--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -7,7 +7,6 @@ developers:
 - "jglick"
 - "kohsuke"
 - "schristou"
-- "stephenconnolly"
 - "batmat"
 - "owood"
 - "escoem"

--- a/permissions/plugin-unique-id.yml
+++ b/permissions/plugin-unique-id.yml
@@ -7,7 +7,6 @@ developers:
 - "andresrc"
 - "oleg_nenashev"
 - "recampbell"
-- "stephenconnolly"
 - "oleg_nenashev"
 security:
   contacts:

--- a/permissions/plugin-workflow-multibranch.yml
+++ b/permissions/plugin-workflow-multibranch.yml
@@ -7,7 +7,6 @@ developers:
 - "jglick"
 - "recena"
 - "abayer"
-- "stephenconnolly"
 - "svanoort"
 - "dnusbaum"
 - "rsandell"

--- a/permissions/pom-pipeline-model-parent.yml
+++ b/permissions/pom-pipeline-model-parent.yml
@@ -6,7 +6,6 @@ paths:
 developers:
 - "abayer"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "rsandell"
 - "bitwiseman"
 - "dnusbaum"

--- a/permissions/pom-plugin.yml
+++ b/permissions/pom-plugin.yml
@@ -9,7 +9,6 @@ developers:
 - "jglick"
 - "kohsuke"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "tfennelly"
 - "batmat"
 - "timja"

--- a/permissions/pom-structs-parent.yml
+++ b/permissions/pom-structs-parent.yml
@@ -7,7 +7,6 @@ developers:
 - "jglick"
 - "kohsuke"
 - "oleg_nenashev"
-- "stephenconnolly"
 - "abayer"
 - "svanoort"
 - "dnusbaum"


### PR DESCRIPTION
# Description

I asked @stephenc earlier today whether he still considers himself a maintainer of plugins because I saw he still was for some, and he told me, only Gitea.

So with his approval I'd like to clean up some stuff here.

The following components no longer have a maintainer with this change:

* The components `jnr-ffi`, `sshd-core`, `sshd-pam`, and `sshd-sftp` (probably just mirrored into Artifactory from upstream?)
* https://github.com/jenkinsci/build-token-trigger-plugin / https://plugins.jenkins.io/build-token-trigger
* https://github.com/jenkinsci/chaos-butler-plugin / https://plugins.jenkins.io/chaos-butler
* https://github.com/jenkinsci/cloudbees-deployer-plugin (distribution suspended)
* https://github.com/jenkinsci/cloudbees-plugin-gateway / https://plugins.jenkins.io/cloudbees-plugin-gateway
* https://github.com/jenkinsci/impersonation-plugin (never released)
* https://github.com/jenkinsci/jsoup-plugin / https://plugins.jenkins.io/jsoup
* https://github.com/jenkinsci/mapdb-api-plugin / https://plugins.jenkins.io/mapdb-api
* https://github.com/jenkinsci/metrics-diskusage-plugin / https://plugins.jenkins.io/metrics-diskusage
* https://github.com/jenkinsci/metrics-ganglia-plugin / https://plugins.jenkins.io/metrics-ganglia
* https://github.com/jenkinsci/metrics-graphite-plugin / https://plugins.jenkins.io/metrics-graphite
* https://github.com/jenkinsci/nodenamecolumn-plugin / https://plugins.jenkins.io/nodenamecolumn
* https://github.com/jenkinsci/openid4java-plugin / https://plugins.jenkins.io/openid4java
* https://github.com/jenkinsci/optional-plugin-helper-module

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
