### PR TITLE
Remove myself from blueocean plugins

### DIFF
--- a/permissions/component-blueocean-test-ssh-server.yml
+++ b/permissions/component-blueocean-test-ssh-server.yml
@@ -15,4 +15,3 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"

--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-dashboard.yml
+++ b/permissions/plugin-blueocean-dashboard.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-display-url.yml
+++ b/permissions/plugin-blueocean-display-url.yml
@@ -16,6 +16,5 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "imeredith"
 - "jamesdumay"

--- a/permissions/plugin-blueocean-events.yml
+++ b/permissions/plugin-blueocean-events.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "imeredith"
 - "tscherler"
 security:

--- a/permissions/plugin-blueocean-git-pipeline.yml
+++ b/permissions/plugin-blueocean-git-pipeline.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-personalization.yml
+++ b/permissions/plugin-blueocean-personalization.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-pipeline-editor.yml
+++ b/permissions/plugin-blueocean-pipeline-editor.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-pipeline-scm-api.yml
+++ b/permissions/plugin-blueocean-pipeline-scm-api.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-rest-impl.yml
+++ b/permissions/plugin-blueocean-rest-impl.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-blueocean-web.yml
+++ b/permissions/plugin-blueocean-web.yml
@@ -16,7 +16,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 - "tscherler"
 security:
   contacts:

--- a/permissions/plugin-sse-gateway.yml
+++ b/permissions/plugin-sse-gateway.yml
@@ -18,7 +18,6 @@ developers:
 - "kshultz"
 - "bitwiseman"
 - "olamy"
-- "halkeye"
 security:
   contacts:
     jira: "pipeline_security_members"


### PR DESCRIPTION
# Description

I havn't been involved with blueocean for a few years. I've already left the github teams, but now that plugin site lists people from here, I will remove myself here too

# Submitter checklist for adding or changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
