### PR TITLE
Enable cd.enabled for conventional-commits

### DIFF
--- a/permissions/plugin-conventional-commits.yml
+++ b/permissions/plugin-conventional-commits.yml
@@ -1,6 +1,8 @@
 ---
 name: "conventional-commits"
 github: &GH "jenkinsci/conventional-commits-plugin"
+cd:
+  enabled: true
 paths:
 - "io/jenkins/plugins/conventional-commits"
 developers:


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/conventional-commits-plugin

CC @jglick 

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
