### PR TITLE
Add permission for ci-with-toad-edge plugin

### DIFF
--- a/permissions/plugin-ci-with-toad-edge.yml
+++ b/permissions/plugin-ci-with-toad-edge.yml
@@ -5,3 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/ci-with-toad-edge"
 developers:
 - "pchudani"
+- "mkumar_jenkins"
+- "tmajumda"


### PR DESCRIPTION
New permissions for ci-with-toad-edge plugin hosted in this repository.
https://github.com/jenkinsci/ci-with-toad-edge-plugin

As discussed over the INFRA jiras, we need to update the license(currently it is not OSI-approved) in order to republish the plugin.
https://issues.jenkins.io/browse/INFRA-2936
https://issues.jenkins.io/browse/INFRA-2945 

Please give the access to the github repository to the below users as maintainer of the plugin(Github: PChudani-Quest, Jenkins: pchudani) doesn't work with us(Quest Software Inc. ) anymore.

User1:
Jenkins:  mkumar_jenkins
Github:   https://github.com/mkumar-quest

User2:
Jenkins: tmajumda
Github:  https://github.com/tmajumda1

Hosting link:
https://issues.jenkins.io/browse/HOSTING-360
