### PR TITLE
File issues by default with 'Minor' priority

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -94,7 +94,7 @@ public class Definition {
             if (isJira()) {
                 final String id = loadComponentId(source);
                 if (id != null) {
-                    return "https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10172&issuetype=1&components=" + id;
+                    return "https://issues.jenkins.io/secure/CreateIssueDetails!init.jspa?pid=10172&issuetype=1&priority=4&components=" + id;
                 }
                 return null;
             }


### PR DESCRIPTION
This mirrors the configuration of Jira. For some reason, the direct
link to report issues ignores that default and goes with the first
list entry: Blocker
