### PR TITLE
Switch to pure Java sealed box

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,14 +86,14 @@
             <version>4.0.2</version>
         </dependency>
         <dependency>
-            <groupId>com.goterl.lazycode</groupId>
-            <artifactId>lazysodium-java</artifactId>
-            <version>4.3.0</version>
+            <groupId>eu.neilalexander</groupId>
+            <artifactId>jnacl</artifactId>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>5.6.0</version>
+            <groupId>org.kocakosm</groupId>
+            <artifactId>jblake2</artifactId>
+            <version>0.4</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.lib</groupId>


### PR DESCRIPTION
This re-uses a Java port of NaCl, the precursor library to libsodium, as well as a Blake2b library extracted from BouncyCastle, to port the core sealed box algorithm from libsodium to pure Java. See https://doc.libsodium.org/public-key_cryptography/sealed_boxes for the documentation on this feature and [this note in the libsodium crypto_box docs](https://doc.libsodium.org/public-key_cryptography/authenticated_encryption#notes) that explains the weird padding requirements in the original NaCl API that we are stuck with at the moment (this library seems to be one of the only Java implementations of XSalsa20-Poly1305; even BouncyCastle has some assembly required to make that).

See https://github.com/jedisct1/libsodium/blob/master/src/libsodium/crypto_box/crypto_box_seal.c for the upstream code that this is porting. Note that the `crypto_box` implementation from NaCl isn't as straightforward to invoke as the `crypto_box_easy` API introduced in libsodium.