### PR TITLE
Remove myself from plugins that I am not maintaining

### DIFF
--- a/permissions/component-analysis-config.yml
+++ b/permissions/component-analysis-config.yml
@@ -3,5 +3,4 @@ name: "analysis-config"
 github: "jenkinsci/analysis-config-plugin"
 paths:
 - "org/jvnet/hudson/plugins/analysis-config"
-developers:
-- "drulli"
+developers: []

--- a/permissions/component-analysis-test.yml
+++ b/permissions/component-analysis-test.yml
@@ -3,5 +3,4 @@ name: "analysis-test"
 github: "jenkinsci/analysis-test-plugin"
 paths:
 - "org/jvnet/hudson/plugins/analysis-test"
-developers:
-- "drulli"
+developers: []

--- a/permissions/component-library.yml
+++ b/permissions/component-library.yml
@@ -2,5 +2,4 @@
 name: "library"
 paths:
 - "org/jvnet/hudson/plugins/findbugs/library"
-developers:
-- "drulli"
+developers: []

--- a/permissions/component-swarm-client.yml
+++ b/permissions/component-swarm-client.yml
@@ -6,6 +6,5 @@ paths:
 - "org/jvnet/hudson/plugins/swarm-client"
 developers:
 - "basil"
-- "drulli"
 - "mindjiver"
 - "oleg_nenashev"

--- a/permissions/plugin-analysis-collector.yml
+++ b/permissions/plugin-analysis-collector.yml
@@ -3,5 +3,4 @@ name: "analysis-collector"
 github: "jenkinsci/analysis-collector-plugin"
 paths:
 - "org/jvnet/hudson/plugins/analysis-collector"
-developers:
-- "drulli"
+developers: []

--- a/permissions/plugin-analysis-core.yml
+++ b/permissions/plugin-analysis-core.yml
@@ -3,5 +3,4 @@ name: "analysis-core"
 github: "jenkinsci/analysis-core-plugin"
 paths:
 - "org/jvnet/hudson/plugins/analysis-core"
-developers:
-- "drulli"
+developers: []

--- a/permissions/plugin-checkstyle.yml
+++ b/permissions/plugin-checkstyle.yml
@@ -3,5 +3,4 @@ name: "checkstyle"
 github: "jenkinsci/checkstyle-plugin"
 paths:
 - "org/jvnet/hudson/plugins/checkstyle"
-developers:
-- "drulli"
+developers: []

--- a/permissions/plugin-cobertura.yml
+++ b/permissions/plugin-cobertura.yml
@@ -5,7 +5,6 @@ paths:
 - "org/jenkins-ci/plugins/cobertura"
 - "org/jvnet/hudson/plugins/cobertura"
 developers:
-- "drulli"
 - "olivergondza"
 - "tamini"
 - "mbarrien"

--- a/permissions/plugin-database-h2.yml
+++ b/permissions/plugin-database-h2.yml
@@ -4,6 +4,5 @@ github: "jenkinsci/database-h2-plugin"
 paths:
 - "org/jenkins-ci/plugins/database-h2"
 developers:
-- "drulli"
 - "timja"
 

--- a/permissions/plugin-dry.yml
+++ b/permissions/plugin-dry.yml
@@ -3,5 +3,4 @@ name: "dry"
 github: "jenkinsci/dry-plugin"
 paths:
 - "org/jvnet/hudson/plugins/dry"
-developers:
-- "drulli"
+developers: []

--- a/permissions/plugin-findbugs.yml
+++ b/permissions/plugin-findbugs.yml
@@ -3,5 +3,4 @@ name: "findbugs"
 github: "jenkinsci/findbugs-plugin"
 paths:
 - "org/jvnet/hudson/plugins/findbugs"
-developers:
-- "drulli"
+developers: []

--- a/permissions/plugin-plot.yml
+++ b/permissions/plugin-plot.yml
@@ -5,4 +5,3 @@ paths:
 - "org/jenkins-ci/plugins/plot"
 developers:
 - "ericbn"
-- "drulli"

--- a/permissions/plugin-pmd.yml
+++ b/permissions/plugin-pmd.yml
@@ -3,5 +3,4 @@ name: "pmd"
 github: "jenkinsci/pmd-plugin"
 paths:
 - "org/jvnet/hudson/plugins/pmd"
-developers:
-- "drulli"
+developers: []

--- a/permissions/plugin-publish-over-ftp.yml
+++ b/permissions/plugin-publish-over-ftp.yml
@@ -5,6 +5,5 @@ paths:
 - "org/jenkins-ci/plugins/publish-over-ftp"
 - "org/jvnet/hudson/plugins/publish-over-ftp"
 developers:
-- "drulli"
 # Not a maintainer, just tables-to-divs fixes
 - "oleg_nenashev"

--- a/permissions/plugin-swarm.yml
+++ b/permissions/plugin-swarm.yml
@@ -6,6 +6,5 @@ paths:
 - "org/jvnet/hudson/plugins/swarm"
 developers:
 - "basil"
-- "drulli"
 - "mindjiver"
 - "oleg_nenashev"

--- a/permissions/plugin-tasks.yml
+++ b/permissions/plugin-tasks.yml
@@ -3,5 +3,4 @@ name: "tasks"
 github: "jenkinsci/tasks-plugin"
 paths:
 - "org/jvnet/hudson/plugins/tasks"
-developers:
-- "drulli"
+developers: []

--- a/permissions/plugin-warnings.yml
+++ b/permissions/plugin-warnings.yml
@@ -3,5 +3,4 @@ name: "warnings"
 github: "jenkinsci/warnings-plugin"
 paths:
 - "org/jvnet/hudson/plugins/warnings"
-developers:
-- "drulli"
+developers: []

--- a/permissions/pom-analysis-pom.yml
+++ b/permissions/pom-analysis-pom.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/analysis-pom-plugin"
 paths:
 - "org/jvnet/hudson/plugins/analysis-pom"
 developers:
-- "amuniz"
 - "drulli"

--- a/permissions/pom-findbugs-parent.yml
+++ b/permissions/pom-findbugs-parent.yml
@@ -3,5 +3,4 @@ name: "parent" # file name change to disambiguate
 github: "jenkinsci/findbugs-plugin"
 paths:
 - "org/jvnet/hudson/plugins/findbugs/parent"
-developers:
-- "drulli"
+developers: []

--- a/permissions/pom-swarm-plugin.yml
+++ b/permissions/pom-swarm-plugin.yml
@@ -6,6 +6,5 @@ paths:
 - "org/jvnet/hudson/plugins/swarm-plugin"
 developers:
 - "basil"
-- "drulli"
 - "mindjiver"
 - "oleg_nenashev"


### PR DESCRIPTION
I was listed as committer because I published a release of these plugins some time ago. But now I am not contributing to these plugins anymore. 

(And the static analysis plugins are deprecated and have been removed from the update center.)

Followup to a discussion with @daniel-beck. 

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
