### PR TITLE
Update fbelzunc repo owner

### DIFF
--- a/permissions/plugin-amazon-ecr.yml
+++ b/permissions/plugin-amazon-ecr.yml
@@ -5,5 +5,4 @@ paths:
 - "com/cloudbees/jenkins/plugins/amazon-ecr"
 developers:
 - "aheritier"
-- "fbelzunc"
 - "ifernandezcalvo"

--- a/permissions/plugin-batch-task.yml
+++ b/permissions/plugin-batch-task.yml
@@ -3,4 +3,4 @@ name: "batch-task"
 github: "jenkinsci/batch-task-plugin"
 paths:
 - "org/jenkins-ci/plugins/batch-task"
-developers:
+developers: []

--- a/permissions/plugin-batch-task.yml
+++ b/permissions/plugin-batch-task.yml
@@ -4,4 +4,3 @@ github: "jenkinsci/batch-task-plugin"
 paths:
 - "org/jenkins-ci/plugins/batch-task"
 developers:
-- "fbelzunc"

--- a/permissions/plugin-bitbucket.yml
+++ b/permissions/plugin-bitbucket.yml
@@ -6,6 +6,5 @@ paths:
 developers:
 - "aheritier"
 - "imod"
-- "fbelzunc"
 - "codemonky"
 - "tzach_solomon"

--- a/permissions/plugin-deployment-notification.yml
+++ b/permissions/plugin-deployment-notification.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/deployment-notification-plugin"
 paths:
 - "org/jenkins-ci/plugins/deployment-notification"
 developers:
-- "fbelzunc"
 - "kohsuke"

--- a/permissions/plugin-puppet.yml
+++ b/permissions/plugin-puppet.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/puppet-plugin"
 paths:
 - "org/jenkins-ci/plugins/puppet"
 developers:
-- "fbelzunc"
 - "kohsuke"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I am removing myself as owner from some plugins I don't even know why I have permissions. From some others like deployment-notification and puppet, which I previously maintained, I don't have time anymore. I am just keeping the active-directory-plugin.

* https://github.com/jenkinsci/puppet-plugin
* https://github.com/jenkinsci/deployment-notification-plugin
* https://github.com/jenkinsci/bitbucket-plugin
* https://github.com/jenkinsci/batch-task-plugin
* https://github.com/jenkinsci/amazon-ecr-plugin

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
