### PR TITLE
[INFRA-2908] Enable JEP-229 on `stapler/stapler`

### DIFF
--- a/permissions/component-stapler-groovy.yml
+++ b/permissions/component-stapler-groovy.yml
@@ -2,6 +2,8 @@
 # regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler-groovy"
 github: "stapler/stapler"
+cd:
+  enabled: true
 paths:
 - "org/kohsuke/stapler/stapler-groovy"
 developers: []

--- a/permissions/component-stapler-groovy.yml
+++ b/permissions/component-stapler-groovy.yml
@@ -1,9 +1,0 @@
----
-# regularly published to OSSRH, this file exists only for incrementals support
-name: "stapler-groovy"
-github: "stapler/stapler"
-cd:
-  enabled: true
-paths:
-- "org/kohsuke/stapler/stapler-groovy"
-developers: []

--- a/permissions/component-stapler-jelly.yml
+++ b/permissions/component-stapler-jelly.yml
@@ -1,9 +1,0 @@
----
-# regularly published to OSSRH, this file exists only for incrementals support
-name: "stapler-jelly"
-github: "stapler/stapler"
-cd:
-  enabled: true
-paths:
-- "org/kohsuke/stapler/stapler-jelly"
-developers: []

--- a/permissions/component-stapler-jelly.yml
+++ b/permissions/component-stapler-jelly.yml
@@ -2,6 +2,8 @@
 # regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler-jelly"
 github: "stapler/stapler"
+cd:
+  enabled: true
 paths:
 - "org/kohsuke/stapler/stapler-jelly"
 developers: []

--- a/permissions/component-stapler-jrebel.yml
+++ b/permissions/component-stapler-jrebel.yml
@@ -1,9 +1,0 @@
----
-# regularly published to OSSRH, this file exists only for incrementals support
-name: "stapler-jrebel"
-github: "stapler/stapler"
-cd:
-  enabled: true
-paths:
-- "org/kohsuke/stapler/stapler-jrebel"
-developers: []

--- a/permissions/component-stapler-jrebel.yml
+++ b/permissions/component-stapler-jrebel.yml
@@ -2,6 +2,8 @@
 # regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler-jrebel"
 github: "stapler/stapler"
+cd:
+  enabled: true
 paths:
 - "org/kohsuke/stapler/stapler-jrebel"
 developers: []

--- a/permissions/component-stapler-jruby.yml
+++ b/permissions/component-stapler-jruby.yml
@@ -1,9 +1,0 @@
----
-# regularly published to OSSRH, this file exists only for incrementals support
-name: "stapler-jruby"
-github: "stapler/stapler"
-cd:
-  enabled: true
-paths:
-- "org/kohsuke/stapler/stapler-jruby"
-developers: []

--- a/permissions/component-stapler-jruby.yml
+++ b/permissions/component-stapler-jruby.yml
@@ -2,6 +2,8 @@
 # regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler-jruby"
 github: "stapler/stapler"
+cd:
+  enabled: true
 paths:
 - "org/kohsuke/stapler/stapler-jruby"
 developers: []

--- a/permissions/component-stapler-jsp.yml
+++ b/permissions/component-stapler-jsp.yml
@@ -2,6 +2,8 @@
 # regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler-jsp"
 github: "stapler/stapler"
+cd:
+  enabled: true
 paths:
 - "org/kohsuke/stapler/stapler-jsp"
 developers: []

--- a/permissions/component-stapler-jsp.yml
+++ b/permissions/component-stapler-jsp.yml
@@ -1,9 +1,0 @@
----
-# regularly published to OSSRH, this file exists only for incrementals support
-name: "stapler-jsp"
-github: "stapler/stapler"
-cd:
-  enabled: true
-paths:
-- "org/kohsuke/stapler/stapler-jsp"
-developers: []

--- a/permissions/component-stapler.yml
+++ b/permissions/component-stapler.yml
@@ -1,9 +1,8 @@
 ---
-# regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler"
 github: "stapler/stapler"
 cd:
   enabled: true
 paths:
-- "org/kohsuke/stapler/stapler"
+- "org/kohsuke/stapler/stapler*"
 developers: []

--- a/permissions/component-stapler.yml
+++ b/permissions/component-stapler.yml
@@ -2,6 +2,8 @@
 # regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler"
 github: "stapler/stapler"
+cd:
+  enabled: true
 paths:
 - "org/kohsuke/stapler/stapler"
 developers: []

--- a/permissions/pom-stapler-parent.yml
+++ b/permissions/pom-stapler-parent.yml
@@ -1,9 +1,0 @@
----
-# regularly published to OSSRH, this file exists only for incrementals support
-name: "stapler-parent"
-github: "stapler/stapler"
-cd:
-  enabled: true
-paths:
-- "org/kohsuke/stapler/stapler-parent"
-developers: []

--- a/permissions/pom-stapler-parent.yml
+++ b/permissions/pom-stapler-parent.yml
@@ -2,6 +2,8 @@
 # regularly published to OSSRH, this file exists only for incrementals support
 name: "stapler-parent"
 github: "stapler/stapler"
+cd:
+  enabled: true
 paths:
 - "org/kohsuke/stapler/stapler-parent"
 developers: []

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -83,8 +83,8 @@ class ArtifactoryPermissionsUpdater {
                 paths.addAll(definition.paths)
 
                 if (definition.cd && definition.getCd().enabled) {
-                    if (!definition.github.startsWith('jenkinsci/')) {
-                        throw new Exception("CD is only supported when the GitHub repository is in @jenkinsci")
+                    if (!definition.github.matches('(jenkinsci|stapler)/.+')) {
+                        throw new Exception("CD is only supported when the GitHub repository is in @jenkinsci or @stapler")
                     }
                     List<Definition> definitions = cdEnabledComponentsByGitHub[definition.github]
                     if (!definitions) {


### PR DESCRIPTION
# Description

Hoping this works to get https://github.com/stapler/stapler to have an Artifactory token. (Would be nice to refactor this repo to have one file per target repository, with potentially multiple sections for paths.)  https://issues.jenkins.io/browse/INFRA-2908

@daniel-beck @oleg-nenashev 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
