### PR TITLE
Enable CD on jenkins-test-harness-htmlunit

### DIFF
--- a/permissions/component-jenkins-test-harness-htmlunit.yml
+++ b/permissions/component-jenkins-test-harness-htmlunit.yml
@@ -1,6 +1,8 @@
 ---
 name: "jenkins-test-harness-htmlunit"
 github: "jenkinsci/jenkins-test-harness-htmlunit"
+cd:
+  enabled: true
 paths:
 - "org/jenkins-ci/main/jenkins-test-harness-htmlunit"
 developers:


### PR DESCRIPTION
# Description

After https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/11 I would like to set up CD to make it simpler to release bumps to this component. @timja @oleg-nenashev @batmat et al.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
