### PR TITLE
Enable CD on Winstone

### DIFF
--- a/permissions/component-winstone.yml
+++ b/permissions/component-winstone.yml
@@ -1,6 +1,8 @@
 ---
 name: "winstone"
 github: "jenkinsci/winstone"
+cd:
+  enabled: true
 paths:
 - "org/jenkins-ci/winstone"
 developers:


### PR DESCRIPTION
# Description

As in https://github.com/jenkinsci/winstone/pull/153#issuecomment-848551114 it would be nice to make it less overhead to release Winstone bumps. AFAICT this component is only released to Artifactory, is consumed only by Jenkins core, and is version is invisible to users (outside of `/about/`), so it seems a good candidate for JEP-229. If merged, I will follow up with a patch to `winstone`. @olamy @oleg-nenashev @timja 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
