### PR TITLE
Enable continuous delivery on mac-plugin

### DIFF
--- a/permissions/plugin-mac.yml
+++ b/permissions/plugin-mac.yml
@@ -7,3 +7,5 @@ paths:
 - "fr/edf/jenkins/plugins/mac"
 developers:
 - "mat1e"
+cd:
+  enabled: true


### PR DESCRIPTION
Enable continuous delivery on mac-plugin to setting up automated plugin release.
Plugin link :  [https://github.com/jenkinsci/mac-plugin](https://github.com/jenkinsci/mac-plugin)
