### PR TITLE
Enable CD for `mock-slave`

### DIFF
--- a/permissions/plugin-mock-slave.yml
+++ b/permissions/plugin-mock-slave.yml
@@ -1,6 +1,8 @@
 ---
 name: "mock-slave"
 github: "jenkinsci/mock-slave-plugin"
+cd:
+  enabled: true
 issues:
 - jira: '17334' # mock-slave-plugin
 paths:


### PR DESCRIPTION
# Description

To more easily release the likes of https://github.com/jenkinsci/mock-slave-plugin/pull/101.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
