### PR TITLE
Enable continuous delivery for the Nuclei plugin

### DIFF
--- a/permissions/plugin-nuclei.yml
+++ b/permissions/plugin-nuclei.yml
@@ -7,3 +7,5 @@ developers:
 - "forgedhallpass"
 issues:
   - github: *GH
+cd:
+  enabled: true


### PR DESCRIPTION
Enabling continuous delivery for the nuclei plugin.