### PR TITLE
Use lowercase in a username

### DIFF
--- a/permissions/plugin-thycotic-vault.yml
+++ b/permissions/plugin-thycotic-vault.yml
@@ -4,6 +4,6 @@ github: "jenkinsci/thycotic-vault-plugin"
 issues:
 - jira: '25723' # thycotic-vault-plugin
 paths:
-  - "com/thycotic/thycotic-vault"
+- "com/thycotic/thycotic-vault"
 developers:
-  - "thycotic_DSV"
+- "thycotic_dsv"


### PR DESCRIPTION
There is a mismatch between `plugin-thycotic-secret-server.yml` and `plugin-thycotic-vault.yml` -- I assume the lowercase version can be used in both cases.

Inconsistency introduced in #2007