### PR TITLE
Enable CD flag for servicenow-devops-plugin

### DIFF
--- a/permissions/plugin-servicenow-devops.yml
+++ b/permissions/plugin-servicenow-devops.yml
@@ -1,0 +1,11 @@
+---
+name: "servicenow-devops"
+github: "jenkinsci/servicenow-devops-plugin"
+issues:
+- jira: '28628' #servicenow-devops-plugin HOSTING-1111
+paths:
+- "io/jenkins/plugins/servicenow-devops"
+developers:
+- "bhavani_velivala"
+cd:
+  enabled: true


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Github repository : https://github.com/jenkinsci/servicenow-devops-plugin
https://issues.jenkins.io/browse/HOSTING-1111


<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above


### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
