### PR TITLE
Add developers/enable ci for oak9-plugin

### DIFF
--- a/permissions/plugin-oak9.yml
+++ b/permissions/plugin-oak9.yml
@@ -2,8 +2,13 @@
 name: "oak9"
 github: &GH "jenkinsci/oak9-plugin"
 paths:
-- "io/jenkins/plugins/oak9"
+  - "io/jenkins/plugins/oak9"
 developers:
-- "oak9_michaelgrosser"
+  - "oak9_michaelgrosser"
+  - "mherro_oak9"
+  - "jreiner_oak9"
+  - "rpateloak9"
 issues:
   - jira: 28631
+cd:
+  enabled: true


### PR DESCRIPTION
# Description

Adds additional oak9 developers to manage the distribution of https://github.com/jenkinsci/oak9-plugin. I am currently the only developer in the permissions list.

The newly added developers are:
- @rpateloak9
- @oak9jreiner
- @mherro-oak9

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
