### PR TITLE
INFRA-2985 Remove developer from sonarqube-plugin

### DIFF
--- a/permissions/plugin-sonar.yml
+++ b/permissions/plugin-sonar.yml
@@ -12,4 +12,3 @@ developers:
 - "henryju"
 - "tomverin"
 - "maeb"
-- "markrekveld"


### PR DESCRIPTION
# Description

Remove developer from plugin

Refs:
https://github.com/jenkinsci/sonarqube-plugin
https://github.com/SonarSource/sonar-scanner-jenkins
https://issues.jenkins.io/browse/INFRA-2985

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
