### PR TITLE
Update plugin-rb.yml

### DIFF
--- a/permissions/plugin-rb.yml
+++ b/permissions/plugin-rb.yml
@@ -7,3 +7,5 @@ paths:
 - "org/jenkins-ci/plugins/rb"
 developers:
 - "trowbrds"
+cd:
+  enabled: true


### PR DESCRIPTION
Add CD line for GitHub-based releases

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

This updates the permissions for the Review Board integration plugin (https://github.com/jenkinsci/rb-plugin) to allow CD releases.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
