### PR TITLE
Add @jglick to `jenkins-infra-test`

### DIFF
--- a/permissions/plugin-jenkins-infra-test.yml
+++ b/permissions/plugin-jenkins-infra-test.yml
@@ -10,3 +10,4 @@ cd:
 developers:
 - "timja"
 - "olblak"
+- "jglick"


### PR DESCRIPTION
# Description

@timja @olblak @daniel-beck 

https://github.com/jenkinsci/jenkins-infra-test-plugin

context: https://issues.jenkins.io/browse/INFRA-3066

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
