### PR TITLE
Add `basil` to Maven Repository Server

### DIFF
--- a/permissions/component-jenkins-maven-plugin.yml
+++ b/permissions/component-jenkins-maven-plugin.yml
@@ -3,4 +3,5 @@ name: "jenkins-maven-plugin"
 paths:
 - "com/nirima/jenkins/repository/jenkins-maven-plugin"
 developers:
+- "basil"
 - "magnayn"

--- a/permissions/plugin-repository.yml
+++ b/permissions/plugin-repository.yml
@@ -3,4 +3,5 @@ name: "repository"
 paths:
 - "jenkins/repository"
 developers:
+- "basil"
 - "magnayn"


### PR DESCRIPTION
# Description

My primary interest in adopting this plugin is to refresh the plugin metadata and to merge and release the Guava fix in jenkinsci/maven-repository-plugin#5. I may keep maintaining the POM/BOM and merging/releasing minor bug fixes, but I can't promise major feature development, security fixes, or in-depth code reviews.

* https://github.com/jenkinsci/maven-repository-plugin
* https://plugins.jenkins.io/repository

The existing maintainer, @magnayn, is responsive but has indicated that

> TBF, I'm no longer really using Jenkins -- if you are still using the plugin, I'd be happy to pass over the maintainer role -- I can commit the change, but I'm guessing it'd need someone to marshal it through the release process..

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
