### PR TITLE
Fix path for `jenkins-maven-plugin`

### DIFF
--- a/permissions/component-jenkins-maven-plugin.yml
+++ b/permissions/component-jenkins-maven-plugin.yml
@@ -2,6 +2,8 @@
 name: "jenkins-maven-plugin"
 paths:
 - "com/nirima/jenkins/repository"
+- "com/nirima/jenkins/repository/jenkins-maven-plugin"
+- "com/nirima/jenkins/repository/pom"
 developers:
 - "basil"
 - "magnayn"

--- a/permissions/component-jenkins-maven-plugin.yml
+++ b/permissions/component-jenkins-maven-plugin.yml
@@ -1,7 +1,7 @@
 ---
 name: "jenkins-maven-plugin"
 paths:
-- "com/nirima/jenkins/repository/jenkins-maven-plugin"
+- "com/nirima/jenkins/repository"
 developers:
 - "basil"
 - "magnayn"


### PR DESCRIPTION
I just tried to do a release of Maven Repository and got this error:

```
[INFO] --- maven-deploy-plugin:2.8.2:deploy (default-deploy) @ jenkins-maven-plugin ---
Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/1.5/jenkins-maven-plugin-1.5.jar
Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/1.5/jenkins-maven-plugin-1.5.jar (20 kB at 13 kB/s)
Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/1.5/jenkins-maven-plugin-1.5.pom
Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/1.5/jenkins-maven-plugin-1.5.pom (3.5 kB at 5.2 kB/s)
Downloading from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/maven-metadata.xml
Downloaded from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/maven-metadata.xml (660 B at 3.1 kB/s)
Downloading from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/maven-metadata.xml
Downloaded from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/maven-metadata.xml (248 B at 779 B/s)
Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/maven-metadata.xml
Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/jenkins-maven-plugin/maven-metadata.xml (614 B at 990 B/s)
Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/maven-metadata.xml
[INFO] ------------------------------------------------------------------------
[…]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project jenkins-maven-plugin: Failed to deploy metadata: Could not transfer metadata com.nirima.jenkins.repository/maven-metadata.xml from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): authorization failed for https://repo.jenkins-ci.org/releases/com/nirima/jenkins/repository/maven-metadata.xml, status: 403 Forbidden -> [Help 1]
```

I think this is because the path in the YAML file is too strict. Hopefully giving me access to one level up in the directory tree should work. The only thing in the `repository` directory is `jenkins-maven-plugin` (one of the components I'm trying to release) and `pom` (another component I'm trying to release).