### PR TITLE
Add permissions for Maven Repository plugin parent POM

### DIFF
--- a/permissions/component-jenkins-maven-plugin.yml
+++ b/permissions/component-jenkins-maven-plugin.yml
@@ -1,9 +1,9 @@
 ---
 name: "jenkins-maven-plugin"
+github: "jenkinsci/maven-repository-plugin"
 paths:
 - "com/nirima/jenkins/repository"
 - "com/nirima/jenkins/repository/jenkins-maven-plugin"
-- "com/nirima/jenkins/repository/pom"
 developers:
 - "basil"
 - "magnayn"

--- a/permissions/plugin-repository.yml
+++ b/permissions/plugin-repository.yml
@@ -1,5 +1,8 @@
 ---
 name: "repository"
+github: "jenkinsci/maven-repository-plugin"
+issues:
+- jira: "maven-repository-plugin"
 paths:
 - "jenkins/repository"
 developers:

--- a/permissions/pom-maven-repository-plugin.yml
+++ b/permissions/pom-maven-repository-plugin.yml
@@ -1,0 +1,8 @@
+---
+name: "pom"
+github: "jenkinsci/maven-repository-plugin"
+paths:
+- "com/nirima/jenkins/repository/pom"
+developers:
+- "basil"
+- "magnayn"


### PR DESCRIPTION
Trying to fix [this build failure](https://basilcrow.com/log2.txt). Looking at other examples, it seems that adding `com/nirima/jenkins/repository/pom` to `component-jenkins-maven-plugin.yml` in #2109 wasn't quite correct. Other examples have a dedicated `pom-${PLUGIN}.xml` file that (crucially) contains the `artifactId` of the POM as its `name`. So in this PR I am adding a `pom-maven-repository-plugin.yml` whose name is `pom`, which matches the `artifactId` from [here](https://github.com/jenkinsci/maven-repository-plugin/blob/3bfad5f403e45ed9d9e48e107657f97a8c993d70/pom.xml#L12). So I think this should resolve my error.

While I was here, I added GitHub URLs for all three of this plugin's YAML files, and I updated the main plugin YAML file with proper issue tracking.

CC @timja 