### PR TITLE
Remove `basil` from `jquery`

### DIFF
--- a/permissions/plugin-jquery.yml
+++ b/permissions/plugin-jquery.yml
@@ -6,7 +6,6 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/jquery"
 developers:
-- "basil"
 - "kohsuke"
 security:
   contacts:


### PR DESCRIPTION
I originally added myself to this plugin to help maintain its POM back when it was in the BOM. But it is no longer in the BOM, so I don't need permissions anymore.