### PR TITLE
Add @jglick to `mock-load-builder` & prep for CD & GH Issues

### DIFF
--- a/permissions/plugin-mock-load-builder.yml
+++ b/permissions/plugin-mock-load-builder.yml
@@ -1,8 +1,10 @@
 ---
 name: "mock-load-builder"
-github: "jenkinsci/mock-load-builder-plugin"
+github: &GH "jenkinsci/mock-load-builder-plugin"
 issues:
+- github: *GH
 - jira: '18828' # mock-load-builder-plugin
+  report: false
 paths:
 - "org/jenkins-ci/plugins/mock-load-builder"
 cd:


### PR DESCRIPTION
# Description

Would like to be able to easily ship stuff like https://github.com/jenkinsci/mock-load-builder-plugin/pull/5. @Vlatombe

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
