### PR TITLE
Allow cd for the log-file-filter-plugin

### DIFF
--- a/permissions/plugin-log-file-filter.yml
+++ b/permissions/plugin-log-file-filter.yml
@@ -8,3 +8,5 @@ paths:
 developers:
 - "carlescapdevila"
 - "andreasmandel"
+cd:
+  enabled: true


### PR DESCRIPTION
# Description

Allow automated cd deployment for https://github.com/jenkinsci/log-file-filter-plugin, maintained by me @amandel. Following [Setting up automated plugin release](https://www.jenkins.io/doc/developer/publishing/releasing-cd/)

# Submitter checklist for adding or changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
