### PR TITLE
Add Darin Pope as schedule-build & testng maintainer

### DIFF
--- a/permissions/plugin-schedule-build.yml
+++ b/permissions/plugin-schedule-build.yml
@@ -9,3 +9,4 @@ developers:
 - "anderl86"
 - "pingunaut"
 - "markewaite"
+- "darinpope"

--- a/permissions/plugin-testng-plugin.yml
+++ b/permissions/plugin-testng-plugin.yml
@@ -9,3 +9,4 @@ paths:
 developers:
 - "nullin"
 - "markewaite"
+- "darinpope"


### PR DESCRIPTION
# Add Darin Pope as schedule-build & testng maintainer

Darin and Mark are using schedule-build plugin and testng plugin to illustrate some of the steps to modernize a plugin for easier maintenance.

See the video series that starts with https://youtu.be/Fev8KfFsPZE .  Video description includes links to the Google Doc and the other videos in the series.

Repositories where he's being added as a maintainer are:

* https://github.com/jenkinsci/schedule-build-plugin
* https://github.com/jenkinsci/testng-plugin-plugin

I, @MarkEWaite, am an existing maintainer of both plugins.  I approve this addition.

@darinpope is the new maintainer being added.  Darin has shown me the screen that confirms he has authenticated to https://repo.jenkins-ci.org with his accounts.jenkins.io account.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
