### PR TITLE
Enable cd for schedule build plugin

### DIFF
--- a/permissions/plugin-schedule-build.yml
+++ b/permissions/plugin-schedule-build.yml
@@ -10,3 +10,5 @@ developers:
 - "pingunaut"
 - "markewaite"
 - "darinpope"
+cd:
+  enabled: true


### PR DESCRIPTION
@MarkEWaite agrees this is the right choice to do.

# Description

Enable continuous delivery for schedule build plugin

https://github.com/jenkinsci/schedule-build-plugin

# Submitter checklist for adding or changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
