### PR TITLE
[JENKINS-64398] Add @jglick to `envinject`

### DIFF
--- a/permissions/component-envinject-lib.yml
+++ b/permissions/component-envinject-lib.yml
@@ -5,3 +5,4 @@ paths:
 - "org/jenkins-ci/lib/envinject-lib"
 developers:
 - "oleg_nenashev"
+- "jglick"

--- a/permissions/plugin-envinject-api.yml
+++ b/permissions/plugin-envinject-api.yml
@@ -7,3 +7,4 @@ paths:
 - "org/jenkins-ci/plugins/envinject-api"
 developers:
 - "oleg_nenashev"
+- "jglick"

--- a/permissions/plugin-envinject.yml
+++ b/permissions/plugin-envinject.yml
@@ -7,3 +7,4 @@ paths:
 - "org/jenkins-ci/plugins/envinject"
 developers:
 - "oleg_nenashev"
+- "jglick"


### PR DESCRIPTION
# Description

I have no interest in maintaining this plugin generally (superseded by Pipeline) but would like to ship a regression fix related to JEP-228, and @oleg-nenashev is not currently available according to https://github.com/jenkinsci/envinject-lib/pull/19#pullrequestreview-794350041.

I will likely need GitHub write access as well.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
