### PR TITLE
Unify cloudbees account for security contact

### DIFF
--- a/permissions/plugin-artifact-manager-s3.yml
+++ b/permissions/plugin-artifact-manager-s3.yml
@@ -11,4 +11,4 @@ developers:
 - "oleg_nenashev"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-aws-credentials.yml
+++ b/permissions/plugin-aws-credentials.yml
@@ -17,4 +17,4 @@ developers:
 - "ajard"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-aws-global-configuration.yml
+++ b/permissions/plugin-aws-global-configuration.yml
@@ -12,4 +12,4 @@ developers:
 - "ifernandezcalvo"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-aws-java-sdk.yml
+++ b/permissions/plugin-aws-java-sdk.yml
@@ -13,4 +13,4 @@ developers:
 - "vlatombe"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-azure-publishersettings-credentials.yml
+++ b/permissions/plugin-azure-publishersettings-credentials.yml
@@ -10,4 +10,4 @@ developers:
 - "markwm"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-kubernetes-client-api.yml
+++ b/permissions/plugin-kubernetes-client-api.yml
@@ -16,4 +16,4 @@ developers:
 - "kylecronin"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-kubernetes-credentials.yml
+++ b/permissions/plugin-kubernetes-credentials.yml
@@ -11,4 +11,4 @@ developers:
 - "sirstrahd"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-kubernetes.yml
+++ b/permissions/plugin-kubernetes.yml
@@ -16,4 +16,4 @@ developers:
 - "ajard"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-mapdb-api.yml
+++ b/permissions/plugin-mapdb-api.yml
@@ -8,4 +8,4 @@ paths:
 developers: []
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-one-shot-executor.yml
+++ b/permissions/plugin-one-shot-executor.yml
@@ -8,4 +8,4 @@ paths:
 developers: []
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-saml.yml
+++ b/permissions/plugin-saml.yml
@@ -13,4 +13,4 @@ developers:
 - "sbower"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-view-job-filters.yml
+++ b/permissions/plugin-view-job-filters.yml
@@ -11,4 +11,4 @@ developers:
 - "jglick"
 security:
   contacts:
-    jira: "modern_platforms_security_members"
+    jira: "cloudbees_security_members"


### PR DESCRIPTION
Follow-up for https://github.com/jenkins-infra/repository-permissions-updater/pull/2162

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

@Vlatombe  as the main stakeholder behind the "modern_platforms_security_members" account.

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

**Most of the PR template is N/A for this change.**

### Always

- [ ] ~Add link to plugin/component Git repository in description above~ N/A

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
