### PR TITLE
Add basil to various appendages of core

### DIFF
--- a/permissions/component-crypto-util.yml
+++ b/permissions/component-crypto-util.yml
@@ -4,5 +4,6 @@ github: "jenkinsci/lib-crypto-util"
 paths:
 - "org/jenkins-ci/crypto-util"
 developers:
+- "basil"
 - "kohsuke"
 - "timja"

--- a/permissions/component-executable-war.yml
+++ b/permissions/component-executable-war.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/extras-executable-war"
 paths:
 - "org/jenkins-ci/executable-war"
 developers:
+- "basil"
 - "kohsuke"
 - "oleg_nenashev"
 - "batmat"

--- a/permissions/component-lib-access-modifier-annotation.yml
+++ b/permissions/component-lib-access-modifier-annotation.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/lib-access-modifier"
 paths:
 - "org/kohsuke/access-modifier-annotation"
 developers:
+- "basil"
 - "timja"
 - "oleg_nenashev"
 - "jglick"

--- a/permissions/component-lib-access-modifier-checker.yml
+++ b/permissions/component-lib-access-modifier-checker.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/lib-access-modifier"
 paths:
 - "org/kohsuke/access-modifier-checker"
 developers:
+- "basil"
 - "timja"
 - "oleg_nenashev"
 - "jglick"

--- a/permissions/component-lib-access-modifier-suppressions.yml
+++ b/permissions/component-lib-access-modifier-suppressions.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/lib-access-modifier"
 paths:
 - "org/kohsuke/access-modifier-suppressions"
 developers:
+- "basil"
 - "timja"
 - "oleg_nenashev"
 - "jglick"

--- a/permissions/component-memory-monitor.yml
+++ b/permissions/component-memory-monitor.yml
@@ -4,4 +4,5 @@ github: "jenkinsci/extras-memory-monitor"
 paths:
 - "org/jenkins-ci/memory-monitor"
 developers:
+- "basil"
 - "jglick"

--- a/permissions/component-task-reactor.yml
+++ b/permissions/component-task-reactor.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/lib-task-reactor"
 paths:
 - "org/jenkins-ci/task-reactor"
 developers:
+- "basil"
 - "kohsuke"
 - "jglick"
 - "oleg_nenashev"

--- a/permissions/component-test-annotations.yml
+++ b/permissions/component-test-annotations.yml
@@ -5,5 +5,6 @@ paths:
 - "org/jenkins-ci/test-annotations"
 - "org/jvnet/hudson/test-annotations"
 developers:
+- "basil"
 - "kohsuke"
 - "olivergondza"

--- a/permissions/component-version-number.yml
+++ b/permissions/component-version-number.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/lib-version-number"
 paths:
 - "org/jenkins-ci/version-number"
 developers:
+- "basil"
 - "batmat"
 - "jglick"
 - "oleg_nenashev"

--- a/permissions/pom-lib-access-modifier-parent.yml
+++ b/permissions/pom-lib-access-modifier-parent.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/lib-access-modifier"
 paths:
 - "org/kohsuke/access-modifier"
 developers:
+- "basil"
 - "timja"
 - "oleg_nenashev"
 - "jglick"


### PR DESCRIPTION
# Description

These various appendages of Jenkins core could use some love. I've been working on refreshing them (e.g., adding Dependabot configurations, updating dependencies, cleaning up IDE warnings, incrementalifying them, etc.) and would like to be able to cut some releases when I'm done.

- https://github.com/jenkinsci/extras-executable-war/
- https://github.com/jenkinsci/extras-memory-monitor
- https://github.com/jenkinsci/lib-access-modifier/
- https://github.com/jenkinsci/lib-crypto-util
- https://github.com/jenkinsci/lib-task-reactor/
- https://github.com/jenkinsci/lib-test-annotations/
- https://github.com/jenkinsci/lib-version-number/

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
