### PR TITLE
Enabled CD for plugin-keeper-secrets-manager

### DIFF
--- a/permissions/plugin-keeper-secrets-manager.yml
+++ b/permissions/plugin-keeper-secrets-manager.yml
@@ -5,5 +5,7 @@ paths:
 - "io/jenkins/plugins/keeper-secrets-manager"
 developers:
 - "jsupun"
+cd:
+  enabled: true
 issues:
   - github: *GH


### PR DESCRIPTION
Add CD to config

# Description

Enabled CD for plugin-keeper-secrets-manager

https://github.com/jenkinsci/keeper-secrets-manager-plugin

# Submitter checklist for adding or changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
