### PR TITLE
Add `basil` to `symbol-annotation`

### DIFF
--- a/permissions/component-symbol-annotation.yml
+++ b/permissions/component-symbol-annotation.yml
@@ -1,9 +1,10 @@
 ---
 name: "symbol-annotation"
-github: "jenkinsci/structs-plugin"
+github: "jenkinsci/lib-symbol-annotation"
 paths:
 - "org/jenkins-ci/symbol-annotation"
 developers:
+- "basil"
 - "jglick"
 - "kohsuke"
 - "oleg_nenashev"


### PR DESCRIPTION
# Description

See https://github.com/jenkinsci/jenkins/pull/5293#issuecomment-780542952 for context. Please let me know if there is anything I can clarify.

Also updating the GitHub URL to reflect the pending split (see [HOSTING-1155](https://issues.jenkins.io/browse/HOSTING-1155)).

Repositories:

- Current (old): https://github.com/jenkinsci/structs-plugin/tree/master/annotation
- Future (new): https://github.com/basil/lib-symbol-annotation (soon to become https://github.com/jenkinsci/lib-symbol-annotation as of HOSTING-1155).

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
