### PR TITLE
Enable CD for git-automerger plugin

### DIFF
--- a/permissions/plugin-git-automerger.yml
+++ b/permissions/plugin-git-automerger.yml
@@ -8,3 +8,5 @@ paths:
 - "com/vinted/automerger/git-automerger"
 developers:
 - "neworldlt"
+cd:
+  enabled: true


### PR DESCRIPTION
I made a fix of [git-automerger](https://github.com/jenkinsci/git-automerger-plugin/releases/tag/0.6.2) plugin but it seems is no longer published via Jenkins CI. I tried manual publishing, but my credentials for https://repo.jenkins-ci.org/ are not working anymore, so I suppose CD is the straightforward route to publish a fixed version of the plugin. 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
