### PR TITLE
Enable automated release for plugin-pom

### DIFF
--- a/permissions/pom-plugin.yml
+++ b/permissions/pom-plugin.yml
@@ -4,6 +4,8 @@ github: "jenkinsci/plugin-pom"
 paths:
 - "org/jenkins-ci/plugins/plugin"
 - "org/jvnet/hudson/plugins/plugin"
+cd:
+  enabled: true
 developers:
 - "andresrc"
 - "jglick"


### PR DESCRIPTION
# Description

I would like to experiment with automatic, but manually _triggered_, `maven-release-plugin` in https://github.com/jenkinsci/plugin-pom/releases along the lines of https://groups.google.com/g/jenkinsci-dev/c/i348jNcX7pY/m/Rrn453pWAAAJ. I am not calling it “CD” since it would be manually _triggered_ and not use `jenkins-infra/interesting-category-action`. If it works out, we could advertise this system more broadly for plugins which do not wish to use full JEP-229 but whose authors simply do not want to use local credentials (https://groups.google.com/g/jenkinsci-dev/c/EPzkxrsW5C0/m/E4V9kBBEBgAJ for example); would require a minor variant of `jenkins-maven-cd-action/run.sh`.

In principle we could actually convert `plugin-pom` to full JEP-229 but I am nervous about even incrementalifying (JEP-305) a parent POM like this. Ought to be possible to restrict flattening and such things to the parent POM itself, and not to POMs _using_ it, but seems risky and needs more study.

@timja et al.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
