### PR TITLE
Enable CD for `build-token-root`

### DIFF
--- a/permissions/plugin-build-token-root.yml
+++ b/permissions/plugin-build-token-root.yml
@@ -1,6 +1,8 @@
 ---
 name: "build-token-root"
 github: "jenkinsci/build-token-root-plugin"
+cd:
+  enabled: true
 issues:
 - jira: '17622' # build-token-root-plugin
 paths:


### PR DESCRIPTION
# Description

Seems prudent to try https://github.com/jenkins-infra/jenkins-maven-cd-action/pull/14 on something I own which is not yet set up for JEP-229 metadata (though it is incrementalified) with a smaller “blast radius” than `plugin-pom`.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
