### PR TITLE
Enable cd for Peass-CI

### DIFF
--- a/permissions/plugin-peass-ci.yml
+++ b/permissions/plugin-peass-ci.yml
@@ -1,6 +1,8 @@
 ---
 name: "peass-ci"
 github: &GH "jenkinsci/peass-ci-plugin"
+cd:
+  enabled: true
 paths:
 - "de/peass/peass-ci"
 developers:


### PR DESCRIPTION
# Description

I would like to try to continuously deliver Peass-CI.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
