### PR TITLE
Fix Adoption request for "sonar-gerrit" plugin typo

### DIFF
--- a/permissions/plugin-sonar-gerrit.yml
+++ b/permissions/plugin-sonar-gerrit.yml
@@ -6,4 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/sonar-gerrit"
 developers:
-- "reda_alaoui"
+- "reda-alaoui"


### PR DESCRIPTION
@MarkEWaite I can't push to https://github.com/jenkinsci/sonar-gerrit-plugin : 

```
ERROR: Permission to jenkinsci/sonar-gerrit-plugin.git denied to reda-alaoui.
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
```

In https://github.com/jenkins-infra/repository-permissions-updater/pull/2210, I provided my jenkinsci username `reda_alaoui` instead of my github username `reda-alaoui`. I believe this is the cause of my lack of permission :/