### PR TITLE
Update owner for scm filter aged filter, jira validator and commit trait

### DIFF
--- a/permissions/plugin-bitbucket-scm-filter-aged-refs.yml
+++ b/permissions/plugin-bitbucket-scm-filter-aged-refs.yml
@@ -6,4 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/bitbucket-scm-filter-aged-refs"
 developers:
-- "witokondoria"
+- "askalski85"

--- a/permissions/plugin-bitbucket-scm-filter-jira-validator.yml
+++ b/permissions/plugin-bitbucket-scm-filter-jira-validator.yml
@@ -6,4 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/bitbucket-scm-filter-jira-validator"
 developers:
-- "witokondoria"
+- "askalski85"

--- a/permissions/plugin-bitbucket-scm-trait-commit-skip.yml
+++ b/permissions/plugin-bitbucket-scm-trait-commit-skip.yml
@@ -6,4 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/bitbucket-scm-trait-commit-skip"
 developers:
-- "witokondoria"
+- "askalski85"

--- a/permissions/plugin-github-scm-filter-aged-refs.yml
+++ b/permissions/plugin-github-scm-filter-aged-refs.yml
@@ -6,5 +6,5 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/github-scm-filter-aged-refs"
 developers:
-- "witokondoria"
+- "askalski85"
 

--- a/permissions/plugin-github-scm-filter-jira-validator.yml
+++ b/permissions/plugin-github-scm-filter-jira-validator.yml
@@ -6,4 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/github-scm-filter-jira-validator"
 developers:
-- "witokondoria"
+- "askalski85"

--- a/permissions/plugin-github-scm-trait-commit-skip.yml
+++ b/permissions/plugin-github-scm-trait-commit-skip.yml
@@ -6,4 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/github-scm-trait-commit-skip"
 developers:
-- "witokondoria"
+- "askalski85"

--- a/permissions/pom-scm-filter-aged-refs-parent.yml
+++ b/permissions/pom-scm-filter-aged-refs-parent.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/scm-filter-aged-refs-plugin"
 paths:
 - "org/jenkins-ci/plugins/scm-filter-aged-refs-parent"
 developers:
-- "witokondoria"
+- "askalski85"

--- a/permissions/pom-scm-filter-jira-validator-parent.yml
+++ b/permissions/pom-scm-filter-jira-validator-parent.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/scm-filter-jira-validator-plugin"
 paths:
 - "org/jenkins-ci/plugins/scm-filter-jira-validator-parent"
 developers:
-- "witokondoria"
+- "askalski85"

--- a/permissions/pom-scm-trait-commit-skip-parent.yml
+++ b/permissions/pom-scm-trait-commit-skip-parent.yml
@@ -4,4 +4,4 @@ github: "jenkinsci/scm-trait-commit-skip-plugin"
 paths:
 - "org/jenkins-ci/plugins/scm-trait-commit-skip-parent"
 developers:
-- "witokondoria"
+- "askalski85"


### PR DESCRIPTION
Implements: INFRA-3134

# Description

Previous owner @witokondoria .

https://issues.jenkins.io/browse/INFRA-3134

-     scm-filter-aged-refs-plugin https://github.com/jenkinsci/scm-filter-aged-refs-plugin
-     scm-filter-jira-validator-plugin https://github.com/jenkinsci/scm-filter-jira-validator-plugin 
-     scm-trait-commit-skip-plugin https://github.com/jenkinsci/scm-trait-commit-skip-plugin

https://groups.google.com/g/jenkinsci-dev/c/hzIyWK9NEZk

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- https://github.com/jenkinsci/scm-filter-aged-refs-plugin
- https://github.com/jenkinsci/scm-filter-jira-validator-plugin 
- https://github.com/jenkinsci/scm-trait-commit-skip-plugin

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@daniel-beck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
