### PR TITLE
Add `basil` to `component-kohsuke-maven-plugins`

### DIFF
--- a/permissions/component-kohsuke-maven-plugins.yml
+++ b/permissions/component-kohsuke-maven-plugins.yml
@@ -4,6 +4,7 @@ name: "dummy-unused-artifact-name"
 paths:
 - "org/kohsuke"
 developers:
+- "basil"
 - "timja"
 - "oleg_nenashev"
 - "jglick"


### PR DESCRIPTION
I just tried to release `lib-access-modifier`, but the build failed with

<details>
<summary>Build failure</summary>
<br>
<pre>
[INFO] Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/access-modifier-checker/1.26/access-modifier-checker-1.26.jar (38 kB at 41 kB/s)
[INFO] Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/access-modifier-checker/1.26/access-modifier-checker-1.26.pom
[INFO] Progress (1): 4.1/5.8 kB
[INFO] Progress (1): 5.8 kB    
[INFO]                     
[INFO] Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/access-modifier-checker/1.26/access-modifier-checker-1.26.pom (5.8 kB at 8.1 kB/s)
[INFO] Downloading from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/access-modifier-checker/maven-metadata.xml
[INFO] Progress (1): 595 B
[INFO]                    
[INFO] Downloaded from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/access-modifier-checker/maven-metadata.xml (595 B at 2.9 kB/s)
[INFO] Downloading from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/maven-metadata.xml
[INFO] Progress (1): 442 B
[INFO]                    
[INFO] Downloaded from maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/maven-metadata.xml (442 B at 1.6 kB/s)
[INFO] Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/access-modifier-checker/maven-metadata.xml
[INFO] Progress (1): 548 B
[INFO]                    
[INFO] Uploaded to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/access-modifier-checker/maven-metadata.xml (548 B at 867 B/s)
[INFO] Uploading to maven.jenkins-ci.org: https://repo.jenkins-ci.org/releases/org/kohsuke/maven-metadata.xml
[INFO] Progress (1): 442 B
[INFO]                    
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Reactor Summary for Custom access modifier for Java 1.26:
[INFO] [INFO] 
[INFO] [INFO] Custom access modifier for Java .................... SUCCESS [  4.265 s]
[INFO] [INFO] Custom Access Modifier annotations ................. SUCCESS [  7.859 s]
[INFO] [INFO] Suppression for Access Modifier annotations ........ SUCCESS [  6.265 s]
[INFO] [INFO] Custom Access Modifier Checker ..................... FAILURE [  7.456 s]
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] BUILD FAILURE
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Total time:  25.890 s
[INFO] [INFO] Finished at: 2021-12-16T09:28:51-08:00
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [WARNING] The requested profile "consume-incrementals" could not be activated because it does not exist.
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project access-modifier-checker: Failed to deploy metadata: Could not transfer metadata org.kohsuke/maven-metadata.xml from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): authorization failed for https://repo.jenkins-ci.org/releases/org/kohsuke/maven-metadata.xml, status: 403 Forbidden -> [Help 1]
</pre>
</details>

I think this is because this is a Maven plugin so I need access to the parent directory. This PR should correct that problem. Once this is merged and deployed I plan to try again to cut a release.

- https://github.com/jenkinsci/lib-access-modifier

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
