### PR TITLE
add cloudbees-developers to second tier

### DIFF
--- a/permissions/component-pipeline-model-json-shaded.yml
+++ b/permissions/component-pipeline-model-json-shaded.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/pipeline-model-definition-plugin"
 paths:
 - "org/jenkins-ci/lib/pipeline-model-json-shaded"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "oleg_nenashev"
 - "rsandell"

--- a/permissions/plugin-active-directory.yml
+++ b/permissions/plugin-active-directory.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/active-directory"
 developers:
+- "@cloudbees-developers"
 - "fbelzunc"
 - "kohsuke"
 - "alecharp"

--- a/permissions/plugin-apache-httpcomponents-client-4-api.yml
+++ b/permissions/plugin-apache-httpcomponents-client-4-api.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/apache-httpcomponents-client-4-api"
 developers:
+- "@cloudbees-developers"
 - "oleg_nenashev"
 - "dnusbaum"
 - "mramonleon"

--- a/permissions/plugin-azure-publishersettings-credentials.yml
+++ b/permissions/plugin-azure-publishersettings-credentials.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/azure-publishersettings-credentials"
 developers:
+- "@cloudbees-developers"
 - "batmat"
 - "markwm"
 - "@cloudbees-developers"

--- a/permissions/plugin-blueocean-autofavorite.yml
+++ b/permissions/plugin-blueocean-autofavorite.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/blueocean-autofavorite"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "jamesdumay"
 - "vivek"

--- a/permissions/plugin-blueocean-bitbucket-pipeline.yml
+++ b/permissions/plugin-blueocean-bitbucket-pipeline.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-bitbucket-pipeline"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-commons.yml
+++ b/permissions/plugin-blueocean-commons.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-commons"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-config.yml
+++ b/permissions/plugin-blueocean-config.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-config"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-core-js"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-dashboard.yml
+++ b/permissions/plugin-blueocean-dashboard.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-dashboard"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-display-url.yml
+++ b/permissions/plugin-blueocean-display-url.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/blueocean-display-url"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-events.yml
+++ b/permissions/plugin-blueocean-events.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-events"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-executor-info"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-git-pipeline.yml
+++ b/permissions/plugin-blueocean-git-pipeline.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-git-pipeline"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-github-pipeline.yml
+++ b/permissions/plugin-blueocean-github-pipeline.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-github-pipeline"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-i18n.yml
+++ b/permissions/plugin-blueocean-i18n.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-i18n"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-jira.yml
+++ b/permissions/plugin-blueocean-jira.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-jira"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-jwt.yml
+++ b/permissions/plugin-blueocean-jwt.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-jwt"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-personalization.yml
+++ b/permissions/plugin-blueocean-personalization.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-personalization"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-pipeline-api-impl.yml
+++ b/permissions/plugin-blueocean-pipeline-api-impl.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-pipeline-api-impl"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-pipeline-editor.yml
+++ b/permissions/plugin-blueocean-pipeline-editor.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-pipeline-editor"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-pipeline-scm-api.yml
+++ b/permissions/plugin-blueocean-pipeline-scm-api.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-pipeline-scm-api"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-rest-impl.yml
+++ b/permissions/plugin-blueocean-rest-impl.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-rest-impl"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-rest.yml
+++ b/permissions/plugin-blueocean-rest.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-rest"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean-web.yml
+++ b/permissions/plugin-blueocean-web.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean-web"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-blueocean.yml
+++ b/permissions/plugin-blueocean.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/blueocean"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-bouncycastle-api.yml
+++ b/permissions/plugin-bouncycastle-api.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/bouncycastle-api"
 developers:
+- "@cloudbees-developers"
 - "alobato"
 - "dnusbaum"
 - "jthompson"

--- a/permissions/plugin-caffeine-api.yml
+++ b/permissions/plugin-caffeine-api.yml
@@ -4,6 +4,7 @@ github: &GH "jenkinsci/caffeine-api-plugin"
 paths:
 - "io/jenkins/plugins/caffeine-api"
 developers:
+- "@cloudbees-developers"
 - "teilo"
 - "rsandell"
 - "carroll"

--- a/permissions/plugin-cloudbees-bitbucket-branch-source.yml
+++ b/permissions/plugin-cloudbees-bitbucket-branch-source.yml
@@ -7,6 +7,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/cloudbees-bitbucket-branch-source"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "amuniz"
 - "bitwiseman"

--- a/permissions/plugin-command-launcher.yml
+++ b/permissions/plugin-command-launcher.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/command-launcher"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "oleg_nenashev"
 - "mramonleon"

--- a/permissions/plugin-deployer-framework.yml
+++ b/permissions/plugin-deployer-framework.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/deployer-framework"
 developers:
+- "@cloudbees-developers"
 - "jvz"
 - "alecharp"
 - "batmat"

--- a/permissions/plugin-docker-build-publish.yml
+++ b/permissions/plugin-docker-build-publish.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/docker-build-publish"
 developers:
+- "@cloudbees-developers"
 - "csanchez"
 - "michaelneale"
 - "oleg_nenashev"

--- a/permissions/plugin-docker-commons.yml
+++ b/permissions/plugin-docker-commons.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/docker-commons"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "kohsuke"
 - "oleg_nenashev"

--- a/permissions/plugin-docker-workflow.yml
+++ b/permissions/plugin-docker-workflow.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/docker-workflow"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "oleg_nenashev"
 - "abayer"

--- a/permissions/plugin-dockerhub-notification.yml
+++ b/permissions/plugin-dockerhub-notification.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/dockerhub-notification"
 developers:
+- "@cloudbees-developers"
 - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/durable-task"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "kohsuke"
 - "svanoort"

--- a/permissions/plugin-ec2.yml
+++ b/permissions/plugin-ec2.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/ec2"
 developers:
+- "@cloudbees-developers"
 - "thoulen"
 - "julienduchesne"
 - "fcojfernandez"

--- a/permissions/plugin-external-monitor-job.yml
+++ b/permissions/plugin-external-monitor-job.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/external-monitor-job"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "recena"
 - "alecharp"

--- a/permissions/plugin-favorite.yml
+++ b/permissions/plugin-favorite.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jvnet/hudson/plugins/favorite"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "jamesdumay"
 - "vivek"

--- a/permissions/plugin-github-api.yml
+++ b/permissions/plugin-github-api.yml
@@ -9,6 +9,7 @@ paths:
 - "org/jenkins-ci/plugins/github-api"
 developers:
 - "@cloudbees-developers"
+- "@cloudbees-developers"
 - "andresrc"
 - "bitwiseman"
 - "integer"

--- a/permissions/plugin-google-metadata-plugin.yml
+++ b/permissions/plugin-google-metadata-plugin.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/google-metadata-plugin"
 developers:
+- "@cloudbees-developers"
 - "alecharp"
 security:
   contacts:

--- a/permissions/plugin-handy-uri-templates-2-api.yml
+++ b/permissions/plugin-handy-uri-templates-2-api.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/handy-uri-templates-2-api"
 developers:
+- "@cloudbees-developers"
 - "jetersen"
 - "dnusbaum"
 - "bitwiseman"

--- a/permissions/plugin-htmlpublisher.yml
+++ b/permissions/plugin-htmlpublisher.yml
@@ -7,6 +7,7 @@ paths:
 - "org/jenkins-ci/plugins/htmlpublisher"
 - "org/jvnet/hudson/plugins/htmlpublisher"
 developers:
+- "@cloudbees-developers"
 - "mcrooney"
 - "r2b2_nz"
 - "dnusbaum"

--- a/permissions/plugin-jaxb.yml
+++ b/permissions/plugin-jaxb.yml
@@ -7,6 +7,7 @@ issues:
 paths:
 - "io/jenkins/plugins/jaxb"
 developers:
+- "@cloudbees-developers"
 - "kohsuke"
 - "oleg_nenashev"
 - "batmat"

--- a/permissions/plugin-jdk-tool.yml
+++ b/permissions/plugin-jdk-tool.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/jdk-tool"
 developers:
+- "@cloudbees-developers"
 - "dnusbaum"
 - "jglick"
 - "oleg_nenashev"

--- a/permissions/plugin-jenkins-design-language.yml
+++ b/permissions/plugin-jenkins-design-language.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "io/jenkins/blueocean/jenkins-design-language"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/plugin-jira.yml
+++ b/permissions/plugin-jira.yml
@@ -8,6 +8,7 @@ paths:
 - "org/jenkins-ci/plugins/jira"
 - "org/jvnet/hudson/plugins/jira"
 developers:
+- "@cloudbees-developers"
 - "warden"
 - "olamy"
 security:

--- a/permissions/plugin-jjwt-api.yml
+++ b/permissions/plugin-jjwt-api.yml
@@ -8,6 +8,7 @@ issues:
 paths:
 - "io/jenkins/plugins/jjwt-api"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "bitwiseman"
 security:

--- a/permissions/plugin-kubernetes-client-api.yml
+++ b/permissions/plugin-kubernetes-client-api.yml
@@ -8,6 +8,7 @@ paths:
 cd:
   enabled: true
 developers:
+- "@cloudbees-developers"
 - "csanchez"
 - "vlatombe"
 - "jglick"

--- a/permissions/plugin-kubernetes-client-api.yml
+++ b/permissions/plugin-kubernetes-client-api.yml
@@ -8,7 +8,6 @@ paths:
 cd:
   enabled: true
 developers:
-- "@cloudbees-developers"
 - "csanchez"
 - "vlatombe"
 - "jglick"

--- a/permissions/plugin-matrix-project.yml
+++ b/permissions/plugin-matrix-project.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/matrix-project"
 developers:
+- "@cloudbees-developers"
 - "amuniz"
 - "jglick"
 - "oleg_nenashev"

--- a/permissions/plugin-maven-plugin.yml
+++ b/permissions/plugin-maven-plugin.yml
@@ -7,6 +7,7 @@ paths:
 - "org/jenkins-ci/main/maven-plugin"
 - "org/jvnet/hudson/main/maven-plugin"
 developers:
+- "@cloudbees-developers"
 - "integer"
 - "jglick"
 - "kohsuke"

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -7,6 +7,7 @@ paths:
 - "org/jenkins-ci/plugins/mercurial"
 - "org/jvnet/hudson/plugins/mercurial"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "alecharp"
 - "batmat"

--- a/permissions/plugin-node-iterator-api.yml
+++ b/permissions/plugin-node-iterator-api.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/node-iterator-api"
 developers:
+- "@cloudbees-developers"
 - "alecharp"
 - "batmat"
 - "egutierrez"

--- a/permissions/plugin-oauth-credentials.yml
+++ b/permissions/plugin-oauth-credentials.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/oauth-credentials"
 developers:
+- "@cloudbees-developers"
 - "mattmoor"
 - "alecharp"
 - "egutierrez"

--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/parameterized-trigger"
 developers:
+- "@cloudbees-developers"
 - "ikedam"
 - "kwhetstone"
 - "oleg_nenashev"

--- a/permissions/plugin-pipeline-build-step.yml
+++ b/permissions/plugin-pipeline-build-step.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/pipeline-build-step"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "abayer"
 - "svanoort"

--- a/permissions/plugin-pipeline-github-lib.yml
+++ b/permissions/plugin-pipeline-github-lib.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/pipeline-github-lib"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "abayer"
 - "dnusbaum"

--- a/permissions/plugin-pipeline-graph-analysis.yml
+++ b/permissions/plugin-pipeline-graph-analysis.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/pipeline-graph-analysis"
 developers:
+- "@cloudbees-developers"
 - "svanoort"
 - "abayer"
 - "dnusbaum"

--- a/permissions/plugin-pipeline-input-step.yml
+++ b/permissions/plugin-pipeline-input-step.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/pipeline-input-step"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "svanoort"
 - "abayer"

--- a/permissions/plugin-pipeline-milestone-step.yml
+++ b/permissions/plugin-pipeline-milestone-step.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/pipeline-milestone-step"
 developers:
+- "@cloudbees-developers"
 - "amuniz"
 - "svanoort"
 - "jglick"

--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkinsci/plugins/pipeline-model-api"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "oleg_nenashev"
 - "rsandell"

--- a/permissions/plugin-pipeline-model-declarative-agent.yml
+++ b/permissions/plugin-pipeline-model-declarative-agent.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkinsci/plugins/pipeline-model-declarative-agent"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "oleg_nenashev"
 - "rsandell"

--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkinsci/plugins/pipeline-model-definition"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "oleg_nenashev"
 - "rsandell"

--- a/permissions/plugin-pipeline-model-extensions.yml
+++ b/permissions/plugin-pipeline-model-extensions.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkinsci/plugins/pipeline-model-extensions"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "oleg_nenashev"
 - "rsandell"

--- a/permissions/plugin-pipeline-stage-step.yml
+++ b/permissions/plugin-pipeline-stage-step.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/pipeline-stage-step"
 developers:
+- "@cloudbees-developers"
 - "jglick"
 - "svanoort"
 - "abayer"

--- a/permissions/plugin-pipeline-stage-tags-metadata.yml
+++ b/permissions/plugin-pipeline-stage-tags-metadata.yml
@@ -6,6 +6,7 @@ issues:
 paths:
 - "org/jenkinsci/plugins/pipeline-stage-tags-metadata"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "oleg_nenashev"
 - "rsandell"

--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -7,6 +7,7 @@ paths:
 - "org/jenkins-ci/plugins/promoted-builds"
 - "org/jvnet/hudson/plugins/promoted-builds"
 developers:
+- "@cloudbees-developers"
 - "dnozay"
 - "jglick"
 - "oleg_nenashev"

--- a/permissions/pom-blueocean-parent.yml
+++ b/permissions/pom-blueocean-parent.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/blueocean-plugin"
 paths:
 - "io/jenkins/blueocean/blueocean-parent"
 developers:
+- "@cloudbees-developers"
 - "michaelneale"
 - "vivek"
 - "kzantow"

--- a/permissions/pom-pipeline-model-parent.yml
+++ b/permissions/pom-pipeline-model-parent.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/pipeline-model-definition-plugin"
 paths:
 - "org/jenkinsci/plugins/pipeline-model-parent"
 developers:
+- "@cloudbees-developers"
 - "abayer"
 - "oleg_nenashev"
 - "rsandell"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
This PR adds the team `cloudbees-developers` to another possible set of cloudbees-owned plugins.
Keeping in draft right now as this is a first pass.

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
