### PR TITLE
Move sonar-gerrit-plugin issues from JIRA to GitHub

### DIFF
--- a/permissions/plugin-sonar-gerrit.yml
+++ b/permissions/plugin-sonar-gerrit.yml
@@ -1,8 +1,8 @@
 ---
 name: "sonar-gerrit"
-github: "jenkinsci/sonar-gerrit-plugin"
+github: &GH "jenkinsci/sonar-gerrit-plugin"
 issues:
-- jira: '20853' # sonar-gerrit-plugin
+- github: *GH
 paths:
 - "org/jenkins-ci/plugins/sonar-gerrit"
 developers:


### PR DESCRIPTION
# Description

Move [sonar-gerrit-plugin](https://github.com/jenkinsci/sonar-gerrit-plugin) issues from JIRA to GitHub

# Submitter checklist for adding or changing permissions

### Always

- [X] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
