### PR TITLE
Add issue forms (preparation for moving hosting to GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-hosting-request.yml
+++ b/.github/ISSUE_TEMPLATE/1-hosting-request.yml
@@ -1,0 +1,58 @@
+name: '🏠 Hosting request'
+labels: 'hosting-request'
+description: I want to host a plugin or library in the Jenkins organization
+
+body:
+  - type: input
+    attributes:
+      label: Repository URL
+      description: |
+        URL of the repository to host in the jenkinsci organization
+      placeholder: |
+        https://github.com/your-org/your-repo-name
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: New Repository Name
+      description: |
+        Name of the repository in the jenkinsci organization on GitHub
+      placeholder: |
+        your-cool-plugin
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        Describe what you want hosted here. Explain how it's different from other components that may be considered similar to this one.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: GitHub users to have commit permission
+      placeholder: |
+        @user1
+        @user2
+        @user3
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Jenkins project users to have release permission
+      description: The Jenkins project has it's own identity system, users can sign up at https://accounts.jenkins.io. All users *must* sign in to [Jira](https://issues.jenkins.io) and [Artifactory](https://repo.jenkins-ci.org/).
+      placeholder: |
+        user1
+        user2
+        user3
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Issue tracker
+      description: Which issue tracker to use. Issues for this component can be tracked on issues.jenkins.io in a component in the JENKINS project, or in the GitHub repository using GitHub issues. Using both at the same time is discouraged.
+      options:
+        - "Jira"
+        - "GitHub issues"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-report-bug.yml
@@ -1,0 +1,39 @@
+name: '🐛 Bug report'
+labels: 'bug'
+description: Create a bug report to help us improve
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Never report security issues on GitHub or other public channels (Gitter/Twitter/etc.)**
+        Follow these instruction to report security issues: https://www.jenkins.io/security/#reporting-vulnerabilities
+  - type: textarea
+    attributes:
+      label: Reproduction steps
+      description: |
+        Write bullet-point reproduction steps.
+      placeholder: |
+        1. Step 1: ...
+        2. Step 2: ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Results
+      description: What was your expected result?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual Results
+      description: What was the actual result?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: You can provide additional context below.

--- a/.github/ISSUE_TEMPLATE/3-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.yml
@@ -1,0 +1,16 @@
+name: '🚀 Feature request'
+labels: 'enhancement'
+description: I have a suggestion
+
+body:
+  - type: textarea
+    attributes:
+      label: What feature do you want to see added?
+      description: A clear and concise description of your feature request.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Upstream changes
+      description: Link here any upstream changes that might be relevant to this request

--- a/.github/ISSUE_TEMPLATE/4-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/4-documentation.yml
@@ -1,0 +1,15 @@
+name: '📝 Documentation'
+labels: 'documentation'
+description: 'Let us know if any documentation is missing or could be improved'
+
+body:
+  - type: textarea
+    attributes:
+      label: Describe your use-case which is not covered by existing documentation.
+      description: If it is easier to submit a documentation patch instead of writing an issue, just do it!
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community forum
+    url: https://community.jenkins.io/
+    about: Please ask and answer questions here
+  - name: Mailing lists
+    url: https://www.jenkins.io/mailing-lists/
+    about: You can also raise a question in one of the user or developer mailing lists


### PR DESCRIPTION
See:

- https://github.com/timja/repository-permissions-updater/issues/new/choose
- https://github.com/timja/repository-permissions-updater/issues/1

Other forms are imported from https://github.com/jenkinsci/.github/tree/master/.github/ISSUE_TEMPLATE