### PR TITLE
Enable CD for `scm-api`

### DIFF
--- a/permissions/plugin-scm-api.yml
+++ b/permissions/plugin-scm-api.yml
@@ -5,6 +5,8 @@ issues:
 - jira: '18054' # scm-api-plugin
 paths:
 - "org/jenkins-ci/plugins/scm-api"
+cd:
+  enabled: true
 developers:
 - "jglick"
 - "recena"


### PR DESCRIPTION
# Description

@dwnusbaum @rsandell et al. https://github.com/jenkinsci/scm-api-plugin/pull/102#issuecomment-1007228864

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
