### PR TITLE
Add danile42 as maintainer.

### DIFF
--- a/permissions/plugin-dependency-check-jenkins-plugin.yml
+++ b/permissions/plugin-dependency-check-jenkins-plugin.yml
@@ -6,4 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/dependency-check-jenkins-plugin"
 developers:
-- "kudos_dude"
+- "danile42"


### PR DESCRIPTION
# Description

Set @danile42 (myself) as maintainer of https://plugins.jenkins.io/dependency-check-jenkins-plugin/ (https://github.com/jenkinsci/dependency-check-plugin), replacing the previous maintainer @kudos-dude.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
