### PR TITLE
Chore(Jenkinsfile) use a maven-11 agent and stop relying on pipeline tools

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ props += pipelineTriggers(triggers)
 properties(props)
 
 
-node('java') {
+node('maven-11') {
     try {
         stage ('Clean') {
             deleteDir()
@@ -39,9 +39,7 @@ node('java') {
         }
 
         stage ('Build') {
-            def mvnHome = tool 'mvn'
-            env.JAVA_HOME = tool 'jdk11'
-            sh "${mvnHome}/bin/mvn -U clean verify"
+            sh "mvn -U clean verify"
         }
 
         stage ('Run') {
@@ -57,14 +55,14 @@ node('java') {
                     withCredentials([
                             usernamePassword(credentialsId: 'jiraUser', passwordVariable: 'JIRA_PASSWORD', usernameVariable: 'JIRA_USERNAME')
                             ]) {
-                        sh '${JAVA_HOME}/bin/java -DdryRun=true' + javaArgs
+                        sh 'java -DdryRun=true' + javaArgs
                     }
                 } catch(ignored) {
                     if (fileExists('checks-title.txt')) {
                         def title = readFile file: 'checks-title.txt', encoding: 'utf-8'
                         def summary = readFile file:'checks-details.txt', encoding:  'utf-8'
                         publishChecks conclusion: 'ACTION_REQUIRED',
-                                name: 'Validation', 
+                                name: 'Validation',
                             summary: summary,
                             title: title
                     }
@@ -79,7 +77,7 @@ node('java') {
                         usernamePassword(credentialsId: 'artifactoryAdmin', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME'),
                         usernamePassword(credentialsId: 'jenkins-infra-bot-github-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
                 ]) {
-                    sh '${JAVA_HOME}/bin/java ' + javaArgs
+                    sh 'java ' + javaArgs
                 }
             }
         }


### PR DESCRIPTION
Using tools is blocking a lot of PRs. The proposal is to stop relying on tools when both maven and java are already present in the machines.

Tested with a "debug" commit that shall be removed in https://github.com/jenkins-infra/repository-permissions-updater/pull/2315 with the help of @tfennelly .

Is there any impact of doing this that I could have forgotten?