### PR TITLE
Add java label, trusted doesn't have maven-* labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ props += pipelineTriggers(triggers)
 properties(props)
 
 
-node('maven-11') {
+node('java') {
     try {
         stage ('Clean') {
             deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ node('maven-11 || java') {
         }
 
         stage ('Build') {
-            sh "mvn -U clean verify"
+            sh "mvn -U -B -ntp clean verify"
         }
 
         stage ('Run') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ props += pipelineTriggers(triggers)
 properties(props)
 
 
-node('java') {
+node('maven-11 || java') {
     try {
         stage ('Clean') {
             deleteDir()


### PR DESCRIPTION
Relates to https://github.com/jenkins-infra/helpdesk/issues/2754

Trusted CI doesn't have maven-* or java-* labels only java

According to https://github.com/jenkins-infra/packer-images/search?q=DEFAULT_JDK

Default JDK is 11

Which should be equivalent to this