### PR TITLE
Enable CD for `external-monitor-job`

### DIFF
--- a/permissions/plugin-external-monitor-job.yml
+++ b/permissions/plugin-external-monitor-job.yml
@@ -5,6 +5,8 @@ issues:
 - jira: '17123' # external-monitor-job-plugin
 paths:
 - "org/jenkins-ci/plugins/external-monitor-job"
+cd:
+  enabled: true
 developers:
 - "jglick"
 - "recena"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/external-monitor-job-plugin/pull/20#issuecomment-1018719515 CC @batmat @rsandell @fcojfernandez et al.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
