### PR TITLE
Always use maven-11 Docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ props += pipelineTriggers(triggers)
 properties(props)
 
 
-node('maven-11 || java') {
+node('maven-11') {
     try {
         stage ('Clean') {
             deleteDir()


### PR DESCRIPTION
## Use only the maven-11 docker image

The previous label expression in the Jenkinsfile would accept a Java agent that does not have maven-11 (for example, the maven-8 image or another java image that does not include maven-11).

Be explicit that this job runs maven, therefore, use the maven-11 Docker image 

# Description

Fixes https://github.com/jenkins-infra/helpdesk/issues/2732

### Always

- [x] Add link to plugin/component Git repository in description above **N/A**

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
