### PR TITLE
Update plugin-lockable-resources.yml

### DIFF
--- a/permissions/plugin-lockable-resources.yml
+++ b/permissions/plugin-lockable-resources.yml
@@ -12,3 +12,4 @@ developers:
 - "basil"
 - "tgr"
 - "robinjarry"
+- "jimklimov"


### PR DESCRIPTION
Add developer "jimklimov" to adopt the Lockable Resources plugin

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

As the "Lockable Resources" plugin has been marked for `adopt-this-plugin` and releases for the past couple of years concerned mostly dependabot updates, I would like to take up the duties and adopt the plugin in order to keep it maintained in terms of community-contributed features and so to keep it updated, useful, and relevant.

For some past years I had to roll my own fork with my and others' PRs applied over master, in order to have the features my farms rely on. This is not as convenient as just installing a current plugin release from Artifactory and having the features there :)

The link to the concerned GitHub repository is https://github.com/jenkinsci/lockable-resources-plugin/

CC @basil who suggested that I (@jimklimov) and/or @offa take over :) in https://github.com/jenkinsci/lockable-resources-plugin/pull/273

Also CC @abayer and @jglick as they had a good architectural view for the plugin discussed in e.g. https://github.com/jenkinsci/lockable-resources-plugin/pull/64 so hopefully might lead me away from mistakes in the future ;) (That said, we do need and use a sort of feature proposed in that PR, implemented elsewhere in a shared library, and I'd love to have an in-core ability to separate the lock() and unlock() activities...)

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
