### PR TITLE
Enable CD on plugin-typetalk

### DIFF
--- a/permissions/plugin-typetalk.yml
+++ b/permissions/plugin-typetalk.yml
@@ -1,7 +1,12 @@
 ---
 name: "typetalk"
+github: "jenkinsci/typetalk-plugin"
+issues:
+  - jira: '18421' # typetalk-plugin
 paths:
 - "org/jenkins-ci/plugins/typetalk"
+cd:
+  enabled: true
 developers:
 - "ikikko"
 - "yasuyuki_baba"


### PR DESCRIPTION
# Description

I would like to set up CD to make it easier to release Typetalk Plugin https://github.com/jenkinsci/typetalk-plugin

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
