### PR TITLE
Revert "Added Security Contacts (#2394)"

### DIFF
--- a/permissions/plugin-conjur-credentials.yml
+++ b/permissions/plugin-conjur-credentials.yml
@@ -8,6 +8,3 @@ paths:
 - "org/conjur/jenkins/conjur-credentials"
 developers:
 - "cyberark_bizdev"
-security:
-  contacts:
-    email: "product_security@cyberark.com"


### PR DESCRIPTION
_As it was not approved by the Security Officer and was done using email instead of Jira account._

_This reverts commit bc788f90fa5093c1763bfb8cb30ea4c7da5362ac._

I would like to get rid of the email part of this feature to have a single communication channel with the maintainers and the security contacts. Having emails there add a non-necessary layer of complexity.

Comment posted in https://github.com/jenkins-infra/repository-permissions-updater/pull/2394#issuecomment-1043626001 but not followed by a modification => reverting the change.

@cyberark-bizdev Please create a Jira account backed by the proposed email and it will be accepted.

I will keep this PR open until the end of the week to give you a chance to propose your own PR updating the existing.