### PR TITLE
Add CB maintainers to plugins

### DIFF
--- a/permissions/plugin-bouncycastle-api.yml
+++ b/permissions/plugin-bouncycastle-api.yml
@@ -11,3 +11,4 @@ developers:
 - "jthompson"
 - "teilo"
 - "@security"
+- "@cloudbees-developers"

--- a/permissions/plugin-credentials-binding.yml
+++ b/permissions/plugin-credentials-binding.yml
@@ -6,7 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/credentials-binding"
 developers:
-- "danielbeck"
 - "jglick"
 - "jvz"
-- "wfollonier"
+- "@security"
+- "@cloudbees-developers"

--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -14,3 +14,4 @@ developers:
 - "jvz"
 - "jthompson"
 - "@security"
+- "@cloudbees-developers"

--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -7,3 +7,4 @@ paths:
 - "org/jenkins-ci/plugins/matrix-auth"
 developers:
 - "danielbeck"
+- "@cloudbees-developers"

--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -7,4 +7,3 @@ paths:
 - "org/jenkins-ci/plugins/matrix-auth"
 developers:
 - "danielbeck"
-- "@cloudbees-developers"

--- a/permissions/plugin-pam-auth.yml
+++ b/permissions/plugin-pam-auth.yml
@@ -6,7 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/pam-auth"
 developers:
-- "danielbeck"
 - "recena"
 - "jvz"
-- "wfollonier"
+- "@security"
+- "@cloudbees-developers"

--- a/permissions/plugin-plain-credentials.yml
+++ b/permissions/plugin-plain-credentials.yml
@@ -6,7 +6,7 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/plain-credentials"
 developers:
-- "danielbeck"
 - "jglick"
 - "jthompson"
-- "wfollonier"
+- "@security"
+- "@cloudbees-developers"

--- a/permissions/plugin-secure-requester-whitelist.yml
+++ b/permissions/plugin-secure-requester-whitelist.yml
@@ -7,7 +7,6 @@ paths:
 - "org/jenkins-ci/plugins/secure-requester-whitelist"
 developers:
 - "jglick"
-- "danielbeck"
 - "andresrc"
-- "wfollonier"
-  
+- "@security"
+- "@cloudbees-developers"

--- a/permissions/plugin-ssh-credentials.yml
+++ b/permissions/plugin-ssh-credentials.yml
@@ -6,9 +6,9 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/ssh-credentials"
 developers:
-- "danielbeck"
 - "jglick"
 - "oleg_nenashev"
 - "jvz"
 - "jthompson"
-- "wfollonier"
+- "@security"
+- "@cloudbees-developers"

--- a/teams/security.yml
+++ b/teams/security.yml
@@ -2,4 +2,5 @@
 name: "security"
 developers:
 - "danielbeck"
+- "kevingrdj"
 - "wfollonier"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

- [x] As part of `@security` I auto-approve my changes to all except matrix-auth
- ~[ ] matrix-auth requires approval from @daniel-beck~ => refused

The `@security` team will keep working on the security aspects of those plugins and additional people will help/contribute.

CC @jtnord @batmat as it's the result of our discussion last week.
CC @Kevin-CB for the addition to the `@security` team

Plugin repositories:
- [x] https://github.com/jenkinsci/bouncycastle-api-plugin, approved by me as member of @security
- [x] https://github.com/jenkinsci/credentials-plugin, approved by me as member of @security
- [x] https://github.com/jenkinsci/credentials-binding-plugin, approved by me as "direct" maintainer
- [x] https://github.com/jenkinsci/pam-auth-plugin, approved by me as "direct" maintainer
- [x] https://github.com/jenkinsci/plain-credentials-plugin, approved by me as "direct" maintainer
- [x] https://github.com/jenkinsci/secure-requester-whitelist-plugin, approved by me as "direct" maintainer
- [x] https://github.com/jenkinsci/ssh-credentials-plugin, approved by me as "direct" maintainer

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
