### PR TITLE
JENKINS-67935: updates compuware plugin permissions

### DIFF
--- a/permissions/plugin-compuware-ispw-operations.yml
+++ b/permissions/plugin-compuware-ispw-operations.yml
@@ -6,5 +6,4 @@ issues:
 paths:
 - "com/compuware/jenkins/compuware-ispw-operations"
 developers:
-- "zhouqr2000"
 - "cpwr_jenkins"

--- a/permissions/plugin-compuware-strobe-measurement.yml
+++ b/permissions/plugin-compuware-strobe-measurement.yml
@@ -6,5 +6,4 @@ issues:
 paths:
 - "com/compuware/jenkins/compuware-strobe-measurement"
 developers:
-- "VinceCapodanno"
-- "pfhjgd0"
+- "cpwr_jenkins"

--- a/permissions/plugin-compuware-topaz-for-total-test.yml
+++ b/permissions/plugin-compuware-topaz-for-total-test.yml
@@ -6,5 +6,4 @@ issues:
 paths:
 - "com/compuware/jenkins/compuware-topaz-for-total-test"
 developers:
-- "efhjnw0"
-- "112655"
+- "cpwr_jenkins"

--- a/permissions/plugin-compuware-topaz-for-total-test.yml
+++ b/permissions/plugin-compuware-topaz-for-total-test.yml
@@ -6,4 +6,5 @@ issues:
 paths:
 - "com/compuware/jenkins/compuware-topaz-for-total-test"
 developers:
-- "cpwr_jenkins"
+- "efhjnw0"
+- "112655"

--- a/permissions/plugin-compuware-zadviser-api.yml
+++ b/permissions/plugin-compuware-zadviser-api.yml
@@ -5,5 +5,4 @@ issues:
 paths:
 - "com/compuware/jenkins/compuware-zadviser-api"
 developers:
-- "jgoering41"
 - "cpwr_jenkins"


### PR DESCRIPTION
Permissions for compuware plugins were updated to have only one
developer: cpwr_jenkins

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Updating some permissions for compuware jenkins plugins.
Links to plugins:
- [x] https://github.com/jenkinsci/compuware-ispw-operations-plugin - approved via jira `cpwr_jenkins`
- [x] https://github.com/jenkinsci/compuware-strobe-measurement-plugin approved by [pfhjgd0](https://github.com/pfhjgd0)
- [ ] https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin - needs @RonVorndam or @efhjnw0
- [x] https://github.com/jenkinsci/compuware-zadviser-api-plugin - approved via jira `cpwr_jenkins`

Tagging contributors:
@zhouqr2000 
@VinceCapodanno 
@pfhjgd0
@efhjnw0  
@RonVorndam 
@jgoering41

The current person managing the cpwr_jenkins account is me, so I think my username needs to be added to commiters.
@vzamoragbmc


# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
