### PR TITLE
Enable CD for `junit-attachments`

### DIFF
--- a/permissions/plugin-junit-attachments.yml
+++ b/permissions/plugin-junit-attachments.yml
@@ -7,6 +7,8 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/junit-attachments"
 - "org/jvnet/hudson/plugins/junit-attachments"
+cd:
+  enabled: true
 developers:
 - "abayer"
 - "jglick"


### PR DESCRIPTION
# Description

Make it easier to release e.g. https://github.com/jenkinsci/junit-attachments-plugin/pull/29

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
