### PR TITLE
Adopt global build stats plugin

### DIFF
--- a/permissions/plugin-global-build-stats.yml
+++ b/permissions/plugin-global-build-stats.yml
@@ -7,3 +7,6 @@ paths:
 - "org/jenkins-ci/plugins/global-build-stats"
 developers:
 - "dhinske"
+- "notmyfault"
+cd:
+  enabled: true


### PR DESCRIPTION
I'm looking forward to adopt https://github.com/jenkinsci/global-build-stats-plugin to - at least - deliver my PRs that adapt the icon path removal from core.
The plugin itself is abandoned since 2016, yet I'm mentioning the listed maintainer below, for the record.

# Description

cc @dhinske 

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [X] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
