### PR TITLE
Remove danielbeck from sshd plugin

### DIFF
--- a/permissions/plugin-sshd.yml
+++ b/permissions/plugin-sshd.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/sshd-plugin"
 paths:
 - "org/jenkins-ci/modules/sshd"
 developers:
-- "danielbeck"
 - "ifernandezcalvo"
 - "jvz"
 - "oleg_nenashev"


### PR DESCRIPTION
I do not see myself as a maintainer of this plugin. This used to be a core module (#1680), now isn't anymore.