### PR TITLE
Migrate strict-crumb-issuer to 'security' team

### DIFF
--- a/permissions/plugin-strict-crumb-issuer.yml
+++ b/permissions/plugin-strict-crumb-issuer.yml
@@ -6,5 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/strict-crumb-issuer"
 developers:
-- "danielbeck"
-- "wfollonier"
+- "@security"


### PR DESCRIPTION
This effectively adds @Kevin-CB as a new co-maintainer.

@Wadeck to approve.

A potential problem here is the semantic conflict of `security` being either "folks working pretty much full time in the Jenkins security team led by the security officer" or "the people in the team at CloudBees working on Jenkins security", which overlap but are not identical. I'll leave that for @Wadeck to clear up, potentially with @batmat who defined the team.