### PR TITLE
Remove danielbeck from compress-buildlog plugin

### DIFF
--- a/permissions/plugin-compress-buildlog.yml
+++ b/permissions/plugin-compress-buildlog.yml
@@ -6,5 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/compress-buildlog"
 developers:
-- "danielbeck"
 - "oleg_nenashev"


### PR DESCRIPTION
I am disowning this plugin. I have no interest in further maintaining it.