### PR TITLE
Retroactively add ux team to ui samples plugin

### DIFF
--- a/permissions/plugin-ui-samples-plugin.yml
+++ b/permissions/plugin-ui-samples-plugin.yml
@@ -8,3 +8,4 @@ paths:
 - "org/jvnet/hudson/main/ui-samples-plugin"
 developers:
 - "@core"
+- "@ux"

--- a/permissions/plugin-ui-samples-plugin.yml
+++ b/permissions/plugin-ui-samples-plugin.yml
@@ -4,7 +4,7 @@ github: &GH "jenkinsci/design-library-plugin"
 issues:
   - github: *GH
 paths:
-- "io/jenkins/plugins/design-library-plugin"
+- "io/jenkins/plugins/design-library"
 - "org/jenkins-ci/main/ui-samples-plugin"
 - "org/jvnet/hudson/main/ui-samples-plugin"
 developers:

--- a/permissions/plugin-ui-samples-plugin.yml
+++ b/permissions/plugin-ui-samples-plugin.yml
@@ -1,11 +1,14 @@
 ---
 name: "ui-samples-plugin"
-github: &GH "jenkinsci/ui-samples-plugin"
+github: &GH "jenkinsci/design-library-plugin"
 issues:
   - github: *GH
 paths:
+- "io/jenkins/plugins/design-library-plugin"
 - "org/jenkins-ci/main/ui-samples-plugin"
 - "org/jvnet/hudson/main/ui-samples-plugin"
 developers:
 - "@core"
 - "@ux"
+cd:
+  enabled: true

--- a/teams/ux.yml
+++ b/teams/ux.yml
@@ -1,0 +1,10 @@
+---
+name: "ux"
+developers:
+- "batmat"
+- "drulli"
+- "oleg_nenashev"
+- "fqueiruga"
+- "notmyfault"
+- "timja"
+- "janfaracik"


### PR DESCRIPTION
Add ux people retroactively to ui samples aka design lib: https://github.com/jenkinsci/ui-samples-plugin

I'm not sure if @janfaracik did log into [Artifactory](https://repo.jenkins-ci.org/) yet, I couldn't find his username in the artifactory ldap user report.

cc @timja 

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [X] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [X] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
