### PR TITLE
Add remoting-security-workaround permissions file

### DIFF
--- a/permissions/plugin-remoting-security-workaround.yml
+++ b/permissions/plugin-remoting-security-workaround.yml
@@ -1,0 +1,9 @@
+---
+name: "remoting-security-workaround"
+github: &GH "jenkinsci/remoting-security-workaround-plugin"
+issues:
+- github: *GH
+paths:
+- "io/jenkins/plugins/remoting-security-workaround"
+developers:
+- "@security"


### PR DESCRIPTION
This plugin was released as part of the [2021-11-04 security advisory](https://www.jenkins.io/security/advisory/2021-11-04/) as a workaround for anyone not able to immediately update Jenkins. As such, its first and only release so far was published through the security process, which bypasses regular hosting permissions.

This now creates the corresponding RPU file. An after-the-fact hosting request seems unnecessary.

GitHub: https://github.com/jenkinsci/remoting-security-workaround-plugin
Site: https://plugins.jenkins.io/remoting-security-workaround/

@Wadeck to approve since it's going into his team 😛 