### PR TITLE
`instance-identity-module` is now `instance-identity-plugin`

### DIFF
--- a/permissions/plugin-instance-identity.yml
+++ b/permissions/plugin-instance-identity.yml
@@ -1,6 +1,6 @@
 ---
 name: "instance-identity"
-github: "jenkinsci/instance-identity-module"
+github: "jenkinsci/instance-identity-plugin"
 paths:
 - "org/jenkins-ci/modules/instance-identity"
 developers:


### PR DESCRIPTION
# Description

Noticed that Incrementals are not being deployed after the repo rename following https://github.com/jenkinsci/instance-identity-plugin/pull/17 + https://github.com/jenkinsci/instance-identity-plugin/commit/7ee33c8831f2203ff6adc28be3aa962b1c11d992. @timja

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
