### PR TITLE
Publish design library

### DIFF
--- a/permissions/plugin-design-library.yml
+++ b/permissions/plugin-design-library.yml
@@ -1,10 +1,12 @@
 ---
-name: "ui-samples-plugin"
+name: "design-library"
 github: &GH "jenkinsci/design-library-plugin"
 issues:
   - github: *GH
 paths:
-- "org/jenkins-ci/main/ui-samples-plugin"
+- "io/jenkins/plugins/design-library"
 developers:
 - "@core"
 - "@ux"
+cd:
+  enabled: true

--- a/permissions/plugin-ui-samples-plugin.yml
+++ b/permissions/plugin-ui-samples-plugin.yml
@@ -1,10 +1,14 @@
 ---
 name: "ui-samples-plugin"
-github: &GH "jenkinsci/ui-samples-plugin"
+github: &GH "jenkinsci/design-library-plugin"
 issues:
   - github: *GH
 paths:
+- "io/jenkins/plugins/design-library"
 - "org/jenkins-ci/main/ui-samples-plugin"
 - "org/jvnet/hudson/main/ui-samples-plugin"
 developers:
 - "@core"
+- "@ux"
+cd:
+  enabled: true

--- a/teams/ux.yml
+++ b/teams/ux.yml
@@ -1,0 +1,10 @@
+---
+name: "ux"
+developers:
+- "batmat"
+- "drulli"
+- "oleg_nenashev"
+- "fqueiruga"
+- "notmyfault"
+- "timja"
+- "janfaracik"


### PR DESCRIPTION
Reverts https://github.com/jenkins-infra/repository-permissions-updater/pull/2455 with corrections applied on top

cc @NotMyFault @janfaracik @uhafner 

https://github.com/jenkinsci/design-library-plugin

<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
