### PR TITLE
Use Jira for implied labels plugin issues

### DIFF
--- a/permissions/plugin-implied-labels.yml
+++ b/permissions/plugin-implied-labels.yml
@@ -3,7 +3,6 @@ name: "implied-labels"
 github: &gh "jenkinsci/implied-labels-plugin"
 issues:
 - jira: '18330' # implied-labels-plugin
-- github: *gh
 paths:
 - "org/jenkins-ci/plugins/implied-labels"
 developers:


### PR DESCRIPTION
# Description

Use Jira for [implied labels plugin](https://github.com/jenkinsci/implied-labels-plugin) issue reports

Only one issue had been reported using GitHub issues.  Jira issues are easier for me to track and to connect to other issues.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
