### PR TITLE
Adopt abandoned plugins to cut a release

### DIFF
--- a/permissions/plugin-clearcase-ucm-api.yml
+++ b/permissions/plugin-clearcase-ucm-api.yml
@@ -8,3 +8,6 @@ paths:
 developers:
 - "praqma"
 - "atombrella"
+- "notmyfault"
+cd:
+  enabled: true

--- a/permissions/plugin-copy-project-link.yml
+++ b/permissions/plugin-copy-project-link.yml
@@ -7,4 +7,6 @@ paths:
 - "hudson/plugins/copyProjectLink/copy-project-link"
 - "org/jenkins-ci/plugins/copy-project-link"
 developers:
-- "olivergondza"
+- "notmyfault"
+cd:
+  enabled: true

--- a/permissions/plugin-jenkins-multijob-plugin.yml
+++ b/permissions/plugin-jenkins-multijob-plugin.yml
@@ -10,3 +10,6 @@ developers:
 - "hagzag"
 - "yorammi"
 - "cohencil"
+- "notmyfault"
+cd:
+  enabled: true


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I'm looking forward to adopt
- [x] https://github.com/jenkinsci/clearcase-ucm-plugin
- [x] https://github.com/jenkinsci/copy-project-link-plugin
- [x] https://github.com/jenkinsci/tikal-multijob-plugin

to cut a release regarding [JENKINS-68251](https://issues.jenkins.io/browse/JENKINS-68251) and the forthcoming LTS release.
The first plugin is not labeled as up for adaption but clearly indicates it in the [Readme](https://github.com/jenkinsci/tikal-multijob-plugin#does-anyone-want-to-become-a-maintainer-of-this-plugin). The second one has the appropriate label (almost, that should suffice) and the third one's last commit was olivergondza removing themself as maintainer.


# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [X] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [X] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
