### PR TITLE
Remove Basil from Exclusion, Git Bisect, and Maven Repository Server

### DIFF
--- a/permissions/component-jenkins-maven-plugin.yml
+++ b/permissions/component-jenkins-maven-plugin.yml
@@ -5,5 +5,4 @@ paths:
 - "com/nirima/jenkins/repository"
 - "com/nirima/jenkins/repository/jenkins-maven-plugin"
 developers:
-- "basil"
 - "magnayn"

--- a/permissions/plugin-Exclusion.yml
+++ b/permissions/plugin-Exclusion.yml
@@ -7,4 +7,3 @@ paths:
 - "org/jenkins-ci/plugins/Exclusion"
 developers:
 - "anthonyroux"
-- "basil"

--- a/permissions/plugin-git-bisect.yml
+++ b/permissions/plugin-git-bisect.yml
@@ -7,5 +7,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/git-bisect"
 developers:
-- "basil"
 - "dorav"

--- a/permissions/plugin-repository.yml
+++ b/permissions/plugin-repository.yml
@@ -6,5 +6,4 @@ issues:
 paths:
 - "jenkins/repository"
 developers:
-- "basil"
 - "magnayn"

--- a/permissions/pom-maven-repository-plugin.yml
+++ b/permissions/pom-maven-repository-plugin.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/maven-repository-plugin"
 paths:
 - "com/nirima/jenkins/repository/pom"
 developers:
-- "basil"
 - "magnayn"


### PR DESCRIPTION
I initially adopted these plugins to update them for Guava support. Builds and CI runs are now stable, releases have been in use for a while now, and there have been no reported issues, so it is time for me to say goodbye. I have added the `adopt-this-plugin` label to each one in GitHub.