### PR TITLE
Removal of the email support in the security contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,18 +88,14 @@ Add a section like the following to your plugin's YAML file:
 security:
   contacts:
     jira: some_user_name
-    email: security@acme.org
 ```
 
-Given the above example, we will primarily assign any security issue in Jira to `some_user_name` and send an email notification to `security@acme.org` to establish contact.
+Given the above example, we will primarily assign any security issue in Jira to `some_user_name`.
 Regular maintainers are added to the issue as well to give visibility and allow participation/discussion.
 This means that specifying a Jira security contact is only useful when it's an account not already listed as maintainer.
-Either of `jira` and `email` is optional.
+`jira` is optional.
 
-Please note that we generally reject email contacts due to the additional overhead in reaching out via email.
-Unless you represent a large organization with dedicated security team that needs to be involved in the coordination of a release, but is not otherwise part of plugin maintenance, please refrain from requesting to be contacted via email.
-
-⚠️ Update from 2022-02-24, note from the security officer, we plan to remove the email support to reduce the overhead of communication.
+If you represent a company with dedicated security team that needs to be involved, we recommend you to create a Jira account backed by a shared email.
 
 Managing Issue Trackers
 -----------------------

--- a/permissions/plugin-aws-codebuild.yml
+++ b/permissions/plugin-aws-codebuild.yml
@@ -10,6 +10,3 @@ developers:
 - "johnhankataw"
 - "taoyong"
 - "leobaran_aws"
-security:
-  contacts:
-    email: "aws-security@amazon.com"

--- a/permissions/plugin-aws-device-farm.yml
+++ b/permissions/plugin-aws-device-farm.yml
@@ -8,6 +8,3 @@ paths:
 developers:
 - "nikdabn"
 - "aws_device_farm_jenkins"
-security:
-  contacts:
-    email: "aws-security@amazon.com"

--- a/permissions/plugin-aws-sam.yml
+++ b/permissions/plugin-aws-sam.yml
@@ -8,6 +8,3 @@ paths:
 - "io/jenkins/plugins/aws-sam"
 developers:
 - "aws_sae_jenkinsio"
-security:
-  contacts:
-    email: "aws-security@amazon.com"

--- a/permissions/plugin-codedeploy.yml
+++ b/permissions/plugin-codedeploy.yml
@@ -13,6 +13,3 @@ developers:
 - "feverlu"
 - "q13117god"
 - "alena"
-security:
-  contacts:
-    email: "aws-security@amazon.com"

--- a/permissions/plugin-openshift-client.yml
+++ b/permissions/plugin-openshift-client.yml
@@ -16,5 +16,4 @@ developers:
 security:
   contacts:
     jira: "akram"
-    email: prodsec-openshift@redhat.com
 

--- a/permissions/plugin-openshift-login.yml
+++ b/permissions/plugin-openshift-login.yml
@@ -14,5 +14,4 @@ developers:
 security:
   contacts:
     jira: "akram"
-    email: prodsec-openshift@redhat.com
 

--- a/permissions/plugin-openshift-pipeline.yml
+++ b/permissions/plugin-openshift-pipeline.yml
@@ -14,5 +14,4 @@ developers:
 security:
   contacts:
     jira: "akram"
-    email: prodsec-openshift@redhat.com
 

--- a/permissions/plugin-openshift-sync.yml
+++ b/permissions/plugin-openshift-sync.yml
@@ -14,5 +14,4 @@ developers:
 security:
   contacts:
     jira: "akram"
-    email: prodsec-openshift@redhat.com
 

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -17,7 +17,6 @@ public class Definition {
     }
 
     public static class SecurityContacts {
-        public String email;
         public String jira;
     }
 


### PR DESCRIPTION
The email support for the security contact is creating more overhead than benefit to keep. So I want to get rid of this.

I contacted both AWS and RedHat security teams with explanation and proposal to create a Jira account instead. 
I set a deadline set to end of March, but I got no non-automatic reply since then.

So, moving forward, we should no longer accept email in the security contact.

FYI @timja @halkeye @daniel-beck 

----

<details><summary>regular template</summary>

# Description

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
</details>