### PR TITLE
Enable CD for `ant`

### DIFF
--- a/permissions/plugin-ant.yml
+++ b/permissions/plugin-ant.yml
@@ -5,6 +5,8 @@ issues:
 - jira: '15488' # ant-plugin
 paths:
 - "org/jenkins-ci/plugins/ant"
+cd:
+  enabled: true
 developers:
 - "armfergom"
 - "jglick"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/ant-plugin/pull/93#issuecomment-1104784950 etc.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
