### PR TITLE
enable continuous deployment for image-link plugin

### DIFF
--- a/permissions/plugin-container-image-link.yml
+++ b/permissions/plugin-container-image-link.yml
@@ -7,3 +7,5 @@ developers:
 - "gabocuadros"
 issues:
   - jira: 28921
+cd:
+  enabled: true  


### PR DESCRIPTION

# Description

allow continuous deployment for container-image-link plugin 

# Plugin Involved

- [x] Add link to plugin/component Git repository in description above
https://github.com/jenkinsci/container-image-link-plugin

