### PR TITLE
Enable CD for `workflow-aggregator`

### DIFF
--- a/permissions/plugin-workflow-aggregator.yml
+++ b/permissions/plugin-workflow-aggregator.yml
@@ -5,6 +5,8 @@ issues:
 - jira: '21710' # workflow-aggregator-plugin
 paths:
 - "org/jenkins-ci/plugins/workflow/workflow-aggregator"
+cd:
+  enabled: true
 developers:
 - "jglick"
 - "kohsuke"


### PR DESCRIPTION
# Description

To release https://github.com/jenkinsci/workflow-aggregator-plugin/pull/47 and the like.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
