### PR TITLE
Add missing issue tracker link for sshd plugin

### DIFF
--- a/permissions/plugin-sshd.yml
+++ b/permissions/plugin-sshd.yml
@@ -1,6 +1,8 @@
 ---
 name: "sshd"
-github: "jenkinsci/sshd-plugin"
+github: &GH "jenkinsci/sshd-plugin"
+issues:
+  - github: *GH
 paths:
 - "org/jenkins-ci/modules/sshd"
 developers:


### PR DESCRIPTION
There's currently no issue tracker linked on https://plugins.jenkins.io/sshd/, this PR takes care of that.