### PR TITLE
Enable CD for `aws-global-configuration`

### DIFF
--- a/permissions/plugin-aws-global-configuration.yml
+++ b/permissions/plugin-aws-global-configuration.yml
@@ -5,6 +5,8 @@ issues:
 - jira: '23929' # aws-global-configuration-plugin
 paths:
 - "io/jenkins/plugins/aws-global-configuration"
+cd:
+  enabled: true
 developers:
 - "jglick"
 - "csanchez"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/aws-global-configuration-plugin/pull/21#pullrequestreview-983301481 not sure if other maintainers are active e.g. @Vlatombe and CC @car-roll 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
