### PR TITLE
Add hosting to assignees of new plugin requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-hosting-request.yml
+++ b/.github/ISSUE_TEMPLATE/1-hosting-request.yml
@@ -1,7 +1,8 @@
 name: '🏠 Hosting request'
 labels: 'hosting-request'
 description: I want to host a plugin or library in the Jenkins organization
-
+assignees:
+  - @jenkins-infra/hosting
 body:
   - type: input
     attributes:


### PR DESCRIPTION
that way @jenkins-infra/hosting actually gets notified of new issues.

I suspect this won't work because you can't assign to a team.