### PR TITLE
Add permissions file for groovy-sandbox

### DIFF
--- a/permissions/component-groovy-sandbox.yml
+++ b/permissions/component-groovy-sandbox.yml
@@ -1,0 +1,10 @@
+---
+name: "groovy-sandbox"
+github: "jenkinsci/groovy-sandbox"
+paths:
+- "org/kohsuke/groovy-sandbox"
+developers:
+- "carroll"
+- "dnusbaum"
+- "jglick"
+- "rsandell"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

https://github.com/jenkinsci/groovy-sandbox was moved into the `jenkinsci` org long ago, but it was still configured to use Kohsuke's parent POM and release to Maven Central. For the past four years this library has only been released to https://repo.jenkins-ci.org/, and only as part of Jenkins security advisories, which bypass the permissions set by this repository. I would like to be able to release this library to https://repo.jenkins-ci.org/ independently of security advisories.

For additional context, the last Maven Central release of the library was version 1.19 back in April 2018. However, even before that, versions 1.13 and 1.16, which were part of Jenkins security advisories, never got mirrored to Maven Central, leading to confusion for non-Jenkins consumers. In https://github.com/jenkinsci/groovy-sandbox/pull/58 we updated the library's readme to indicate that all new versions would only be released to https://repo.jenkins-ci.org/releases, and later in https://github.com/jenkinsci/groovy-sandbox/pull/63 we started explicitly discouraging all non-Jenkins usage of the library.

See also https://github.com/jenkinsci/groovy-sandbox/pull/76. The users listed in the new permission file are users who are listed in `permissions/script-security-plugin.yml` (which should be the only plugin consuming `groovy-sandbox`) that are still active in the Jenkins project. Eventually I would like to move this library into https://github.com/jenkinsci/script-security-plugin, but it will need its own permissions file either way.

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] ~[Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)~
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] ~Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).~
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] ~Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)~ (Not needed)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
