### PR TITLE
Prevent further releases of disk-usage

### DIFF
--- a/permissions/plugin-disk-usage.yml
+++ b/permissions/plugin-disk-usage.yml
@@ -4,8 +4,9 @@ github: "jenkinsci/disk-usage-plugin"
 issues:
 - jira: '15537' # disk-usage-plugin
 paths:
-- "org/jenkins-ci/plugins/disk-usage"
-- "org/jvnet/hudson/plugins/disk-usage"
+# Block creation of new releases. If you want to release the plugin, contact the Jenkins security team about SECURITY-2412
+- "org/jenkins-ci/plugins/disk-usage-releaseblock"
+- "org/jvnet/hudson/plugins/disk-usage-releaseblock"
 developers:
 - "vjuranek"
 - "oleg_nenashev"


### PR DESCRIPTION
The master branch of the disk-usage plugin introduces a security vulnerability. Since it's not present on any release, and maintainers are unresponsive, announcing it as unresolved would be kinda pointless, as it doesn't affect any releases.

So @Wadeck and I decided to instead prevent further releases instead, so that returning or new maintainers do not accidentally publish the vulnerability.