### PR TITLE
Remove Basil from GitLab plugins

### DIFF
--- a/permissions/plugin-gitlab-oauth.yml
+++ b/permissions/plugin-gitlab-oauth.yml
@@ -6,5 +6,4 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/gitlab-oauth"
 developers:
-- "basil"
 - "elhabib_med"

--- a/permissions/plugin-gitlab-plugin.yml
+++ b/permissions/plugin-gitlab-plugin.yml
@@ -8,5 +8,4 @@ paths:
 - "com/dabsquared/gitlab-plugin"
 - "org/jenkins-ci/plugins/gitlab-plugin"
 developers:
-- "basil"
 - "elbidouilleur" # jenkins.io/jira Username MaximeMazet Github username


### PR DESCRIPTION
# Description

I originally adopted these plugins in September and October 2021 to deliver [JENKINS-66304](https://issues.jenkins.io/browse/JENKINS-66304) and [JENKINS-66303](https://issues.jenkins.io/browse/JENKINS-66303). Since then, I have modernized these plugins and delivered a few releases, including several bug fixes and new features. I did some major work on updating the dependency trees for proper dynamic linking, including creating the `jersey2-api` plugin, updating `jackson2-api`, and modernizing `gitlab-api`. I feel that now is a good time for me to step away from these plugins, having left them in a better state than I found them. I have added the `adopt-this-plugin` label to each plugin.

https://github.com/jenkinsci/gitlab-plugin
https://github.com/jenkinsci/gitlab-oauth-plugin

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
