### PR TITLE
Add bguerin as developer on pipeline-maven-parent  and pipeline-maven-spy

### DIFF
--- a/permissions/component-pipeline-maven-spy.yml
+++ b/permissions/component-pipeline-maven-spy.yml
@@ -7,3 +7,4 @@ developers:
 - "alobato"
 - "cleclerc"
 - "aheritier"
+- "bguerin"

--- a/permissions/pom-pipeline-maven-parent.yml
+++ b/permissions/pom-pipeline-maven-parent.yml
@@ -7,3 +7,4 @@ developers:
 - "alobato"
 - "cleclerc"
 - "aheritier"
+- "bguerin"


### PR DESCRIPTION
Followup of #2082 to give to bguerin the permission to release the dependencies used by the plugin