### PR TITLE
Enable CD for pipeline-maven-plugin

### DIFF
--- a/permissions/component-pipeline-maven-spy.yml
+++ b/permissions/component-pipeline-maven-spy.yml
@@ -1,6 +1,8 @@
 ---
 name: "pipeline-maven-spy"
 github: "jenkinsci/pipeline-maven-plugin"
+cd:
+  enabled: true
 paths:
 - "org/jenkins-ci/plugins/pipeline-maven-spy"
 developers:

--- a/permissions/pom-pipeline-maven-parent.yml
+++ b/permissions/pom-pipeline-maven-parent.yml
@@ -1,6 +1,8 @@
 ---
 name: "pipeline-maven-parent"
 github: "jenkinsci/pipeline-maven-plugin"
+cd:
+  enabled: true
 paths:
 - "org/jenkins-ci/plugins/pipeline-maven-parent"
 developers:


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

https://github.com/jenkinsci/pipeline-maven-plugin Preparation for enabling CD releases

Follow up of https://github.com/jenkins-infra/repository-permissions-updater/pull/2608, as it was incomplete (missing components)

FYI @alecharp @aheritier 

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
