### PR TITLE
Prevent further releases of build-notifications

### DIFF
--- a/permissions/plugin-build-notifications.yml
+++ b/permissions/plugin-build-notifications.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/build-notifications-plugin"
 issues:
 - jira: '22524' # build-notifications-plugin
 paths:
-- "tools/devnull/build-notifications"
+# Block creation of new releases. If you want to release the plugin, contact the Jenkins security team about SECURITY-2333
+- "tools/devnull/build-notifications-releaseblock"
 developers:
 - "ataxexe"


### PR DESCRIPTION
The master branch of the build-notifications plugin introduces a security vulnerability. Since it's not present on any release, and maintainers are unresponsive, announcing it as unresolved would be kinda pointless, as it doesn't affect any releases.

So @Wadeck and I decided to instead prevent further releases instead, so that returning or new maintainers do not accidentally publish the vulnerability.
