### PR TITLE
Enable CD on `instance-identity`

### DIFF
--- a/permissions/plugin-instance-identity.yml
+++ b/permissions/plugin-instance-identity.yml
@@ -5,5 +5,7 @@ issues:
   - jira: '23222'
 paths:
 - "org/jenkins-ci/modules/instance-identity"
+cd:
+  enabled: true
 developers:
 - "@core"


### PR DESCRIPTION
# Description

Was reluctant to do this earlier since it makes it slightly more work to prefile PRs like https://github.com/jenkins-infra/update-center2/pull/594 or https://github.com/jenkins-infra/update-center2/pull/601 but those should no longer be necessary after https://github.com/jenkinsci/instance-identity-plugin/pull/25. @timja @jtnord et al.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
