### PR TITLE
[HOSTING-731][SECURITY-1779] Add/block ibm-g11-pipeline

### DIFF
--- a/permissions/plugin-ibm-g11n-pipeline.yml
+++ b/permissions/plugin-ibm-g11n-pipeline.yml
@@ -1,0 +1,9 @@
+---
+name: "ibm-g11n-pipeline"
+github: "jenkinsci/ibm-g11n-pipeline-plugin"
+issues:
+- jira: '25029' # ibm-g11n-pipeline-plugin
+paths:
+# Block creation of new releases. If you want to release the plugin, contact the Jenkins security team about SECURITY-1779
+- "org/jenkins-ci/plugins/ibm-g11n-pipeline-releaseblock"
+developers: []


### PR DESCRIPTION
# Description

[HOSTING-731](https://issues.jenkins.io/browse/HOSTING-731) was never finished. https://github.com/jenkinsci/ibm-g11n-pipeline-plugin exists, but this file wasn't set up, and there's no real release.

At the same time, we identified a vulnerability in this unreleased plugin. Like https://github.com/jenkins-infra/repository-permissions-updater/pull/2603 and https://github.com/jenkins-infra/repository-permissions-updater/pull/2618 before, this PR aims to block releases. Different from those previously released plugins with unreleased vulnerabilities, this is a completely new plugin, so this PR creates the permissions file for it.

# Submitter checklist for adding or changing permissions


### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [n/a] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [n/a] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [n/a] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [n/a] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
