### PR TITLE
Enable CD for `groovy`

### DIFF
--- a/permissions/plugin-groovy.yml
+++ b/permissions/plugin-groovy.yml
@@ -3,6 +3,8 @@ name: "groovy"
 github: "jenkinsci/groovy-plugin"
 issues:
 - jira: '15549' # groovy-plugin
+cd:
+  enabled: true
 paths:
 - "org/jenkins-ci/plugins/groovy"
 - "org/jvnet/hudson/plugins/groovy"

--- a/permissions/plugin-groovy.yml
+++ b/permissions/plugin-groovy.yml
@@ -9,4 +9,4 @@ paths:
 - "org/jenkins-ci/plugins/groovy"
 - "org/jvnet/hudson/plugins/groovy"
 developers:
-- "vjuranek"
+- "jglick"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/groovy-plugin/pull/32#issuecomment-1172885724 @olivergondza @vjuranek @daniel-beck 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
