### PR TITLE
Permissions for new WebSocket components

### DIFF
--- a/permissions/component-websocket-jetty10.yml
+++ b/permissions/component-websocket-jetty10.yml
@@ -1,0 +1,7 @@
+---
+name: "websocket-jetty10"
+github: "jenkinsci/jenkins"
+paths:
+- "org/jenkins-ci/main/websocket-jetty10"
+developers:
+- "releasebot"

--- a/permissions/component-websocket-jetty9.yml
+++ b/permissions/component-websocket-jetty9.yml
@@ -1,0 +1,7 @@
+---
+name: "websocket-jetty9"
+github: "jenkinsci/jenkins"
+paths:
+- "org/jenkins-ci/main/websocket-jetty9"
+developers:
+- "releasebot"

--- a/permissions/component-websocket-spi.yml
+++ b/permissions/component-websocket-spi.yml
@@ -1,0 +1,7 @@
+---
+name: "websocket-spi"
+github: "jenkinsci/jenkins"
+paths:
+- "org/jenkins-ci/main/websocket-spi"
+developers:
+- "releasebot"


### PR DESCRIPTION
# Description

Seen in https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6801/1/console:

```
14:05:27  Invalid archive retrieved from Jenkins, perhaps the plugin is not properly incrementalized?
14:05:27  Error: ZIP error: Error: No permissions for org/jenkins-ci/main/websocket-jetty10/2.359-rc32567.c1c2c6d60a_78/websocket-jetty10-2.359-rc32567.c1c2c6d60a_78-sources.jar from https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6801/1/artifact/**/*c1c2c6d60a*78*/*c1c2c6d60a*78*/*zip*/archive.zip
14:05:27  Success: Status code 400 is in the accepted range: 100:599
```

This is the result of the new WebSocket components introduced in https://github.com/jenkinsci/jenkins/pull/6780 and https://github.com/jenkinsci/jenkins/pull/6785.

The current PR adds permissions consistent with the existing permissions for Jenkins core components:

- `permissions/component-cli.yml`
- `permissions/component-jenkins-bom.yml`
- `permissions/component-jenkins-core.yml`
- `permissions/component-jenkins-war.yml`
- `permissions/pom-jenkins-parent.yml`

(With the exception of omitting `kohsuke` from the permissions list, as he is no longer involved with the Jenkins project.)

I verified that the `name` field matches the artifact ID. I verified that the `path` field matches the path from `mvn clean install`.

- https://github.com/jenkinsci/jenkins

CC @jglick @timja

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
