### PR TITLE
[SECURITY-2739] Block new releases of elOyente

### DIFF
--- a/permissions/plugin-elOyente.yml
+++ b/permissions/plugin-elOyente.yml
@@ -4,5 +4,6 @@ github: "jenkinsci/eloyente-plugin"
 issues:
 - jira: '17504' # eloyente-plugin
 paths:
-- "com/technicolor/elOyente"
+# Block creation of new releases. If you want to release the plugin, contact the Jenkins security team about SECURITY-2739
+- "com/technicolor/elOyente-releaseblocker"
 developers: []


### PR DESCRIPTION
The master branch of the elOyente plugin introduces a security vulnerability. Since it's not present on any release, and there are no maintainers, announcing it as unresolved would be kinda pointless, as it doesn't affect any releases.