### PR TITLE
Remove myself and hanabishi from Lucene

### DIFF
--- a/permissions/plugin-lucene-search.yml
+++ b/permissions/plugin-lucene-search.yml
@@ -7,8 +7,6 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/lucene-search"
 developers:
-- "hanabishi"
-- "tobias_"
 - "markch"
 cd:
   enabled: true


### PR DESCRIPTION
We transferred ownership August last year and have not been involved since.

# Description

@hanabishi Please confirm that you agree to this change

https://github.com/jenkinsci/lucene-search-plugin

# Submitter checklist for adding or changing permissions

### Always

- [X] [Add link to plugin/component Git repository in description above](https://github.com/jenkinsci/lucene-search-plugin)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
