### PR TITLE
Remove `basil` from `maven-metadata`

### DIFF
--- a/permissions/plugin-maven-metadata-plugin.yml
+++ b/permissions/plugin-maven-metadata-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
 - "eu/markov/jenkins/plugin/mvnmeta/maven-metadata-plugin"
 developers:
-- "basil"
 - "gesh"
 - "marcrohlfs"


### PR DESCRIPTION
# Description

The Java 11 and JAXB updates to Maven Metadata Plugin were released in [2.1](https://github.com/jenkinsci/maven-metadata-plugin/releases/tag/maven-metadata-plugin-2.1), and no regressions have been reported since that release took place on May 18, so my work here is done. In addition, I left this plugin in a better state than I found it by making the plugin compatible with Pipeline jobs (https://github.com/jenkinsci/maven-metadata-plugin/pull/20) and migrating documentation from the old wiki (https://github.com/jenkinsci/maven-metadata-plugin/pull/24). I have already marked the plugin for adoption.

- https://github.com/jenkinsci/maven-metadata-plugin

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
