### PR TITLE
Sick of keeping up with pointless UI nonsense in core

### DIFF
--- a/permissions/plugin-cctray-xml.yml
+++ b/permissions/plugin-cctray-xml.yml
@@ -5,5 +5,4 @@ issues:
 - jira: '21967' # cctray-xml-plugin
 paths:
 - "org/jenkins-ci/plugins/cctray-xml"
-developers:
-- "danielbeck"
+developers: []


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/6229 broke the plugin less than a week after its release.

Now https://github.com/jenkinsci/jenkins/pull/6799 is the fourth iteration of updating the same UI element in less than a year.
