### PR TITLE
Add darinpope and markewaite as embeddable build status maintainers

### DIFF
--- a/permissions/plugin-embeddable-build-status.yml
+++ b/permissions/plugin-embeddable-build-status.yml
@@ -8,7 +8,9 @@ paths:
 - "org/jenkins-ci/plugins/embeddable-build-status"
 developers:
 - "christiangalsterer"
+- "darinpope"
 - "jglick"
+- "markewaite"
 - "mgedmin"
 - "thomas_dee"
 cd:


### PR DESCRIPTION
# Add darinpope and markewaite as embeddable build status maintainers
 
## Adopt Plugin: [Embeddable build status](https://github.com/jenkinsci/embeddable-build-status-plugin)

[Governance meeting notes](https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg/edit?disco=AAAAYXxgRHI) provides more context for the adoption request.  We believe it may be cheaper and easier to adopt this plugin than to remove the plugin from ci.jenkins.io and update the many repositories that refer to it.

[Help desk 3013](https://github.com/jenkins-infra/helpdesk/issues/3013) suggests that we should consider removing the plugin because it is not actively maintained.

[Help desk 3044](https://github.com/jenkins-infra/helpdesk/issues/3044) proposes steps to replace the use of this plugin with something hosted elsewhere on Jenkins infrastructure.

One of the existing maintainers needs to approve the adoption request.  Existing maintainers are:

* @thomas-dee
* @mgedmin
* @christiangalsterer
* @jglick

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
