### PR TITLE
Add `websocket-jetty11` permissions for prototyping

### DIFF
--- a/permissions/component-websocket-jetty11.yml
+++ b/permissions/component-websocket-jetty11.yml
@@ -1,0 +1,7 @@
+---
+name: "websocket-jetty11"
+github: "jenkinsci/jenkins"
+paths:
+- "org/jenkins-ci/main/websocket-jetty11"
+developers:
+- "releasebot"


### PR DESCRIPTION
# Description

Like #2638, but for Jetty 11. Even though we're not using Jetty 11 yet, the lack of these permissions prevents me from getting an incremental build of https://github.com/jenkinsci/jenkins/pull/6085:

```
Invalid archive retrieved from Jenkins, perhaps the plugin is not properly incrementalized?
Error: ZIP error: Error: No permissions for org/jenkins-ci/main/websocket-jetty11/2.363-rc32712.2307a_6dc9273/websocket-jetty11-2.363-rc32712.2307a_6dc9273-sources.jar from https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6085/3/artifact/**/*2307a*6dc9273*/*2307a*6dc9273*/*zip*/archive.zip
```

The lack of that incremental build prevents me from bootstrapping the test harness and doing further prototyping, so I would like to get these permissions set up.

- https://github.com/jenkinsci/jenkins

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
