### PR TITLE
chore: Add (myself to) component-maven-stapler-plugin

### DIFF
--- a/permissions/component-maven-stapler-plugin.yml
+++ b/permissions/component-maven-stapler-plugin.yml
@@ -1,0 +1,10 @@
+---
+name: "maven-stapler-plugin"
+github: &GH "jenkinsci/maven-stapler-plugin"
+issues:
+  - github: *GH
+paths:
+- "org/kohsuke/stapler/maven-stapler-plugin"
+developers:
+- "@core"
+- "notmyfault"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/maven-stapler-plugin

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

~~### For a newly hosted plugin only~~

~~- [ ] Add link to resolved HOSTING issue in description above~~

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
~~- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins~~

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it