### PR TITLE
Enable CD for Levo Plugin

### DIFF
--- a/permissions/plugin-levo.yml
+++ b/permissions/plugin-levo.yml
@@ -3,6 +3,8 @@ name: "levo"
 github: &GH "jenkinsci/levo-plugin"
 paths:
 - "io/jenkins/plugins/levo"
+cd:
+  enabled: true
 developers:
 - "mauroatlevo"
 issues:


### PR DESCRIPTION
# Description

Github Repository: [#jenkinsci/levo-plugin](https://github.com/jenkinsci/levo-plugin)
Resolved Hosting Issue: https://github.com/jenkins-infra/repository-permissions-updater/issues/2679

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [x] Add link to resolved HOSTING issue in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
