### PR TITLE
Enable CD for `docker-workflow`

### DIFF
--- a/permissions/plugin-docker-workflow.yml
+++ b/permissions/plugin-docker-workflow.yml
@@ -5,6 +5,8 @@ issues:
 - jira: '20625' # docker-workflow-plugin
 paths:
 - "org/jenkins-ci/plugins/docker-workflow"
+cd:
+  enabled: true
 developers:
 - "jglick"
 - "oleg_nenashev"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/docker-workflow-plugin/pull/269 is necessary for PCT runs against newer versions of core (between 2.357 and 2.361), apparently requiring https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.38 either for https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/51 or https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/54. Would like to make it easier to push out releases like this though I have no intention of maintaining the plugin from a feature perspective. @rsandell @dwnusbaum @car-roll 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
