### PR TITLE
Enable CD for `mercurial`

### DIFF
--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -6,6 +6,8 @@ issues:
 paths:
 - "org/jenkins-ci/plugins/mercurial"
 - "org/jvnet/hudson/plugins/mercurial"
+cd:
+  enabled: true
 developers:
 - "jglick"
 - "alecharp"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/mercurial-plugin/pull/228 etc.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
