### PR TITLE
Add jm_meessen, markewaite, poddingue as parameterized-trigger developers

### DIFF
--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -13,6 +13,9 @@ developers:
 - "svanoort"
 - "wolfs"
 - "olamy"
+- "jm_meessen"
+- "markewaite"
+- "poddingue"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
# Add jm_meessen, markewaite, poddingue as parameterized-trigger developers

Add @jmMeessen, @markewaite, and @gounthar as developers of the parameterized-trigger plugin.  The plugin is up for adoption so permission should not be required from current maintainers.

We will use the plugins we adopt as part of our "Contributing to Open Source" workshop at DevOps World 2022. Participants will be invited to create useful contributions to the plugins as part of the workshop.  We'll assure the plugins have been updated sufficiently to use as a baseline for the workshop. Participants in the workshop will be guided as they take specific steps to improve the plugin.  We'll have reference pull requests that the contributors can use as "answers" when they are perplexed by a problem or unable to proceed.

* Repository: https://github.com/jenkinsci/parameterized-trigger-plugin
* Pull requests: https://github.com/jenkinsci/parameterized-trigger-plugin/pulls?q=is%3Apr+author%3AjmMeessen

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it

