### PR TITLE
Drop kubernetes-cd adoption

### DIFF
--- a/permissions/plugin-kubernetes-cd.yml
+++ b/permissions/plugin-kubernetes-cd.yml
@@ -8,6 +8,3 @@ paths:
 - "org/jenkins-ci/plugins/kubernetes-cd"
 developers:
 - "zooopx"
-- "jm_meessen"
-- "markewaite"
-- "poddingue"


### PR DESCRIPTION
## Drop kubernetes-cd adoption

The kubernetes-cd plugin distribution has been suspended by the Jenkins security team.  Jean-Marc, Mark, and Bruno do not intend to resolve security issues in their contributing to open source workshop.  Dropping the plugin because we don't plan to make further changes to it.

https://github.com/jenkinsci/kubernetes-cd-plugin

This reverts commit 07ebdb15b0c78858db0f4760be8bc6c335657049.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
