### PR TITLE
Enable CD flag in Dynamic Search View

### DIFF
--- a/permissions/plugin-dynamic-search-view.yml
+++ b/permissions/plugin-dynamic-search-view.yml
@@ -5,6 +5,8 @@ issues:
 - jira: '17668' # dynamic-search-view-plugin
 paths:
 - "com/synopsys/arc/jenkinsci/dynamic-search-view"
+cd:
+  enabled: true
 developers:
 - "oleg_nenashev"
 - "kmartens27"


### PR DESCRIPTION
# Description

Looking to enable/add the CD flag for [Dynamic Search View](https://plugins.jenkins.io/dynamic-search-view/) as adoption process continues

# Submitter checklist for adding or changing permissions

### Always

- [x ] Add link to plugin/component Git repository in description above


### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
