### PR TITLE
Enable CD for maven-snapshot-check-plugin

### DIFF
--- a/permissions/plugin-maven-snapshot-check.yml
+++ b/permissions/plugin-maven-snapshot-check.yml
@@ -6,5 +6,7 @@ issues:
   - jira: '25126'  # maven-snapshot-check-plugin
 paths:
   - "org/jenkins-ci/plugins/maven-snapshot-check"
+cd:
+  enabled: true
 developers:
   - "donhui"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description
Enable CD for maven-snapshot-check-plugin

https://github.com/jenkinsci/maven-snapshot-check-plugin/pull/26


### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
