### PR TITLE
申请插件维护权限

### DIFF
--- a/permissions/plugin-upload-pgyer.yml
+++ b/permissions/plugin-upload-pgyer.yml
@@ -7,3 +7,4 @@ paths:
   - "ren/helloworld/upload-pgyer"
 developers:
   - "myroid"
+  - "Caoxy"


### PR DESCRIPTION
pgyer official wants to maintain the uploading-PGyer-plugin, which needs to be updated due to the update of pgyer's official api. However, pgyer submitted PR but failed to get the control's maintainer to merge and update, and contacted the plug-in developer, but no response was received. jenkins plugin could not be updated officially, so it was proposed to adopt and maintain the plugin

Plug-in link:  https://github.com/jenkinsci/upload-pgyer-plugin
Plug-in state: adoption

pull requests: https://github.com/jenkinsci/upload-pgyer-plugin/pull/5

GitHub id: https://github.com/manongxiaoyun

Email thread: https://groups.google.com/g/jenkinsci-dev/c/9ymSFoXuUjI

Jenkins infrastructure account id: Caoxy