### PR TITLE
Upgrade actions/github-script from 4.x to 6.x

### DIFF
--- a/.github/workflows/hosting-comment-checker.yml
+++ b/.github/workflows/hosting-comment-checker.yml
@@ -12,11 +12,11 @@ jobs:
     if: ${{ github.event.comment.body == '/hosting re-check'}}
     steps:
       - name: Ack
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |
             const {owner, repo} = context.issue
-            github.reactions.createForIssueComment({
+            github.rest.reactions.createForIssueComment({
               owner,
               repo,
               comment_id: context.payload.comment.id,

--- a/.github/workflows/hosting-comment-hoster.yml
+++ b/.github/workflows/hosting-comment-hoster.yml
@@ -14,11 +14,11 @@ jobs:
       actor_in_hosting_team: ${{ steps.checkUserMember.outputs.isTeamMember }}
     steps:
       - name: Ack
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |
             const {owner, repo} = context.issue
-            github.reactions.createForIssueComment({
+            github.rest.reactions.createForIssueComment({
               owner,
               repo,
               comment_id: context.payload.comment.id,


### PR DESCRIPTION
Follow up to https://github.com/jenkins-infra/repository-permissions-updater/pull/2866, but with the mentioned tweaks.

The breaking changes in 5.x and 6.x are outlined at https://github.com/actions/github-script#breaking-changes-in-v5