### PR TITLE
Removes alecharp from plugin maintainers

### DIFF
--- a/permissions/component-async-http-client.yml
+++ b/permissions/component-async-http-client.yml
@@ -5,7 +5,6 @@ paths:
   # For the 1.7.x branch which is the only needed one at the moment
   - "com/ning/async-http-client"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/component-lib-durable-task.yml
+++ b/permissions/component-lib-durable-task.yml
@@ -9,7 +9,6 @@ developers:
   - "bitwiseman"
   - "rsandell"
   - "teilo"
-  - "alecharp"
   - "batmat"
   - "olamy"
   - "mramonleon"

--- a/permissions/plugin-ace-editor.yml
+++ b/permissions/plugin-ace-editor.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/ui/ace-editor"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-active-directory.yml
+++ b/permissions/plugin-active-directory.yml
@@ -8,7 +8,6 @@ paths:
 developers:
   - "fbelzunc"
   - "kohsuke"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-antisamy-markup-formatter.yml
+++ b/permissions/plugin-antisamy-markup-formatter.yml
@@ -8,7 +8,6 @@ paths:
 developers:
   - "jglick"
   - "schristou"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-async-http-client.yml
+++ b/permissions/plugin-async-http-client.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/async-http-client"
   - "org/jenkinsci/plugins/async-http-client"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-bootstrap.yml
+++ b/permissions/plugin-bootstrap.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/ui/bootstrap"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-build-health-cache-updater.yml
+++ b/permissions/plugin-build-health-cache-updater.yml
@@ -8,4 +8,3 @@ paths:
 developers:
   - "rsandell"
   - "egutierrez"
-  - "alecharp"

--- a/permissions/plugin-cloverphp.yml
+++ b/permissions/plugin-cloverphp.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/cloverphp"
 developers:
   - "sogabe"
-  - "alecharp"
   - "batmat"
   - "bitwiseman"
   - "carroll"

--- a/permissions/plugin-deployer-framework.yml
+++ b/permissions/plugin-deployer-framework.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/deployer-framework"
 developers:
   - "jvz"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-diagnostics.yml
+++ b/permissions/plugin-diagnostics.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/diagnostics"
 developers:
-  - "alecharp"
   - "aheritier"
   - "escoem"

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -16,7 +16,6 @@ developers:
   - "bitwiseman"
   - "kshultz"
   - "teilo"
-  - "alecharp"
   - "batmat"
   - "olamy"
   - "mramonleon"

--- a/permissions/plugin-emma.yml
+++ b/permissions/plugin-emma.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/emma"
   - "org/jvnet/hudson/plugins/emma"
 developers:
-  - "alecharp"
   - "batmat"
   - "bitwiseman"
   - "carroll"

--- a/permissions/plugin-external-monitor-job.yml
+++ b/permissions/plugin-external-monitor-job.yml
@@ -10,7 +10,6 @@ cd:
 developers:
   - "jglick"
   - "recena"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-git-server.yml
+++ b/permissions/plugin-git-server.yml
@@ -10,7 +10,6 @@ cd:
 developers:
   - "jglick"
   - "kohsuke"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-google-compute-engine.yml
+++ b/permissions/plugin-google-compute-engine.yml
@@ -13,7 +13,6 @@ developers:
   - "donmccasland"
   - "tarahernandez"
   - "vishalapatel"
-  - "alecharp"
   - "batmat"
   - "teilo"
 security:

--- a/permissions/plugin-google-kubernetes-engine.yml
+++ b/permissions/plugin-google-kubernetes-engine.yml
@@ -13,7 +13,6 @@ developers:
   - "donmccasland"
   - "tarahernandez"
   - "vishalapatel"
-  - "alecharp"
   - "batmat"
   - "teilo"
   - "rarabaolaza"

--- a/permissions/plugin-google-metadata-plugin.yml
+++ b/permissions/plugin-google-metadata-plugin.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/google-metadata-plugin"
 developers:
-  - "alecharp"
   - "batmat"
   - "teilo"
 security:

--- a/permissions/plugin-google-oauth-plugin.yml
+++ b/permissions/plugin-google-oauth-plugin.yml
@@ -13,7 +13,6 @@ developers:
   - "donmccasland"
   - "tarahernandez"
   - "vishalapatel"
-  - "alecharp"
   - "batmat"
   - "teilo"
   - "rsandell"

--- a/permissions/plugin-google-storage-plugin.yml
+++ b/permissions/plugin-google-storage-plugin.yml
@@ -13,7 +13,6 @@ developers:
   - "donmccasland"
   - "tarahernandez"
   - "vishalapatel"
-  - "alecharp"
   - "batmat"
   - "teilo"
   - "rsandell"

--- a/permissions/plugin-handlebars.yml
+++ b/permissions/plugin-handlebars.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/ui/handlebars"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-jackson2-api.yml
+++ b/permissions/plugin-jackson2-api.yml
@@ -16,7 +16,6 @@ developers:
   - "carroll"
   - "olamy"
   - "mramonleon"
-  - "alecharp"
   - "bitwiseman"
 security:
   contacts:

--- a/permissions/plugin-jquery-detached.yml
+++ b/permissions/plugin-jquery-detached.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/ui/jquery-detached"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-junit.yml
+++ b/permissions/plugin-junit.yml
@@ -14,7 +14,6 @@ developers:
   - "olivergondza"
   - "wolfs"
   - "dnusbaum"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-matrix-project.yml
+++ b/permissions/plugin-matrix-project.yml
@@ -12,7 +12,6 @@ developers:
   - "jglick"
   - "oleg_nenashev"
   - "olivergondza"
-  - "alecharp"
   - "batmat"
   - "mramonleon"
   - "rsandell"

--- a/permissions/plugin-maven-dependency-update-trigger.yml
+++ b/permissions/plugin-maven-dependency-update-trigger.yml
@@ -7,4 +7,3 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/maven-dependency-update-trigger"
 developers:
-  - "alecharp"

--- a/permissions/plugin-maven-dependency-update-trigger.yml
+++ b/permissions/plugin-maven-dependency-update-trigger.yml
@@ -6,4 +6,4 @@ issues:
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/maven-dependency-update-trigger"
-developers:
+developers: []

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -10,7 +10,6 @@ cd:
   enabled: true
 developers:
   - "jglick"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-momentjs.yml
+++ b/permissions/plugin-momentjs.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/ui/momentjs"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-msbuild.yml
+++ b/permissions/plugin-msbuild.yml
@@ -9,7 +9,6 @@ developers:
   - mramonleon
   - batmat
   - rsandell
-  - alecharp
   - bitwiseman
   - carroll
   - olamy

--- a/permissions/plugin-node-iterator-api.yml
+++ b/permissions/plugin-node-iterator-api.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/node-iterator-api"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-numeraljs.yml
+++ b/permissions/plugin-numeraljs.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/ui/numeraljs"
 developers:
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-oauth-credentials.yml
+++ b/permissions/plugin-oauth-credentials.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/oauth-credentials"
 developers:
   - "mattmoor"
-  - "alecharp"
   - "egutierrez"
 security:
   contacts:

--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -15,7 +15,6 @@ developers:
   - "carroll"
   - "teilo"
   - "olamy"
-  - "alecharp"
   - "batmat"
   - "rarabaolaza"
 security:

--- a/permissions/plugin-ssh-agent.yml
+++ b/permissions/plugin-ssh-agent.yml
@@ -11,7 +11,6 @@ developers:
   - "jglick"
   - "kohsuke"
   - "recena"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-suppress-stack-trace.yml
+++ b/permissions/plugin-suppress-stack-trace.yml
@@ -8,7 +8,6 @@ paths:
 developers:
   - "jglick"
   - "recena"
-  - "alecharp"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-windows-slaves.yml
+++ b/permissions/plugin-windows-slaves.yml
@@ -10,7 +10,6 @@ developers:
   - "jglick"
   - "oleg_nenashev"
   - "rsandell"
-  - "alecharp"
   - "teilo"
   - "carroll"
   - "bitwiseman"

--- a/permissions/pom-js-module-base.yml
+++ b/permissions/pom-js-module-base.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/js-libs"
 paths:
   - "org/jenkins-ci/ui/jenkins-js-libs"
 developers:
-  - "alecharp"
   - "batmat"
   - "mramonleon"
   - "rsandell"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

I'm removing myself from the maintainers list of some plugins because I don't have time to actively maintain them anymore. @rsandell @batmat @jtnord @escoem @MRamonLeon 

There is a special case for https://github.com/jenkinsci/diagnostics-plugin where I think the plugin should be removed cc @escoem.

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
