### PR TITLE
Remove `basil` from `adoptopenjdk` and `sloccount`

### DIFF
--- a/permissions/plugin-adoptopenjdk.yml
+++ b/permissions/plugin-adoptopenjdk.yml
@@ -6,5 +6,4 @@ issues:
 paths:
   - "io/jenkins/plugins/adoptopenjdk"
 developers:
-  - "basil"
   - "mmchr"

--- a/permissions/plugin-sloccount.yml
+++ b/permissions/plugin-sloccount.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "hudson/plugins/sloccount/sloccount"
 developers:
-  - "basil"
   - "mixalturek"
   - "imarinkov"


### PR DESCRIPTION
# Description

I am no longer interested in maintaining these plugins and have marked them for adoption.

# Submitter checklist for adding or changing permissions

- https://github.com/jenkinsci/adoptopenjdk-plugin
- https://github.com/jenkinsci/sloccount-plugin

### Always

- [x] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
