### PR TITLE
Automatically detects plugins up for adoption

### DIFF
--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -234,7 +234,7 @@ class ArtifactoryPermissionsUpdater {
                         if (definition.github) {
                             repositoriesUpForAdoption.add(definition.github)
                         } else {
-                            LOGGER.log(Level.WARNING, "${definition.name} has no GitHub details, will not be able to add adoption label")
+                            LOGGER.log(Level.WARNING, "${definition.name} has no GitHub details, will not be able to add adoption topic")
                         }
                     } else {
                         users definition.developers.collectEntries { developer ->

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/GitHubAPI.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/GitHubAPI.groovy
@@ -81,13 +81,7 @@ abstract class GitHubAPI {
         @CheckForNull
         GitHubPublicKey getRepositoryPublicKey(String repositoryName) {
             LOGGER.log(Level.INFO, "GET call to retrieve public key for ${repositoryName}")
-            URL url = new URL("https://api.github.com/repos/${repositoryName}/actions/secrets/public-key")
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection()
-
-            // The GitHub API doesn't do an auth challenge
-            conn.setRequestProperty('Authorization', 'Basic ' + Base64.getEncoder().encodeToString((System.getenv("GITHUB_USERNAME") + ':' + System.getenv("GITHUB_TOKEN")).getBytes(StandardCharsets.UTF_8)))
-            conn.setRequestProperty('Accept', 'application/vnd.github.v3+json')
-            conn.setRequestMethod('GET')
+            HttpURLConnection conn = createConnection("https://api.github.com/repos/${repositoryName}/actions/secrets/public-key", 'GET')
             conn.connect()
             String text = conn.getInputStream().getText()
 
@@ -98,13 +92,7 @@ abstract class GitHubAPI {
         @Override
         void createOrUpdateRepositorySecret(String name, String encryptedSecret, String repositoryName, String keyId) {
             LOGGER.log(Level.INFO, "Create/update the secret ${name} for ${repositoryName} encrypted with key ${keyId}")
-            URL url = new URL("https://api.github.com/repos/${repositoryName}/actions/secrets/${name}")
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection()
-
-            // The GitHub API doesn't do an auth challenge
-            conn.setRequestProperty('Authorization', 'Basic ' + Base64.getEncoder().encodeToString((System.getenv("GITHUB_USERNAME") + ':' + System.getenv("GITHUB_TOKEN")).getBytes(StandardCharsets.UTF_8)))
-            conn.setRequestProperty('Accept', 'application/vnd.github.v3+json')
-            conn.setRequestMethod('PUT')
+            HttpURLConnection conn = createConnection("https://api.github.com/repos/${repositoryName}/actions/secrets/${name}", 'PUT')
             conn.setDoOutput(true)
             OutputStreamWriter osw = new OutputStreamWriter(conn.getOutputStream())
             osw.write('{"encrypted_value":"' + encryptedSecret + '","key_id":"' + keyId + '"}')

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/GitHubAPI.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/GitHubAPI.groovy
@@ -81,7 +81,7 @@ abstract class GitHubAPI {
         @CheckForNull
         GitHubPublicKey getRepositoryPublicKey(String repositoryName) {
             LOGGER.log(Level.INFO, "GET call to retrieve public key for ${repositoryName}")
-            HttpURLConnection conn = createConnection("https://api.github.com/repos/${repositoryName}/actions/secrets/public-key", 'GET')
+            HttpURLConnection conn = githubRequest("https://api.github.com/repos/${repositoryName}/actions/secrets/public-key", 'GET')
             conn.connect()
             String text = conn.getInputStream().getText()
 
@@ -92,7 +92,7 @@ abstract class GitHubAPI {
         @Override
         void createOrUpdateRepositorySecret(String name, String encryptedSecret, String repositoryName, String keyId) {
             LOGGER.log(Level.INFO, "Create/update the secret ${name} for ${repositoryName} encrypted with key ${keyId}")
-            HttpURLConnection conn = createConnection("https://api.github.com/repos/${repositoryName}/actions/secrets/${name}", 'PUT')
+            HttpURLConnection conn = githubRequest("https://api.github.com/repos/${repositoryName}/actions/secrets/${name}", 'PUT')
             conn.setDoOutput(true)
             OutputStreamWriter osw = new OutputStreamWriter(conn.getOutputStream())
             osw.write('{"encrypted_value":"' + encryptedSecret + '","key_id":"' + keyId + '"}')
@@ -101,7 +101,7 @@ abstract class GitHubAPI {
             String text = conn.getInputStream().getText()
         }
 
-        private static HttpURLConnection createConnection(String url, String method) {
+        private static HttpURLConnection githubRequest(String url, String method) {
             HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection()
 
             conn.setRequestProperty('Authorization', 'Basic ' + Base64.getEncoder().encodeToString((System.getenv("GITHUB_USERNAME") + ':' + System.getenv("GITHUB_TOKEN")).getBytes(StandardCharsets.UTF_8)))
@@ -111,7 +111,7 @@ abstract class GitHubAPI {
 
         @Override
         void addTopicToRepository(String repositoryName, String topic) {
-            LOGGER.log(Level.INFO, "Add topic ${topic} on ${repositoryName}")
+            LOGGER.log(Level.INFO, "Add topic '${topic}' on ${repositoryName}")
 
             HttpURLConnection conn = createConnection("https://api.github.com/repos/${repositoryName}/topics", 'GET')
             conn.connect()
@@ -130,7 +130,7 @@ abstract class GitHubAPI {
 
                 conn.getInputStream().getText();
             } else {
-                LOGGER.log(Level.INFO, "Repository ${repositoryName} already has topic ${topic}")
+                LOGGER.log(Level.INFO, "Repository ${repositoryName} already has topic '${topic}'")
             }
         }
     }

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/GitHubAPI.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/GitHubAPI.groovy
@@ -57,6 +57,14 @@ abstract class GitHubAPI {
      */
     abstract void createOrUpdateRepositorySecret(String name, String encryptedSecret, String repositoryName, String keyId);
 
+    /**
+     * Adds a topic to a repository
+     *
+     * @param repositoryName the repository name
+     * @param topic the topic to add to the repository
+     */
+    abstract void addTopicToRepository(String repositoryName, String topic);
+
     /* Singleton support */
     private static GitHubAPI INSTANCE = null;
     static synchronized GitHubAPI getInstance() {
@@ -102,6 +110,11 @@ abstract class GitHubAPI {
             osw.close()
 
             String text = conn.getInputStream().getText()
+        }
+
+        @Override
+        void addTopicToRepository(String repositoryName, String topic) {
+            LOGGER.log(Level.INFO, "Add topic ${topic} on ${repositoryName}")
         }
     }
 }


### PR DESCRIPTION
The tasks to mark a plugin up for adoption is manual. 
However, when the `developers` list is empty, no one has the permission to push a new release to Artifactory.
It means that no one (admins and security officers don't count) can push a new bug fix to users.

Out of fairness for the users, I think it would be ok to mark any plugin without any `developers` as up for adoption. 

This is of course, up for debate. 