### PR TITLE
doc: Fix instructions on prerequisite logins (add Jira requirement)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ Make sure to implement all relevant entries (see section headers to when they ap
 - [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
 - [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
 - [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
-- [ ] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
+- [ ] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
 
 ### Reviewer checklist (not for requesters!)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains both the definitions for Artifactory upload permissions
 Requesting Permissions
 ----------------------
 
-**Prerequisite**: You need to have logged in once to [Artifactory](https://repo.jenkins-ci.org/) with your Jenkins community account (this is the same as the account you would use to login to Jira) before you can be added to a permissions target.
+**Prerequisite**: You need to have logged in once to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io) with your Jenkins community account (this is the same as the account you would use to login to Jira) before you can be added to a permissions target.
 
 To request upload permissions to an artifact (typically a plugin), [file a PR](https://help.github.com/articles/creating-a-pull-request/) editing the appropriate YAML file, and provide a reference that shows you have commit permissions, or have an existing committer to the plugin comment on your PR, approving it.
 See [this page](https://jenkins.io/doc/developer/plugin-governance/managing-permissions/) for more information.


### PR DESCRIPTION
The checker checks if the user has logged in to Artifactory and Jira, so this adds information to the instructions in the README and the PR template.