### PR TITLE
Restore maintainer for violations plugin

### DIFF
--- a/permissions/plugin-violations.yml
+++ b/permissions/plugin-violations.yml
@@ -8,4 +8,5 @@ paths:
 # Block creation of new releases. If you want to release the plugin, contact the Jenkins security team.
   - "org/jenkins-ci/plugins/violations-releaseblocker"
   - "org/jvnet/hudson/plugins/violations-releaseblocker"
-developers: []
+developers:
+  - "tomasbjerre"


### PR DESCRIPTION
Partially undo https://github.com/jenkins-infra/repository-permissions-updater/pull/2892: With the changed path, releases are still blocked, but this can still serve as a reference that Tomas is the maintainer.

CC @yaroslavafenkin 