### PR TITLE
Prefer GitHub Issues over Jira for my plugins

### DIFF
--- a/permissions/plugin-amazon-ecr.yml
+++ b/permissions/plugin-amazon-ecr.yml
@@ -1,8 +1,8 @@
 ---
 name: "amazon-ecr"
-github: "jenkinsci/amazon-ecr-plugin"
+github: &gh "jenkinsci/amazon-ecr-plugin"
 issues:
-  - jira: '21454'  # amazon-ecr-plugin
+  - github: *gh
 paths:
   - "com/cloudbees/jenkins/plugins/amazon-ecr"
 developers:

--- a/permissions/plugin-compact-columns.yml
+++ b/permissions/plugin-compact-columns.yml
@@ -1,8 +1,8 @@
 ---
 name: "compact-columns"
-github: "jenkinsci/compact-columns-plugin"
+github: &gh "jenkinsci/compact-columns-plugin"
 issues:
-  - jira: '15735'  # compact-columns-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/compact-columns"
 developers:

--- a/permissions/plugin-dashboard-view.yml
+++ b/permissions/plugin-dashboard-view.yml
@@ -1,8 +1,8 @@
 ---
 name: "dashboard-view"
-github: "jenkinsci/dashboard-view-plugin"
+github: &gh "jenkinsci/dashboard-view-plugin"
 issues:
-  - jira: '15679'  # dashboard-view-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/dashboard-view"
   - "org/jvnet/hudson/plugins/dashboard-view"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

This adds the a link to GitHub Issues to all my plugins (amazon-ecr, compact-columns, dashboard-view) - I kept the reference to Jira if there are still relevant issues open there (not sure what to do with them in the future :disappointed:).

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [ ] Add link to plugin/component Git repository in description above

### For a newly hosted plugin only

- [ ] Add link to resolved HOSTING issue in description above

### For a new permissions file only

- [ ] Make sure the file is created in `permissions/` directory
- [ ] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [ ] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
