### PR TITLE
Add permissions files for groovy-cps and workflow-cps-parent

### DIFF
--- a/permissions/component-groovy-cps.yml
+++ b/permissions/component-groovy-cps.yml
@@ -14,6 +14,7 @@ developers:
   - "bitwiseman"
   - "kshultz"
   - "jtaboada"
+  - "teilo"
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/component-groovy-cps.yml
+++ b/permissions/component-groovy-cps.yml
@@ -1,0 +1,21 @@
+---
+name: "groovy-cps"
+github: "jenkinsci/workflow-cps-plugin"
+paths:
+  - "com/cloudbees/groovy-cps"
+developers:
+  - "jglick"
+  - "kohsuke"
+  - "abayer"
+  - "svanoort"
+  - "rsandell"
+  - "dnusbaum"
+  - "carroll"
+  - "bitwiseman"
+  - "kshultz"
+  - "jtaboada"
+security:
+  contacts:
+    jira: "cloudbees_security_members"
+cd:
+  enabled: true

--- a/permissions/pom-workflow-cps-parent.yml
+++ b/permissions/pom-workflow-cps-parent.yml
@@ -1,0 +1,21 @@
+---
+name: "workflow-cps-parent"
+github: "jenkinsci/workflow-cps-plugin"
+paths:
+  - "org/jenkins-ci/plugins/workflow/workflow-cps-parent"
+developers:
+  - "jglick"
+  - "kohsuke"
+  - "abayer"
+  - "svanoort"
+  - "rsandell"
+  - "dnusbaum"
+  - "carroll"
+  - "bitwiseman"
+  - "kshultz"
+  - "jtaboada"
+security:
+  contacts:
+    jira: "cloudbees_security_members"
+cd:
+  enabled: true

--- a/permissions/pom-workflow-cps-parent.yml
+++ b/permissions/pom-workflow-cps-parent.yml
@@ -14,6 +14,7 @@ developers:
   - "bitwiseman"
   - "kshultz"
   - "jtaboada"
+  - "teilo"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

In https://github.com/jenkinsci/workflow-cps-plugin/pull/612, we are merging https://github.com/cloudbees/groovy-cps into https://github.com/jenkinsci/workflow-cps-plugin to simplify maintenance and testing. `groovy-cps` is technically set up to be released to Maven Central, but I am not even sure whether there is anyone who still has permissions set up to perform a release. The previous two releases have been released to https://repo.jenkins-ci.org/ as part of Jenkins security advisories, which bypass the permissions set by this repository.

This PR copies the [existing permissions](https://github.com/jenkins-infra/repository-permissions-updater/blob/b04a444ed9d76c5f10b62757e8569f1dacd4d7ea/permissions/plugin-workflow-cps.yml) for `workflow-cps` and applies them to the moved `groovy-cps` library and the new `workflow-cps-parent` parent POM.

I am filing this as a draft for now in case we want to change `groovy-cps`'s `groupId`.

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x"). Remove sections that don't apply, e.g. the second and third when adding a new uploader to an existing permissions file.
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### For a new permissions file only

- [x] Make sure the file is created in `permissions/` directory
- [x] `artifactId` (pom.xml) is used for `name` (permissions YAML file).
- [x] [`groupId` / `artifactId` (pom.xml) are correctly represented in `path` (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [x] Check that the file is named `plugin-${artifactId}.yml` for plugins

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
