### PR TITLE
Create zos-devops.yml

### DIFF
--- a/permissions/plugin-zos-devops.yml
+++ b/permissions/plugin-zos-devops.yml
@@ -1,0 +1,9 @@
+---
+name: "zos-devops"
+github: &gh "jenkinsci/zos-devops-plugin"
+issues:
+  - github: *gh
+paths:
+  - "io/jenkins/plugins/zos-devops"
+developers:
+  - "iba_mainframe_dev"


### PR DESCRIPTION
The hosting bot failed to create a PR for https://github.com/jenkins-infra/repository-permissions-updater/issues/2904

Presumably, because it uses Kotlin? Not to sure.