### PR TITLE
Enable continuous delivery for cloud stats plugin

### DIFF
--- a/permissions/plugin-cloud-stats.yml
+++ b/permissions/plugin-cloud-stats.yml
@@ -9,3 +9,5 @@ paths:
 developers:
   - "olivergondza"
   - "markewaite"
+cd:
+  enabled: true


### PR DESCRIPTION
## Enable continous delivery for cloud stats plugin

[Cloud stats plugin](https://github.com/jenkinsci/cloud-stats-plugin) will benefit from continuous delivery on each relevant merge.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it

Closes https://github.com/jenkins-infra/repository-permissions-updater/pull/2934