### PR TITLE
plugin database doesn't have a jira component

### DIFF
--- a/permissions/plugin-database.yml
+++ b/permissions/plugin-database.yml
@@ -2,7 +2,7 @@
 name: "database"
 github: "jenkinsci/database-plugin"
 issues:
-  - jira: '17514'  # database-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/database"
 developers:

--- a/permissions/plugin-database.yml
+++ b/permissions/plugin-database.yml
@@ -1,6 +1,6 @@
 ---
 name: "database"
-github: "jenkinsci/database-plugin"
+&GH github: "jenkinsci/database-plugin"
 issues:
   - github: *GH
 paths:


### PR DESCRIPTION
This breaks listing issues on plugin site. Looks like everything is in github anyways