### PR TITLE
Remove Mark, Jean-Marc, and Bruno from several plugins

### DIFF
--- a/permissions/plugin-artifactdeployer.yml
+++ b/permissions/plugin-artifactdeployer.yml
@@ -9,6 +9,3 @@ developers:
   - "alecharp"
   - "gbois"
   - "seanturner83"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-authorize-project.yml
+++ b/permissions/plugin-authorize-project.yml
@@ -7,8 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/authorize-project"
 developers:
   - "ikedam"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"
   # Not a maintainer, just tables-to-divs fixes
   - "oleg_nenashev"

--- a/permissions/plugin-badge.yml
+++ b/permissions/plugin-badge.yml
@@ -8,6 +8,3 @@ paths:
   - "org/jenkins-ci/plugins/badge"
 developers:
   - "bakito"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-build-timestamp.yml
+++ b/permissions/plugin-build-timestamp.yml
@@ -7,6 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/build-timestamp"
 developers:
   - "orctom"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"
+

--- a/permissions/plugin-conditional-buildstep.yml
+++ b/permissions/plugin-conditional-buildstep.yml
@@ -12,9 +12,6 @@ developers:
   - "olamy"
   - "teilo"
   - "rarabaolaza"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-configurationslicing.yml
+++ b/permissions/plugin-configurationslicing.yml
@@ -13,6 +13,3 @@ developers:
   - "mdonohue"
   - "ninian"
   - "guysoft"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-cvs.yml
+++ b/permissions/plugin-cvs.yml
@@ -10,6 +10,3 @@ developers:
   - "mc1arke"
   - "kohsuke"
   - "jglick"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-emailext-template.yml
+++ b/permissions/plugin-emailext-template.yml
@@ -6,6 +6,3 @@ issues:
 paths:
   - "org/jenkinsci/plugins/emailext-template"
 developers:
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-emailext-template.yml
+++ b/permissions/plugin-emailext-template.yml
@@ -5,4 +5,4 @@ issues:
   - jira: '18764'  # emailext-template-plugin
 paths:
   - "org/jenkinsci/plugins/emailext-template"
-developers:
+developers: []

--- a/permissions/plugin-github-oauth.yml
+++ b/permissions/plugin-github-oauth.yml
@@ -10,6 +10,3 @@ developers:
   - "sag47"
   - "skottler"
   - "surya548"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-gitlab-oauth.yml
+++ b/permissions/plugin-gitlab-oauth.yml
@@ -7,6 +7,3 @@ paths:
   - "org/jenkins-ci/plugins/gitlab-oauth"
 developers:
   - "elhabib_med"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-global-build-stats.yml
+++ b/permissions/plugin-global-build-stats.yml
@@ -7,8 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/global-build-stats"
 developers:
   - "dhinske"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"
 cd:
   enabled: true

--- a/permissions/plugin-http_request.yml
+++ b/permissions/plugin-http_request.yml
@@ -8,6 +8,3 @@ paths:
 developers:
   - "janario"
   - "oleg_nenashev"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-job-restrictions.yml
+++ b/permissions/plugin-job-restrictions.yml
@@ -7,6 +7,3 @@ paths:
   - "com/synopsys/arc/jenkinsci/plugins/job-restrictions"
 developers:
   - "oleg_nenashev"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"

--- a/permissions/plugin-m2release.yml
+++ b/permissions/plugin-m2release.yml
@@ -9,6 +9,3 @@ paths:
 developers:
   - "imod"
   - "teilo"
-  - "jm_meessen"
-  - "markewaite"
-  - "poddingue"


### PR DESCRIPTION
# Description

Plugins were adopted for the "Contributing to Open Source" workshop at DevOps World 2022.  The workshop was cancelled when DevOps World was postponed.  Changes from Mark, Jean-Marc, and Bruno have been merged to many of these plugins.  Returning them to the pool of plugins that are up for adoption.

Confirmed in a private meeting with @jmMeessen and @gounthar that they approve.  If desired, merge can wait until they approve on this pull request.

Plugins being returned include:

* https://github.com/jenkinsci/artifactdeployer-plugin/
* https://github.com/jenkinsci/authorize-project-plugin/
* https://github.com/jenkinsci/badge-plugin/
* https://github.com/jenkinsci/build-timestamp-plugin/
* https://github.com/jenkinsci/conditional-buildstep-plugin/
* https://github.com/jenkinsci/configurationslicing-plugin/
* https://github.com/jenkinsci/cvs-plugin/
* https://github.com/jenkinsci/emailext-template-plugin/
* https://github.com/jenkinsci/github-oauth-plugin/
* https://github.com/jenkinsci/gitlab-oauth-plugin/
* https://github.com/jenkinsci/global-build-stats-plugin/
* https://github.com/jenkinsci/http_request-plugin/
* https://github.com/jenkinsci/job-restrictions-plugin/
* https://github.com/jenkinsci/m2release-plugin/

Plugins were never removed from the "Adopt a plugin" list, so they will still appear in that list after this is merged.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
