### PR TITLE
Enable continuous delivery for versioncolumn plugin

### DIFF
--- a/permissions/plugin-versioncolumn.yml
+++ b/permissions/plugin-versioncolumn.yml
@@ -1,4 +1,6 @@
 ---
+cd:
+  enabled: true
 name: "versioncolumn"
 github: "jenkinsci/versioncolumn-plugin"
 issues:


### PR DESCRIPTION
## Enable continuous delivery for the versioncolumn plugin

Version column plugin helps users check that their agents are well configured.  Enable CD for it.

https://github.com/jenkinsci/versioncolumn-plugin

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
