### PR TITLE
CHG: Enabling CD for the propelo-job-reporter plugin

### DIFF
--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -11,3 +11,5 @@ developers:
 - "amit_propelo"
 issues:
   - jira: 29121
+cd:
+  enabled: true


### PR DESCRIPTION
# Description

Enabling CD for the propelo-job-reporter plugin (https://github.com/jenkinsci/propelo-job-reporter-plugin).

