### PR TITLE
Add support for Java 17 at compile time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
-                        <version>2.5.15</version>
+                        <version>3.0.13</version>
                         <scope>runtime</scope>
                         <type>pom</type>
                     </dependency>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.5.15</version>
+            <version>3.0.13</version>
             <type>pom</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
Groovy 2.x bundles asm versions, which do not support Java 17. Groovy 3.x onwards mitigates this limitation.
Local testing passes, let's see if the pipeline does the same.