### PR TITLE
Bump lowest jenkins version

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -27,7 +27,7 @@ public class HostingChecker {
 
     public static final String INVALID_FORK_FROM = "Repository URL '%s' is not a valid GitHub repository (check that you do not have .git at the end, GitHub API doesn't support this).";
 
-    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 277, 1);
+    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 332, 4);
 
     public static void main(String[] args) throws IOException {
         new HostingChecker().checkRequest(Integer.parseInt(args[0]));


### PR DESCRIPTION
2.277.x is almost 2 years old and behind recent major upgrade campaigns, like Java 11/17 support, EOL of JSR 305, Guava upgrade from 11.0.1 to 31 etc.

I'd like to move on and use a baseline, that's still supported by our tooling and doesn't reintroduce things, a lot of people worked on to get a rid of. 2.332.x is the oldest version supported by bom and would make a good choice, in my opinion, and is advised to be used by the baseline guides on jenkins.io.