### PR TITLE
Bump minimum parent pom version to 4.50

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
@@ -31,7 +31,7 @@ public class MavenVerifier implements BuildSystemVerifier {
     private static final int MAX_LENGTH_OF_ARTIFACT_ID = 37;
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenVerifier.class);
 
-    public static final Version LOWEST_PARENT_POM_VERSION = new Version(4, 0, 0);
+    public static final Version LOWEST_PARENT_POM_VERSION = new Version(4, 50, 0);
     public static final Version PARENT_POM_WITH_JENKINS_VERSION = new Version(2);
 
     public static final String INVALID_POM = "The pom.xml file in the root of the origin repository is not valid";


### PR DESCRIPTION
There are a plenty of benefits in using newer versions, than 4.0, like support for Java 17, JUnit 5 support in JenkinsRule or a lot of policy adaptions, like making a `index.jelly` mandatory.
Not to forget all the bug fixes and other feature additions.

Therefore, I'd like to move forward, and bump the minimum parent pom version to a recent release.