### PR TITLE
Add markewaite as buildresult-trigger plugin maintainer (#2967)

### DIFF
--- a/permissions/plugin-buildresult-trigger.yml
+++ b/permissions/plugin-buildresult-trigger.yml
@@ -8,3 +8,4 @@ paths:
 developers:
   - "gbois"
   - "stealthdj"
+  - "markewaite"


### PR DESCRIPTION
# Description

I use this plugin to validate some bug fixes related to freestyle jobs in my instance.

The Jenkins baseline that it requires is old enough that it causes an implicit dependency on the windows-slaves-plugin.  The windows-slaves-plugin plugin will be deprecated in May 2023 when Microsoft bans the DCOM technique required by the windows-slave-plugin.  I don't want deprecated plugins in my installation, so I need to increase the minimum Jenkins version of this plugin so that it no longer has an implicit dependency on windows-slaves-plugin.

@gboissinot or @TonyNoble could you approve me being added as a plugin maintainer?

If no response, then the two week timeout should be considered started now.

https://github.com/jenkinsci/buildresult-trigger-plugin

The plugin site describes implied dependencies as follows:

Features are sometimes detached (or split off) from Jenkins core and moved into a plugin. Many plugins, like Subversion or JUnit, started as features of Jenkins core.

Plugins that depend on a Jenkins core version before such a plugin was detached from core may or may not actually use any of its features. To ensure that plugins don't break whenever functionality they depend on is detached from Jenkins core, it is considered to have a dependency on the detached plugin if it declares a dependency on a version of Jenkins core before the split. Since that dependency to the detached plugin is not explicitly specified, it is implied.

Plugins that don't regularly update which Jenkins core version they depend on will accumulate implied dependencies over time.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
