### PR TITLE
Enable cd for pre-scm build step plugin

### DIFF
--- a/permissions/plugin-preSCMbuildstep.yml
+++ b/permissions/plugin-preSCMbuildstep.yml
@@ -7,3 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/preSCMbuildstep"
 developers:
   - "markewaite"
+cd:
+  enabled: true


### PR DESCRIPTION
# Description

The current release of pre-scm build step plugin depends on an old enough Jenkins version that it implies a dependency on the windows-slave plugin.  I want to remove the windows-slave plugin without removing the pre-scm build step plugin.  I need a new release of the pre-scm build step plugin that depends on a more modern Jenkins version.

Enable continuous delivery.

https://github.com/jenkinsci/pre-scm-buildstep-plugin

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
