### PR TITLE
markewaite adopt saferestart and built-on-column plugins

### DIFF
--- a/permissions/plugin-built-on-column.yml
+++ b/permissions/plugin-built-on-column.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '16001'  # built-on-column-plugin
 paths:
   - "org/jenkins-ci/plugins/built-on-column"
-developers: []
+developers:
+  - "markewaite"

--- a/permissions/plugin-saferestart.yml
+++ b/permissions/plugin-saferestart.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '16072'  # saferestart-plugin
 paths:
   - "org/jenkins-ci/plugins/saferestart"
-developers: []
+developers:
+  - "markewaite"


### PR DESCRIPTION
## markewaite adopt two plugins with implied dependencies on windows-slaves plugin

- markewaite adopt the built-on-column plugin
- markewaite adopt saferestart plugin

Plugins are installed in over 13000 controllers and have an implied dependency on the deprecated windows-slaves plugin.  Will resolve the implied dependency by releasing a new version that requires a modern Jenkins version as its minimum Jenkins version

* https://github.com/jenkinsci/saferestart-plugin
* https://github.com/jenkinsci/builton-column-plugin

No existing maintainers for either plugin.  No waiting period should be required and no approval is possible since no maintainers are listed.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
