### PR TITLE
Remove 'stapler' from set of allowed organizations

### DIFF
--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -149,8 +149,8 @@ class ArtifactoryPermissionsUpdater {
                 paths.addAll(definition.paths)
 
                 if (definition.cd && definition.getCd().enabled) {
-                    if (!definition.github.matches('(jenkinsci|stapler)/.+')) {
-                        throw new Exception("CD is only supported when the GitHub repository is in @jenkinsci or @stapler")
+                    if (!definition.github.matches('(jenkinsci)/.+')) {
+                        throw new Exception("CD is only supported when the GitHub repository is in @jenkinsci")
                     }
                     List<Definition> definitions = cdEnabledComponentsByGitHub[definition.github]
                     if (!definitions) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -188,7 +188,7 @@ public class Definition {
     }
 
     public String getGithub() {
-        if (github != null && (github.startsWith("jenkinsci/") || github.startsWith("stapler/"))) {
+        if (github != null && github.startsWith("jenkinsci/")) {
             return github;
         }
         return null;


### PR DESCRIPTION
The RPU contains no repository file for the stapler organization, nor is the organization much of use these days, given all major repositories have been transferred to jenkinsci.