### PR TITLE
Let markewaite adopt 2 plugins with implied WMI Windows Agents dependencies

### DIFF
--- a/permissions/plugin-clone-workspace-scm.yml
+++ b/permissions/plugin-clone-workspace-scm.yml
@@ -6,4 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/clone-workspace-scm"
   - "org/jvnet/hudson/plugins/clone-workspace-scm"
-developers: []
+developers:
+  - "markewaite"

--- a/permissions/plugin-email-ext-recipients-column.yml
+++ b/permissions/plugin-email-ext-recipients-column.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '17617'  # email-ext-recipients-column-plugin
 paths:
   - "org/jenkins-ci/plugins/email-ext-recipients-column"
-developers: []
+developers:
+  - "markewaite"


### PR DESCRIPTION
## Allow markewaite to adopt two plugins with implied dependencies on WMI Windows Agents plugin

- Allow markewaite to adopt the email ext recipients column plugin
- markewaite adopt clone workspace SCM plugin

* https://github.com/jenkinsci/email-ext-recipients-column-plugin and [modernization pull request](https://github.com/jenkinsci/email-ext-recipients-column-plugin/pull/4)
* https://github.com/jenkinsci/jenkins-clone-workspace-scm-plugin and [modernization pull request](https://github.com/jenkinsci/jenkins-clone-workspace-scm-plugin/pull/16)

No existing developers, so no one to mention in the pull request.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
