### PR TITLE
Enable CD for clone workspace scm plugin

### DIFF
--- a/permissions/plugin-clone-workspace-scm.yml
+++ b/permissions/plugin-clone-workspace-scm.yml
@@ -8,3 +8,5 @@ paths:
   - "org/jvnet/hudson/plugins/clone-workspace-scm"
 developers:
   - "markewaite"
+cd:
+  enabled: true


### PR DESCRIPTION
## Enable CD for [clone workspace scm plugin](https://github.com/jenkinsci/jenkins-clone-workspace-scm-plugin)

Plugin is
https://github.com/jenkinsci/jenkins-clone-workspace-scm-plugin

Enable CD for the pull request
https://github.com/jenkinsci/jenkins-clone-workspace-scm-plugin/pull/20

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [x] Add a link to the pull request, which enables continous delivery for your plugin or component
- [x] Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
