### PR TITLE
Enable CD for email-ext-recipients-column plugin

### DIFF
--- a/permissions/plugin-email-ext-recipients-column.yml
+++ b/permissions/plugin-email-ext-recipients-column.yml
@@ -7,3 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/email-ext-recipients-column"
 developers:
   - "markewaite"
+cd:
+  enabled: true


### PR DESCRIPTION
## Enable CD for email-ext-recipients-column plugin

https://github.com/jenkinsci/email-ext-recipients-column-plugin

https://github.com/jenkinsci/email-ext-recipients-column-plugin/pull/7
is the pull request in the plugin repository

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [x] Add a link to the pull request, which enables continous delivery for your plugin or component.  
- [x] Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
