### PR TITLE
Bump plugin baseline and pom version

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -27,7 +27,7 @@ public class HostingChecker {
 
     public static final String INVALID_FORK_FROM = "Repository URL '%s' is not a valid GitHub repository (check that you do not have .git at the end, GitHub API doesn't support this).";
 
-    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 332, 4);
+    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 361, 4);
 
     public static void main(String[] args) throws IOException {
         new HostingChecker().checkRequest(Integer.parseInt(args[0]));

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
@@ -32,7 +32,7 @@ public class MavenVerifier implements BuildSystemVerifier {
     private static final int MAX_LENGTH_OF_ARTIFACT_ID = 37;
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenVerifier.class);
 
-    public static final Version LOWEST_PARENT_POM_VERSION = new Version(4, 50);
+    public static final Version LOWEST_PARENT_POM_VERSION = new Version(4, 52);
     public static final Version PARENT_POM_WITH_JENKINS_VERSION = new Version(2);
 
     public static final String INVALID_POM = "The pom.xml file in the root of the origin repository is not valid";


### PR DESCRIPTION
This proposal aligns with the default skeleton generation of archetypes, the documentation on jenkins.io and the overall positive response on the mailing list to move tooling forward to Java 11.