### PR TITLE
Remove `basil` from 5 plugins

### DIFF
--- a/permissions/plugin-extra-tool-installers.yml
+++ b/permissions/plugin-extra-tool-installers.yml
@@ -7,6 +7,5 @@ paths:
   - "com/synopsys/arc/jenkinsci/extra-tool-installers"
   - "io/jenkins/plugins/extra-tool-installers"
 developers:
-  - "basil"
   - "oleg_nenashev"
   - "pjdarton"

--- a/permissions/plugin-github-pr-coverage-status.yml
+++ b/permissions/plugin-github-pr-coverage-status.yml
@@ -7,6 +7,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/github-pr-coverage-status"
 developers:
-  - "basil"
   - "terma"
   - "dmotpan"

--- a/permissions/plugin-ivy.yml
+++ b/permissions/plugin-ivy.yml
@@ -9,4 +9,3 @@ paths:
   - "org/jvnet/hudson/plugins/ivy"
 developers:
   - "arothian"
-  - "basil"

--- a/permissions/plugin-jdepend.yml
+++ b/permissions/plugin-jdepend.yml
@@ -7,5 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/jdepend"
   - "org/jvnet/hudson/plugins/jdepend"
 developers:
-  - "basil"
   - "oleg_nenashev"

--- a/permissions/plugin-nexus-artifact-uploader.yml
+++ b/permissions/plugin-nexus-artifact-uploader.yml
@@ -6,5 +6,4 @@ issues:
 paths:
   - "sp/sd/nexus-artifact-uploader"
 developers:
-  - "basil"
   - "pskumar448"


### PR DESCRIPTION
# Description

I adopted these plugins to release fixes related to the removal of Commons HttpClient 3.x from core. The fixes have been merged and released and no regressions have been reported, so my work here is done. I have ensured each plugin has the `adopt-this-plugin` label for easy adoption for the next maintainer.

- https://github.com/jenkinsci/extra-tool-installers-plugin
- https://github.com/jenkinsci/github-pr-coverage-status-plugin
- https://github.com/jenkinsci/ivy-plugin
- https://github.com/jenkinsci/jdepend-plugin
- https://github.com/jenkinsci/nexus-artifact-uploader-plugin

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x").
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [ ] Add a link to the pull request, which enables continous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
