### PR TITLE
Suspend Gradle checks for new plugins

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
@@ -34,6 +34,10 @@ import org.kohsuke.github.GitHub;
 import static io.jenkins.infra.repository_permissions_updater.hosting.HostingChecker.LOWEST_JENKINS_VERSION;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
+/**
+ * @deprecated until the Gradle JPI plugin supports the same scope of features as the Maven HPI plugin.
+ */
+@Deprecated
 public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVerifier {
 
     public static final String SPECIFY_LICENSE = "Please specify a license in your build.gradle file using the `licenses` closure. See https://github.com/jenkinsci/gradle-jpi-plugin#configuration for an example.";

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -388,25 +388,18 @@ public class Hoster {
         String artifactId = null;
         String groupId = null;
 
-        String[] buildFiles = new String[]{"pom.xml", "build.gradle"};
-        for (String buildFile : buildFiles) {
-            try {
-                GHContent file = fork.getFileContent(buildFile);
-                if (file != null && file.isFile()) {
-                    String contents = IOUtils.toString(file.read(), StandardCharsets.UTF_8);
-                    if (buildFile.equalsIgnoreCase("pom.xml")) {
-                        artifactId = MavenVerifier.getArtifactId(contents);
-                        groupId = MavenVerifier.getGroupId(contents);
-                    } else if (buildFile.equalsIgnoreCase("build.gradle")) {
-                        artifactId = GradleVerifier.getShortName(contents);
-                        groupId = GradleVerifier.getGroupId(contents);
-                    }
-                    break;
+        try {
+            GHContent file = fork.getFileContent("pom.xml");
+            if (file != null && file.isFile()) {
+                String contents = IOUtils.toString(file.read(), StandardCharsets.UTF_8);
+                if (file.isFile()) {
+                    artifactId = MavenVerifier.getArtifactId(contents);
+                    groupId = MavenVerifier.getGroupId(contents);
                 }
-            } catch (IOException e) {
-                LOGGER.error("Could not find supported build file (pom.xml or build.gradle) to get artifact path from or another error occurred.");
-                return null;
             }
+        } catch (IOException e) {
+            LOGGER.error("Could not find pom.xml to get artifact path from or another error occurred.");
+            return null;
         }
 
         if (!StringUtils.isBlank(artifactId) && !StringUtils.isBlank((groupId))) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -43,9 +43,7 @@ public class HostingChecker {
         verifications.add(Triplet.with("Jira", new HostingFieldVerifier(), null));
         verifications.add(Triplet.with("GitHub", new GitHubVerifier(), null));
         verifications.add(Triplet.with("Maven", new MavenVerifier(), new FileExistsConditionChecker("pom.xml")));
-        verifications.add(Triplet.with("Gradle", new GradleVerifier(), new FileExistsConditionChecker("build.gradle")));
         verifications.add(Triplet.with("JenkinsProjectUsers", new JenkinsProjectUserVerifier(), null));
-        //verifications.add(Triplet.with("Kotlin", new KotlinVerifier(), new FileExistsConditionChecker("build.gradle.kts")));
 
         final HostingRequest hostingRequest = HostingRequestParser.retrieveAndParse(issueID);
 
@@ -66,7 +64,7 @@ public class HostingChecker {
         }
 
         if (!hasBuildSystem) {
-            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.WARNING, "No build system found (pom.xml, build.gradle)"));
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.WARNING, "No pom.xml detected."));
         }
 
         LOGGER.info("Done checking hosting for " + issueID + ", found " + hostingIssues.size() + " issues");

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingFieldVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingFieldVerifier.java
@@ -46,7 +46,7 @@ public class HostingFieldVerifier implements Verifier {
 
         if(StringUtils.isBlank(forkTo)) {
             HashSet<VerificationMessage> subitems = new HashSet<>();
-            subitems.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It must match the artifactId (with -plugin added) from your build file (pom.xml/build.gradle)."));
+            subitems.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It must match the artifactId (with -plugin added) from your pom.xml."));
             subitems.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It must end in -plugin if hosting request is for a Jenkins plugin."));
             subitems.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It must be all lowercase."));
             subitems.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It must NOT contain \"Jenkins\"."));


### PR DESCRIPTION
Picks up my comment from https://github.com/jenkins-infra/helpdesk/issues/3279#issuecomment-1339681950

I suggest we do no longer host new plugins using the JPI plugin, until it supports the same scope as the maven architecture. As of now, there's no built-in release functionality, no support for JEP-229 (CD) and probably a few other components, which have been added within the past years.