### PR TITLE
Adopt some WMI windows agents implied dependencies

### DIFF
--- a/permissions/plugin-JDK_Parameter_Plugin.yml
+++ b/permissions/plugin-JDK_Parameter_Plugin.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '18038'  # jdk_parameter_plugin-plugin
 paths:
   - "org/jenkins-ci/plugins/JDK_Parameter_Plugin"
-developers: []
+developers:
+  - "markewaite"

--- a/permissions/plugin-discard-old-build.yml
+++ b/permissions/plugin-discard-old-build.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '17422'  # discard-old-build-plugin
 paths:
   - "jp/shiftinc/jenkins/plugins/discard-old-build"
-developers: []
+developers:
+  - "markewaite"

--- a/permissions/plugin-skip-certificate-check.yml
+++ b/permissions/plugin-skip-certificate-check.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '15923'  # skip-certificate-check-plugin
 paths:
   - "org/jenkins-ci/plugins/skip-certificate-check"
-developers: []
+developers:
+  - "markewaite"


### PR DESCRIPTION
## Adopt some WMI Windows Agents implied dependencies

- Let markewaite adopt discard-old-build plugin
- Let markewaite adopt skip-certificate-check plugin
- Let markewaite adopt the JDK parameter plugin

Reduce the problems related to implied dependencies on the WMI Windows Agents plugin by releasing new versions of the more popular plugins so that users can upgrade to those new versions and then remove the WMI Windows Agents plugin.

Repositories are:

* https://github.com/jenkinsci/discard-old-build-plugin
* https://github.com/jenkinsci/skip-certificate-check-plugin
* https://github.com/jenkinsci/JDK_Parameter_Plugin-plugin

No existing maintainers to mention.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
