### PR TITLE
Recommend lowercase artifact names when fixing naming convention issues

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
@@ -367,7 +367,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
             String shortName = e.getText();
             if(StringUtils.isNotBlank(shortName)) {
                 if(StringUtils.isNotBlank(forkTo) && !shortName.equals(forkTo.replace("-plugin", ""))) {
-                    hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The `shortName` from the build.gradle (%s) is incorrect, it should be '%s' ('New Repository Name' field with \"-plugin\" removed)", shortName, forkTo.replace("-plugin", "")));
+                    hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The `shortName` from the build.gradle (%s) is incorrect, it should be '%s' ('New Repository Name' field with \"-plugin\" removed)", shortName, (forkTo.replace("-plugin", "")).toLowerCase()));
                 }
 
                 if(shortName.toLowerCase().contains("jenkins")) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
@@ -101,7 +101,7 @@ public class MavenVerifier implements BuildSystemVerifier {
             String artifactId = model.getArtifactId();
             if(StringUtils.isNotBlank(artifactId)) {
                 if(StringUtils.isNotBlank(forkTo) && !artifactId.equals(forkTo.replace("-plugin", ""))) {
-                    hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The 'artifactId' from the pom.xml (`%s`) is incorrect, it should be `%s` ('New Repository Name' field with \"-plugin\" removed)", artifactId, forkTo.replace("-plugin", "")));
+                    hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The 'artifactId' from the pom.xml (`%s`) is incorrect, it should be `%s` ('New Repository Name' field with \"-plugin\" removed)", artifactId, (forkTo.replace("-plugin", "")).toLowerCase()));
                 }
 
                 if (artifactId.length() >= MAX_LENGTH_OF_ARTIFACT_ID) {


### PR DESCRIPTION
Spotted in https://github.com/jenkins-infra/repository-permissions-updater/issues/3026#issuecomment-1354401772

If you're following the [maven conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html) and have a lowercased artifact name but an uppercased repository name, the fixing recommendation isn't much of a help.

This PR takes care of that.