### PR TITLE
Provide a GH permissions template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-github-permissions.yml
+++ b/.github/ISSUE_TEMPLATE/5-github-permissions.yml
@@ -1,0 +1,31 @@
+name: '🚀 GitHub permissions'
+labels: ['github-permissions', 'triage']
+description: Request GitHub permissions
+
+body:
+  - type: textarea
+    attributes:
+      label: GitHub repositories
+    validations:
+      required: true
+    placeholder: |
+        https://github.com/jenkinsci/a-plugin
+        https://github.com/jenkinsci/b-plugin
+        https://github.com/jenkinsci/c-lib
+
+  - type: textarea
+    attributes:
+      label: GitHub users to have permission
+      placeholder: |
+        @user1
+        @user2
+        @user3
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Justification
+      description: |
+        Please provide justification for access and the access level
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/5-github-permissions.yml
+++ b/.github/ISSUE_TEMPLATE/5-github-permissions.yml
@@ -1,5 +1,5 @@
 name: '🚀 GitHub permissions'
-labels: ['github-permissions', 'triage']
+labels: ['github-permissions']
 description: Request GitHub permissions
 
 body:

--- a/.github/ISSUE_TEMPLATE/5-github-permissions.yml
+++ b/.github/ISSUE_TEMPLATE/5-github-permissions.yml
@@ -8,10 +8,6 @@ body:
       label: GitHub repositories
     validations:
       required: true
-    placeholder: |
-        https://github.com/jenkinsci/a-plugin
-        https://github.com/jenkinsci/b-plugin
-        https://github.com/jenkinsci/c-lib
 
   - type: textarea
     attributes:


### PR DESCRIPTION
See https://github.com/jenkins-infra/helpdesk/pull/3299

I removed the permissions level dropdown, given teams typically have admin permissions over the repository. 