### PR TITLE
[JENKINS-70326] Deprecate unleash plugin

### DIFF
--- a/permissions/plugin-unleash.yml
+++ b/permissions/plugin-unleash.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '21681'  # unleash-plugin
 paths:
   - "com/itemis/jenkins/plugins/unleash"
-developers:
-  - "shillner"
+developers: []


### PR DESCRIPTION
## [JENKINS-70326](https://issues.jenkins.io/browse/JENKINS-70326) Deprecate unleash plugin

https://github.com/shillner/unleash-maven-plugin/ has been archived.  That is the unleash plugin for Apache Maven.  The Jenkins unleash maven plugin depends on the unleash plugin for Apache Maven.

https://github.com/jenkinsci/unleash-plugin has been archived.  That is the Jenkins unleash Maven plugin. The last release of the Jenkins unleash maven plugin was 3 years ago. Since the Jenkins plugin repository has been archived, we can expect no new releases of the plugin.

[JENKINS-70326](https://issues.jenkins.io/browse/JENKINS-70326) notes that the Jenkins unleash maven plugin does not work with Java 17.

Let's deprecate the Jenkins plugin so that it is clear to users that the Jenkins plugin is not being maintained and that the Apache Maven plugin is not being maintained.

The [deprecation document](https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/) says that the preferred way to deprecate a plugin is to add the "deprecated" topic to the repository and to explain in the plugin documentation why it is being deprecated.  That would mean allowing writes to the repository again, just long enough to set the topic.

I assume that is more complicated than the alternate method, a pull request to the update center repository to mark the repository as deprecated.  @daniel-beck is it better / easier for me to submit the pull request to the update center or would you prefer that I ask that the repository be temporarily unarchived?

https://github.com/jenkins-infra/plugins-wiki-docs/tree/master/unleash is the documentation for the plugin.  I'll submit a pull request to the wiki repository to note that the plugin is deprecated.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
