### PR TITLE
2nd adoption row of wmi-affected plugins

### DIFF
--- a/permissions/plugin-any-buildstep.yml
+++ b/permissions/plugin-any-buildstep.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/any-buildstep"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-anything-goes-formatter.yml
+++ b/permissions/plugin-anything-goes-formatter.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/anything-goes-formatter"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-build-cause-run-condition.yml
+++ b/permissions/plugin-build-cause-run-condition.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/build-cause-run-condition"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-build-keeper-plugin.yml
+++ b/permissions/plugin-build-keeper-plugin.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/build-keeper-plugin"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-groovy-remote.yml
+++ b/permissions/plugin-groovy-remote.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkinsci/plugins/groovy-remote"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-nant.yml
+++ b/permissions/plugin-nant.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/nant"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-openid4java.yml
+++ b/permissions/plugin-openid4java.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/openid4java"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-progress-bar-column-plugin.yml
+++ b/permissions/plugin-progress-bar-column-plugin.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/progress-bar-column-plugin"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-sbt.yml
+++ b/permissions/plugin-sbt.yml
@@ -7,3 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/sbt"
   - "org/jvnet/hudson/plugins/sbt"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-statusmonitor.yml
+++ b/permissions/plugin-statusmonitor.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/statusmonitor"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-svn-revert-plugin.yml
+++ b/permissions/plugin-svn-revert-plugin.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/svn-revert-plugin"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-svncompat14.yml
+++ b/permissions/plugin-svncompat14.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/svncompat14"
 developers: []
+cd:
+  enabled: true

--- a/permissions/plugin-windows-exe-runner.yml
+++ b/permissions/plugin-windows-exe-runner.yml
@@ -6,3 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/windows-exe-runner"
 developers: []
+cd:
+  enabled: true


### PR DESCRIPTION
Similar to my [last PR](https://github.com/jenkins-infra/repository-permissions-updater/pull/3043#issuecomment-1361436377), I left out the authors block on purpose, and focus on plugins up for adoption or have no maintainer listed.