### PR TITLE
Let markewaite adopt slave-setup plugin

### DIFF
--- a/permissions/plugin-slave-setup.yml
+++ b/permissions/plugin-slave-setup.yml
@@ -8,3 +8,4 @@ paths:
 developers:
   - "peppe"
   - "wolfs"
+  - "markewaite"


### PR DESCRIPTION
## Let markewaite adopt slave-setup plugin

Plugin has an implied depenendency on WMI Windows Agents plugin as noted at https://plugins.jenkins.io/slave-setup/#dependencies

The implied dependency can be resolved by delivering a new release of the plugin that requires a more modern Jenkins version.

[Resolve implied dependencies on WMI Windows Agent plugin](https://issues.jenkins.io/browse/JENKINS-70301) provides more details on implied dependencies and why a new release is an easy way to resolve the issue.

* https://github.com/jenkinsci/slave-setup-plugin/ is the plugin repository
* https://github.com/jenkinsci/slave-setup-plugin/pull/16 is the pull request that modernizes the plugin, changes its display name to not use the deprecated "slave" term, and prepares it to release a new version that requires Jenkins 2.346.3 or newer.
* https://github.com/jenkinsci/slave-setup-plugin/pull/15 is an earlier pull request that I submitted for inclusive naming changes

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ notes that 2.346.3 is a good choice for a minimum Jenkins version.

@peppelan and @wolfs are listed as current maintainers of the plugin.

@markewaite is the user that needs GitHub merge access.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
