### PR TITLE
Let markewaite adopt cron column plugin

### DIFF
--- a/permissions/plugin-cron_column.yml
+++ b/permissions/plugin-cron_column.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/cron_column"
 developers:
   - "jglick"
+  - "markewaite"


### PR DESCRIPTION
## Let markewaite adopt cron column plugin

The cron column plugin has an implied dependency on WMI Windows Agents plugin due to its old Jenkins version. WMI Windows Agents plugin is deprecated.  Users that try to remove WMI Windows Agents plugin while retaining cron column plugin will typically have an older version of WMI Windows Agents plugin installed to satisfy the implied dependency.

https://issues.jenkins.io/browse/JENKINS-70301 describes the issue in more detail.

https://github.com/jenkinsci/cron_column-plugin/ is the repository.

If I am allowed to adopt the plugin, I'll merge and release:

* https://github.com/jenkinsci/cron_column-plugin/pull/7
* https://github.com/jenkinsci/cron_column-plugin/pull/6
* https://github.com/jenkinsci/cron_column-plugin/pull/4

@jglick is listed as the maintainer of the plugin.
@jglick, can you reply to this with your approval that I adopt the plugin?

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
