### PR TITLE
Remove members from archived plugins

### DIFF
--- a/permissions/plugin-cloudbees-credentials.yml
+++ b/permissions/plugin-cloudbees-credentials.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '18730'  # cloudbees-credentials-plugin
 paths:
   - "com/cloudbees/jenkins/plugins/cloudbees-credentials"
-developers:
-  - "kohsuke"
+developers: [] # archived

--- a/permissions/plugin-cloudbees-plugin-gateway.yml
+++ b/permissions/plugin-cloudbees-plugin-gateway.yml
@@ -5,4 +5,4 @@ issues:
   - jira: '17521'  # cloudbees-plugin-gateway-plugin
 paths:
   - "org/jenkins-ci/plugins/cloudbees-plugin-gateway"
-developers: []
+developers: [] # archived


### PR DESCRIPTION
The recent modernization of WMI-affected plugins has shown that these two are deprecated and archived. This PR updates the state as accordingly.