### PR TITLE
Drop markewaite from slave-setup plugin

### DIFF
--- a/permissions/plugin-slave-setup.yml
+++ b/permissions/plugin-slave-setup.yml
@@ -8,4 +8,3 @@ paths:
 developers:
   - "peppe"
   - "wolfs"
-  - "markewaite"


### PR DESCRIPTION
## Drop markewiate from slave-setup plugin

https://github.com/jenkinsci/slave-setup-plugin/pull/21 notes why I'm not ready to do any further work on the plugin.

Jenkins 2.386 will include a more general fix for the issue that I was trying to resolve here, without risk of breaking the existing users of the `slave-setup` plugin.

https://github.com/jenkinsci/jenkins/pull/7568 is the more general fix.

https://issues.jenkins.io/browse/JENKINS-70301 describes the implied dependency that the slave-setup plugin has on the WMI Windows Agents plugin.

This reverts commit 4d30c5e334decd2efb94597bb4d57df3c2ecf51a.

* Plugin repo: https://github.com/jenkinsci/slave-setup-plugin

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above - https://github.com/jenkinsci/slave-setup-plugin

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
