### PR TITLE
Block further releases of ascii-magician

### DIFF
--- a/permissions/plugin-ascii-magician.yml
+++ b/permissions/plugin-ascii-magician.yml
@@ -2,8 +2,9 @@
 name: "ascii-magician"
 github: &GH "jenkinsci/ascii-magician-plugin"
 paths:
-- "io/jenkins/plugins/ascii-magician"
-developers:
+# Blocked for https://github.com/jenkinsci/ascii-magician-plugin/issues/1
+- "io/jenkins/plugins/ascii-magician-releaseblock"
+developers: []
 - "kadkoda"
 - "ilay_goldman"
 issues:

--- a/permissions/plugin-ascii-magician.yml
+++ b/permissions/plugin-ascii-magician.yml
@@ -4,7 +4,7 @@ github: &GH "jenkinsci/ascii-magician-plugin"
 paths:
 # Blocked for https://github.com/jenkinsci/ascii-magician-plugin/issues/1
 - "io/jenkins/plugins/ascii-magician-releaseblock"
-developers: []
+developers:
 - "kadkoda"
 - "ilay_goldman"
 issues:


### PR DESCRIPTION
Looks like the maintainers are security researchers and decided to spam project infrastructure instead of just setting up their own local update sites.