### PR TITLE
Unblock `ascii-magician`

### DIFF
--- a/permissions/plugin-ascii-magician.yml
+++ b/permissions/plugin-ascii-magician.yml
@@ -2,8 +2,7 @@
 name: "ascii-magician"
 github: &GH "jenkinsci/ascii-magician-plugin"
 paths:
-# Blocked for https://github.com/jenkinsci/ascii-magician-plugin/issues/1
-- "io/jenkins/plugins/ascii-magician-releaseblock"
+- "io/jenkins/plugins/ascii-magician"
 developers:
 - "kadkoda"
 - "ilay_goldman"


### PR DESCRIPTION
Restore the ability for the maintainers of `ascii-magician` to upload new releases to continue their security research.

We will retain the suspension of the plugin through https://github.com/jenkins-infra/update-center2/pull/675 to not have new releases impact actual Jenkins users. Research can continue through locally hosted instances of `update-center2` with a custom ignore list.

Reverts https://github.com/jenkins-infra/repository-permissions-updater/pull/3082.

Lazy branch, please delete on merge.