### PR TITLE
Let markewaite adopt copyartifact plugin

### DIFF
--- a/permissions/plugin-copyartifact.yml
+++ b/permissions/plugin-copyartifact.yml
@@ -9,6 +9,7 @@ paths:
 developers:
   - "ikedam"
   - "wolfs"
+  - "markewaite"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
## Let markewaite adopt copyartifact plugin

Need to release a new version that removes the test dependency on compress-artifacts so that the copyartifact plugin can be updated in the Jenkins plugin bill of materials.

https://github.com/jenkinsci/copyartifact-plugin/pull/163 removes the test dependency.

https://github.com/jenkinsci/bom/pull/1689#issuecomment-1386975882 notes how that removal will help unblock the update of bouncycastle api plugin in the Jenkins plugin BOM.

https://github.com/jenkinsci/copyartifact-plugin/pull/164 is my pull request to require Java 11 and Jenknis 2.361.4 or newer.  That will resolve two additional pull requests:

* https://github.com/jenkinsci/copyartifact-plugin/pull/159
* https://github.com/jenkinsci/copyartifact-plugin/pull/162

https://github.com/jenkinsci/copyartifact-plugin shows the plugin is up for adoption, so no additional approvals are required.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
