### PR TITLE
Use CD for copyartifact

### DIFF
--- a/permissions/plugin-copyartifact.yml
+++ b/permissions/plugin-copyartifact.yml
@@ -13,3 +13,5 @@ developers:
 security:
   contacts:
     jira: "cloudbees_security_members"
+cd:
+  enabled: true


### PR DESCRIPTION
## User CD for copyartifact plugin

https://github.com/jenkinsci/copyartifact-plugin/pull/167 includes the changes to switch the copyartifact plugin to use continuous delivery when relevant changes merge to the master branch.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [x] Add a link to the pull request, which enables continous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
