### PR TITLE
Allow publishing of `commons-jelly-tags-define`

### DIFF
--- a/permissions/component-commons-jelly-tags-define.yml
+++ b/permissions/component-commons-jelly-tags-define.yml
@@ -1,0 +1,7 @@
+---
+name: "commons-jelly-tags-define"
+github: "jenkinsci/jelly"
+paths:
+  - "org/jvnet/hudson/commons-jelly-tags-define"
+developers:
+  - "@core"

--- a/permissions/pom-commons-jelly-parent.yml
+++ b/permissions/pom-commons-jelly-parent.yml
@@ -1,0 +1,7 @@
+---
+name: "commons-jelly-parent"
+github: "jenkinsci/jelly"
+paths:
+  - "org/jenkins-ci/commons-jelly-parent"
+developers:
+  - "@core"

--- a/permissions/pom-commons-jelly-tags.yml
+++ b/permissions/pom-commons-jelly-tags.yml
@@ -1,0 +1,7 @@
+---
+name: "commons-jelly-tags"
+github: "jenkinsci/jelly"
+paths:
+  - "org/jenkins-ci/commons-jelly-tags"
+developers:
+  - "@core"


### PR DESCRIPTION
# Description

I _think_ these are the changes that will be needed to be able to deploy https://github.com/jenkinsci/jelly/pull/55. Once this is merged I will check the incremental build for a successful deploy and make any adjustments if necessary.

https://github.com/jenkinsci/jelly

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [ ] Add a link to the pull request, which enables continous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
