### PR TITLE
Remove unused upload permissions from kohsuke

### DIFF
--- a/permissions/component-SECURITY-144-compat.yml
+++ b/permissions/component-SECURITY-144-compat.yml
@@ -5,4 +5,3 @@ paths:
   - "org/jenkins-ci/SECURITY-144-compat"
 developers:
   - "jglick"
-  - "kohsuke"

--- a/permissions/component-acceptance-test-harness.yml
+++ b/permissions/component-acceptance-test-harness.yml
@@ -6,7 +6,6 @@ paths:
 developers:
   - "andresrc"
   - "jglick"
-  - "kohsuke"
   - "olivergondza"
   - "rsandell"
   - "vlatombe"

--- a/permissions/component-cli.yml
+++ b/permissions/component-cli.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/cli"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/component-docker-fixtures.yml
+++ b/permissions/component-docker-fixtures.yml
@@ -8,7 +8,6 @@ cd:
 developers:
   - "andresrc"
   - "jglick"
-  - "kohsuke"
   - "olivergondza"
   - "rsandell"
   - "vlatombe"

--- a/permissions/component-dom4j.yml
+++ b/permissions/component-dom4j.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/dom4j"
 paths:
   - "org/jenkins-ci/dom4j/dom4j"
   - "org/jvnet/hudson/dom4j/dom4j"
-developers:
-  - "kohsuke"
+developers: []

--- a/permissions/component-groovy-cps.yml
+++ b/permissions/component-groovy-cps.yml
@@ -5,7 +5,6 @@ paths:
   - "com/cloudbees/groovy-cps"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "rsandell"

--- a/permissions/component-jenkins-bom.yml
+++ b/permissions/component-jenkins-bom.yml
@@ -4,6 +4,5 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-bom"
 developers:
-  - "kohsuke"
   - "teilo"
   - "releasebot"

--- a/permissions/component-jenkins-core.yml
+++ b/permissions/component-jenkins-core.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-core"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/component-jenkins-war.yml
+++ b/permissions/component-jenkins-war.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-war"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/component-jira-scraper.yml
+++ b/permissions/component-jira-scraper.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/lib-jira-scraper"
 paths:
   - "org/jenkins-ci/jira-scraper"
 developers:
-  - "kohsuke"
   - "oleg_nenashev"

--- a/permissions/component-localizer-maven-plugin.yml
+++ b/permissions/component-localizer-maven-plugin.yml
@@ -1,0 +1,6 @@
+---
+name: "localizer-maven-plugin"
+paths:
+  - "org/jvnet/localizer/localizer-maven-plugin"
+developers:
+  - "kohsuke"

--- a/permissions/component-localizer.yml
+++ b/permissions/component-localizer.yml
@@ -1,0 +1,6 @@
+---
+name: "localizer"
+paths:
+  - "org/jvnet/localizer/localizer"
+developers:
+  - "kohsuke"

--- a/permissions/component-process-utils.yml
+++ b/permissions/component-process-utils.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/lib-process-utils"
 paths:
   - "org/jenkins-ci/process-utils"
 developers:
-  - "kohsuke"
   - "olivergondza"

--- a/permissions/component-remoting-test-client.yml
+++ b/permissions/component-remoting-test-client.yml
@@ -3,7 +3,6 @@ name: "remoting-test-client"
 paths:
   - "org/jenkins-ci/remoting-test-client"
 developers:
-  - "kohsuke"
   - "oleg_nenashev"
   - "jthompson"
   - "releasebot"

--- a/permissions/component-remoting.yml
+++ b/permissions/component-remoting.yml
@@ -5,7 +5,6 @@ paths:
   - "org/jenkins-ci/main/remoting"
   - "org/jvnet/hudson/main/remoting"
 developers:
-  - "kohsuke"
   - "oleg_nenashev"
   - "jthompson"
   - "releasebot"

--- a/permissions/component-trilead-ssh2.yml
+++ b/permissions/component-trilead-ssh2.yml
@@ -5,7 +5,6 @@ paths:
   - "org/jenkins-ci/trilead-ssh2"
   - "org/jvnet/hudson/trilead-ssh2"
 developers:
-  - "kohsuke"
   - "mc1arke"
   - "ifernandezcalvo"
 cd:

--- a/permissions/component-winsw.yml
+++ b/permissions/component-winsw.yml
@@ -4,4 +4,3 @@ paths:
   - "com/sun/winsw/winsw"
 developers:
   - "oleg_nenashev"
-  - "kohsuke"

--- a/permissions/plugin-active-directory.yml
+++ b/permissions/plugin-active-directory.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/active-directory"
 developers:
   - "fbelzunc"
-  - "kohsuke"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-chef-tracking.yml
+++ b/permissions/plugin-chef-tracking.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '18825'  # chef-tracking-plugin
 paths:
   - "org/jenkins-ci/plugins/chef-tracking"
-developers:
-  - "kohsuke"
+developers: []

--- a/permissions/plugin-cloudbees-folder.yml
+++ b/permissions/plugin-cloudbees-folder.yml
@@ -9,7 +9,6 @@ cd:
   enabled: true
 developers:
   - "jglick"
-  - "kohsuke"
   - "oleg_nenashev"
   - "recena"
   - "dnusbaum"

--- a/permissions/plugin-cloudbees-jenkins-advisor.yml
+++ b/permissions/plugin-cloudbees-jenkins-advisor.yml
@@ -8,7 +8,6 @@ paths:
 developers:
   - "owood"
   - "kwhetstone"
-  - "kohsuke"
   - "aheritier"
   - "pierrebtz"
 security:

--- a/permissions/plugin-cloudbees-registration.yml
+++ b/permissions/plugin-cloudbees-registration.yml
@@ -6,5 +6,4 @@ issues:
 paths:
   - "com/cloudbees/jenkins/plugins/cloudbees-registration"
 developers:
-  - "kohsuke"
   - "ydubreuil"

--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -9,7 +9,6 @@ cd:
   enabled: true
 developers:
   - "jglick"
-  - "kohsuke"
   - "oleg_nenashev"
   - "jvz"
   - "@security"

--- a/permissions/plugin-cvs.yml
+++ b/permissions/plugin-cvs.yml
@@ -8,5 +8,4 @@ paths:
   - "org/jvnet/hudson/plugins/cvs"
 developers:
   - "mc1arke"
-  - "kohsuke"
   - "jglick"

--- a/permissions/plugin-deployment-notification.yml
+++ b/permissions/plugin-deployment-notification.yml
@@ -5,7 +5,6 @@ issues:
   - jira: '18726'  # deployment-notification-plugin
 paths:
   - "org/jenkins-ci/plugins/deployment-notification"
-developers:
-  - "kohsuke"
+developers: []
 cd:
   enabled: true

--- a/permissions/plugin-docker-commons.yml
+++ b/permissions/plugin-docker-commons.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/docker-commons"
 developers:
   - "jglick"
-  - "kohsuke"
   - "oleg_nenashev"
   - "rsandell"
   - "dnusbaum"

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/durable-task"
 developers:
   - "jglick"
-  - "kohsuke"
   - "svanoort"
   - "abayer"
   - "dnusbaum"

--- a/permissions/plugin-git-server.yml
+++ b/permissions/plugin-git-server.yml
@@ -9,7 +9,6 @@ cd:
   enabled: true
 developers:
   - "jglick"
-  - "kohsuke"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"

--- a/permissions/plugin-git-userContent.yml
+++ b/permissions/plugin-git-userContent.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '17593'  # git-usercontent-plugin
 paths:
   - "org/jenkins-ci/plugins/git-userContent"
-developers:
-  - "kohsuke"
+developers: []

--- a/permissions/plugin-github-api.yml
+++ b/permissions/plugin-github-api.yml
@@ -12,7 +12,6 @@ developers:
   - "andresrc"
   - "bitwiseman"
   - "integer"
-  - "kohsuke"
   - "ohtake_tomohiro"
   - "recena"
   - "surya548"

--- a/permissions/plugin-github-oauth.yml
+++ b/permissions/plugin-github-oauth.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/github-oauth"
 developers:
-  - "kohsuke"
   - "sag47"
   - "skottler"
   - "surya548"

--- a/permissions/plugin-github-organization-folder.yml
+++ b/permissions/plugin-github-organization-folder.yml
@@ -7,5 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/github-organization-folder"
 developers:
   - "jglick"
-  - "kohsuke"
   - "recena"

--- a/permissions/plugin-jaxb.yml
+++ b/permissions/plugin-jaxb.yml
@@ -8,7 +8,6 @@ paths:
   - "io/jenkins/plugins/jaxb"
 developers:
   - "basil"
-  - "kohsuke"
   - "oleg_nenashev"
   - "batmat"
 security:

--- a/permissions/plugin-jquery.yml
+++ b/permissions/plugin-jquery.yml
@@ -5,8 +5,7 @@ issues:
   - jira: '16017'  # jquery-plugin
 paths:
   - "org/jenkins-ci/plugins/jquery"
-developers:
-  - "kohsuke"
+developers: []
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-junit.yml
+++ b/permissions/plugin-junit.yml
@@ -10,7 +10,6 @@ developers:
   - "abayer"
   - "andresrc"
   - "jglick"
-  - "kohsuke"
   - "olivergondza"
   - "wolfs"
   - "dnusbaum"

--- a/permissions/plugin-ldap.yml
+++ b/permissions/plugin-ldap.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/ldap"
 developers:
   - "andresrc"
-  - "kohsuke"
   - "rsandell"
   - "@cloudbees-developers"
 security:

--- a/permissions/plugin-mailer.yml
+++ b/permissions/plugin-mailer.yml
@@ -10,7 +10,6 @@ cd:
 developers:
   - "andresrc"
   - "jglick"
-  - "kohsuke"
   - "rsandell"
   - "oleg_nenashev"
   - "alecharp"

--- a/permissions/plugin-maven-plugin.yml
+++ b/permissions/plugin-maven-plugin.yml
@@ -9,7 +9,6 @@ paths:
 developers:
   - "integer"
   - "jglick"
-  - "kohsuke"
   - "olamy"
   - "olivergondza"
   - "aheritier"

--- a/permissions/plugin-metrics.yml
+++ b/permissions/plugin-metrics.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/metrics"
 developers:
-  - "kohsuke"
   - "sbadger"
   - "alecharp"
   - "@cloudbees-developers"

--- a/permissions/plugin-monitoring.yml
+++ b/permissions/plugin-monitoring.yml
@@ -7,4 +7,3 @@ paths:
   - "org/jvnet/hudson/plugins/monitoring"
 developers:
   - "evernat"
-  - "kohsuke"

--- a/permissions/plugin-patch-parameter.yml
+++ b/permissions/plugin-patch-parameter.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '17503'  # patch-parameter-plugin
 paths:
   - "org/jenkins-ci/plugins/patch-parameter"
-developers:
-  - "kohsuke"
+developers: []

--- a/permissions/plugin-puppet.yml
+++ b/permissions/plugin-puppet.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '18727'  # puppet-plugin
 paths:
   - "org/jenkins-ci/plugins/puppet"
-developers:
-  - "kohsuke"
+developers: []

--- a/permissions/plugin-recipe.yml
+++ b/permissions/plugin-recipe.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '17474'  # recipe-plugin
 paths:
   - "org/jenkins-ci/plugins/recipe"
-developers:
-  - "kohsuke"
+developers: []

--- a/permissions/plugin-script-security.yml
+++ b/permissions/plugin-script-security.yml
@@ -9,7 +9,6 @@ cd:
   enabled: true
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "rsandell"

--- a/permissions/plugin-ssh-agent.yml
+++ b/permissions/plugin-ssh-agent.yml
@@ -9,7 +9,6 @@ cd:
   enabled: true
 developers:
   - "jglick"
-  - "kohsuke"
   - "recena"
   - "batmat"
   - "egutierrez"

--- a/permissions/plugin-ssh-slaves.yml
+++ b/permissions/plugin-ssh-slaves.yml
@@ -8,7 +8,6 @@ paths:
 developers:
   - "andresrc"
   - "jglick"
-  - "kohsuke"
   - "oleg_nenashev"
   - "ifernandezcalvo"
 security:

--- a/permissions/plugin-structs.yml
+++ b/permissions/plugin-structs.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/structs"
 developers:
   - "jglick"
-  - "kohsuke"
   - "oleg_nenashev"
   - "abayer"
   - "svanoort"

--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/support-core"
 developers:
   - "jglick"
-  - "kohsuke"
   - "schristou"
   - "batmat"
   - "owood"

--- a/permissions/plugin-translation.yml
+++ b/permissions/plugin-translation.yml
@@ -7,5 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/translation"
 developers:
   - "jglick"
-  - "kohsuke"
   - "recena"

--- a/permissions/plugin-variant.yml
+++ b/permissions/plugin-variant.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/variant"
 developers:
-  - "kohsuke"
   - "andresrc"
   - "batmat"
   - "jetersen"

--- a/permissions/plugin-workflow-aggregator.yml
+++ b/permissions/plugin-workflow-aggregator.yml
@@ -9,7 +9,6 @@ cd:
   enabled: true
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "dnusbaum"

--- a/permissions/plugin-workflow-api.yml
+++ b/permissions/plugin-workflow-api.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-api"
 developers:
   - "jglick"
-  - "kohsuke"
   - "svanoort"
   - "abayer"
   - "dnusbaum"

--- a/permissions/plugin-workflow-basic-steps.yml
+++ b/permissions/plugin-workflow-basic-steps.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-basic-steps"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "dnusbaum"

--- a/permissions/plugin-workflow-cps-global-lib.yml
+++ b/permissions/plugin-workflow-cps-global-lib.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-cps-global-lib"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "dnusbaum"

--- a/permissions/plugin-workflow-cps.yml
+++ b/permissions/plugin-workflow-cps.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-cps"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "rsandell"

--- a/permissions/plugin-workflow-durable-task-step.yml
+++ b/permissions/plugin-workflow-durable-task-step.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-durable-task-step"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "dnusbaum"

--- a/permissions/plugin-workflow-job.yml
+++ b/permissions/plugin-workflow-job.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-job"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "dnusbaum"

--- a/permissions/plugin-workflow-scm-step.yml
+++ b/permissions/plugin-workflow-scm-step.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-scm-step"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "dnusbaum"

--- a/permissions/plugin-workflow-step-api.yml
+++ b/permissions/plugin-workflow-step-api.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-step-api"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "rsandell"

--- a/permissions/plugin-workflow-support.yml
+++ b/permissions/plugin-workflow-support.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-support"
 developers:
   - "jglick"
-  - "kohsuke"
   - "svanoort"
   - "abayer"
   - "rsandell"

--- a/permissions/pom-jenkins-parent.yml
+++ b/permissions/pom-jenkins-parent.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-parent"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/pom-workflow-cps-parent.yml
+++ b/permissions/pom-workflow-cps-parent.yml
@@ -5,7 +5,6 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-cps-parent"
 developers:
   - "jglick"
-  - "kohsuke"
   - "abayer"
   - "svanoort"
   - "rsandell"

--- a/permissions/pom-workflow-pom.yml
+++ b/permissions/pom-workflow-pom.yml
@@ -4,4 +4,3 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-pom"
 developers:
   - "jglick"
-  - "kohsuke"

--- a/teams/core.yml
+++ b/teams/core.yml
@@ -7,7 +7,6 @@ developers:
 - "batmat"
 - "danielbeck"
 - "jglick"
-- "kohsuke"
 - "markewaite"
 - "notmyfault"
 - "olamy"


### PR DESCRIPTION
This PR removes unused upload permissions from @kohsuke.

The only things released by KK in the last five years were Jenkins releases (ended when automation took over in mid 2021) and https://github.com/kohsuke/localizer:

```
curl --silent --header 'Content-Type: text/plain' --user you:yourpass --data-binary 'items.find({"$and":[{"repo":"releases"},{"created_by":"kohsuke"},{"created":{"$gt":"2018-02-01T00:00:00.00+00:00"}}]}).include("path","name","created")' https://repo.jenkins-ci.org/api/search/aql | jq --raw-output '.results[] | "\( .created ): \( .path )/\( .name ))"'
```

This PR adds new permissions files for `localizer` itself and `localizer-maven-plugin` in anticipation of the removal of KK's unrestricted upload permissions in Artifactory (CC @Wadeck @dduportal).

Removal of component/plugin upload permissions was previously discussed with @kohsuke in March 2021 but I never got around to submitting this PR (and then I simply forgot).