### PR TITLE
Preparation for automated plugin release

### DIFF
--- a/permissions/plugin-performance.yml
+++ b/permissions/plugin-performance.yml
@@ -1,6 +1,8 @@
 ---
 name: "performance"
 github: "jenkinsci/performance-plugin"
+cd:
+  enabled: true
 issues:
   - jira: '15803'  # performance-plugin
 paths:


### PR DESCRIPTION
In order to opt into continuous delivery (CD) for `performance-plugin` I would like to enable CD Permission