### PR TITLE
Remove Jira field from JUnit plugin

### DIFF
--- a/permissions/plugin-junit.yml
+++ b/permissions/plugin-junit.yml
@@ -2,7 +2,6 @@
 name: "junit"
 github: &gh "jenkinsci/junit-plugin"
 issues:
-  - jira: '15499'  # junit-plugin
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/junit"


### PR DESCRIPTION
ref https://issues.jenkins.io/browse/JENKINS-70600.

The jira component has been archived.