### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/hosting-comment-checker.yml
+++ b/.github/workflows/hosting-comment-checker.yml
@@ -1,11 +1,9 @@
 name: Hosting re-checker
-
 on:
   issue_comment:
     types:
       - created
       - edited
-
 jobs:
   hosting:
     runs-on: ubuntu-latest

--- a/.github/workflows/hosting-comment-hoster.yml
+++ b/.github/workflows/hosting-comment-hoster.yml
@@ -1,11 +1,9 @@
 name: Hosting hoster
-
 on:
   issue_comment:
     types:
       - created
       - edited
-
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -13,7 +11,7 @@ jobs:
     outputs:
       actor_in_hosting_team: ${{ steps.checkUserMember.outputs.isTeamMember }}
     steps:
-      - uses: tspascoal/get-user-teams-membership@v2
+      - uses: tspascoal/get-user-teams-membership@37c08f7b52a72ca95d12af2e7ab2553ca9adf13b # v2
         id: checkUserMember
         with:
           username: ${{ github.actor }}

--- a/.github/workflows/hosting-issue-checker.yml
+++ b/.github/workflows/hosting-issue-checker.yml
@@ -1,11 +1,9 @@
 name: Hosting checker
-
 on:
   issues:
     types:
       - opened
       - edited
-
 jobs:
   hosting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402