### PR TITLE
Update `build-monitor-plugin` permissions

### DIFF
--- a/permissions/plugin-build-monitor-plugin.yml
+++ b/permissions/plugin-build-monitor-plugin.yml
@@ -1,7 +1,12 @@
 ---
 name: "build-monitor-plugin"
-github: "jan-molak/jenkins-build-monitor-plugin"
+github: &gh "jenkinsci/build-monitor-plugin"
+issues:
+  - jira: '17722'  # build-monitor-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/build-monitor-plugin"
 developers:
   - "janmolak"
+cd:
+  enabled: true

--- a/permissions/pom-build-monitor.yml
+++ b/permissions/pom-build-monitor.yml
@@ -1,7 +1,9 @@
 ---
 name: "build-monitor"
-github: "jan-molak/jenkins-build-monitor-plugin"
+github: "jenkinsci/build-monitor-plugin"
 paths:
   - "org/jenkins-ci/plugins/build-monitor"
 developers:
   - "janmolak"
+cd:
+  enabled: true


### PR DESCRIPTION
# Description

Updating the GitHub coordinates to reflect the transform of this plugin from https://github.com/jan-molak/jenkins-build-monitor-plugin to https://github.com/jenkinsci/build-monitor-plugin. While I was here I also added an `issues` section to make it easier for end users to find existing issues. I plan to set up CD, so also adding permissions for that. My next course of action is going to be to get the build up and running on ci.jenkins.io and then enable CD.

https://github.com/jenkinsci/build-monitor-plugin

CC @jan-molak

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [ ] Add a link to the pull request, which enables continuous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
