### PR TITLE
Request for comaintainership of shutdown-queue-plugin

### DIFF
--- a/permissions/plugin-shutdown-queue.yml
+++ b/permissions/plugin-shutdown-queue.yml
@@ -5,5 +5,6 @@ paths:
   - "io/jenkins/plugins/shutdown-queue"
 developers:
   - "_dkozubik"
+  - "judovana"
 issues:
   - jira: 28826


### PR DESCRIPTION
# Description
Request  comaintain  [shutdown-queue-plugin](https://github.com/jenkinsci/shutdown-queue-plugin/)
 * please grant @judovana  commit permissions
 * please grant @judovana  release permissions

<!-- fill in description here, this will at least be a link to a GitHub repository, and often also links to hosting request, and @mentioning other committers/maintainers as per the checklist below -->

https://github.com/jenkinsci/shutdown-queue-plugin/
I was part of the plugin development since origin as consultant - https://is.muni.cz/th/ki45d/
There is a bug, which is making this plugin nearly useless - an short period of enabled state when jenkins start in shutdown mode when jobs can leak.  https://github.com/jenkinsci/shutdown-queue-plugin/pull/5 is fixing it.
I was in touch with developer @dkozubik until October 2022. Now he somehow felt silent. 

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x").
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [x] Add a link to the pull request, which enables continuous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
