### PR TITLE
Enable CD for `docker-commons`

### DIFF
--- a/permissions/plugin-docker-commons.yml
+++ b/permissions/plugin-docker-commons.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '20628'  # docker-commons-plugin
 paths:
   - "org/jenkins-ci/plugins/docker-commons"
+cd:
+  enabled: true
 developers:
   - "jglick"
   - "kohsuke"


### PR DESCRIPTION
# Description

Needs routine metadata refresh at least. @rsandell 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
