### PR TITLE
Add release permissions for coverage-model

### DIFF
--- a/permissions/component-coverage-model.yml
+++ b/permissions/component-coverage-model.yml
@@ -1,0 +1,7 @@
+---
+name: "coverage-model"
+github: "jenkinsci/coverage-model"
+paths:
+  - "edu/hm/hafner/coverage-model"
+developers:
+  - "drulli"


### PR DESCRIPTION
See https://github.com/jenkins-infra/repository-permissions-updater/issues/3182

Apparently, the bot picks up plugins only.