### PR TITLE
Drop markewaite as maintainer of 5 plugins

### DIFF
--- a/permissions/plugin-backup.yml
+++ b/permissions/plugin-backup.yml
@@ -7,5 +7,4 @@ paths:
   - "org/jvnet/hudson/plugins/backup"
 developers:
   - "jm_meessen"
-  - "markewaite"
   - "poddingue"

--- a/permissions/plugin-msbuild.yml
+++ b/permissions/plugin-msbuild.yml
@@ -14,7 +14,6 @@ developers:
   - olamy
   - teilo
   - "jm_meessen"
-  - "markewaite"
   - "poddingue"
 security:
   contacts:

--- a/permissions/plugin-skip-certificate-check.yml
+++ b/permissions/plugin-skip-certificate-check.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '15923'  # skip-certificate-check-plugin
 paths:
   - "org/jenkins-ci/plugins/skip-certificate-check"
-developers:
-  - "markewaite"
+developers: []

--- a/permissions/plugin-test-results-analyzer.yml
+++ b/permissions/plugin-test-results-analyzer.yml
@@ -8,5 +8,4 @@ paths:
 developers:
   - "menonvarun"
   - "jm_meessen"
-  - "markewaite"
   - "poddingue"

--- a/permissions/plugin-windows-slaves.yml
+++ b/permissions/plugin-windows-slaves.yml
@@ -16,7 +16,6 @@ developers:
   - "olamy"
   - "mramonleon"
   - "jm_meessen"
-  - "markewaite"
   - "poddingue"
 security:
   contacts:


### PR DESCRIPTION
## Drop markewaite as maintainer of 5 plugins

Drop @markewaite as maintainer of 5 plugins.

* https://github.com/jenkinsci/backup-plugin
* https://github.com/jenkinsci/msbuild-plugin
* https://github.com/jenkinsci/skip-certificate-check-plugin
* https://github.com/jenkinsci/test-results-analyzer-plugin
* https://github.com/jenkinsci/windows-slaves-plugin

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
