### PR TITLE
Block future releases of Compuware plugins with non-free license

### DIFF
--- a/permissions/plugin-compuware-common-configuration.yml
+++ b/permissions/plugin-compuware-common-configuration.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/compuware-common-configuration-plugin"
 issues:
   - jira: '23140'  # compuware-common-configuration-plugin
 paths:
-  - "com/compuware/jenkins/compuware-common-configuration"
+  # New releases blocked due to non-free license, see 2023-03-20 project meeting
+  - "com/compuware/jenkins/compuware-common-configuration-releaseblock"
 developers:
   - "cpwr_jenkins"

--- a/permissions/plugin-compuware-ispw-operations.yml
+++ b/permissions/plugin-compuware-ispw-operations.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/compuware-ispw-operations-plugin"
 issues:
   - jira: '23423'  # compuware-ispw-operations-plugin
 paths:
-  - "com/compuware/jenkins/compuware-ispw-operations"
+  # New releases blocked due to non-free license, see 2023-03-20 project meeting
+  - "com/compuware/jenkins/compuware-ispw-operations-releaseblock"
 developers:
   - "cpwr_jenkins"

--- a/permissions/plugin-compuware-scm-downloader.yml
+++ b/permissions/plugin-compuware-scm-downloader.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/compuware-scm-downloader-plugin"
 issues:
   - jira: '21125'  # compuware-scm-downloader-plugin
 paths:
-  - "com/compuware/jenkins/compuware-scm-downloader"
+  # New releases blocked due to non-free license, see 2023-03-20 project meeting
+  - "com/compuware/jenkins/compuware-scm-downloader-releaseblock"
 developers:
   - "cpwr_jenkins"

--- a/permissions/plugin-compuware-strobe-measurement.yml
+++ b/permissions/plugin-compuware-strobe-measurement.yml
@@ -4,6 +4,7 @@ github: "jenkinsci/compuware-strobe-measurement-plugin"
 issues:
   - jira: '27126'  # compuware-strobe-measurement-plugin
 paths:
-  - "com/compuware/jenkins/compuware-strobe-measurement"
+  # New releases blocked due to non-free license, see 2023-03-20 project meeting
+  - "com/compuware/jenkins/compuware-strobe-measurement-releaseblock"
 developers:
   - "cpwr_jenkins"


### PR DESCRIPTION
These plugins now use a non-free license, violating our hosting guidelines, see e.g. https://www.jenkins.io/doc/developer/publishing/preparation/#license

- `compuware-scm-downloader`
- `compuware-ispw-operations`
- `compuware-common-configuration`
- `compuware-strobe-measurement`

As decided in the [2023-03-20 project meeting](https://docs.google.com/document/d/11Nr8QpqYgBiZjORplL_3Zkwys2qK1vEvK-NYyYa4rzg/edit#heading=h.sn91mb5c7g3x), we are blocking the ability of maintainers to create new releases while these plugins have non-free licenses.
