### PR TITLE
chore(Jenkinsfile) retry the "Run" stage if it fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,9 @@ node('maven-11') {
                         string(credentialsId: 'artifactoryAdminToken', variable: 'ARTIFACTORY_TOKEN'),
                         usernamePassword(credentialsId: 'jenkins-infra-bot-github-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
                 ]) {
-                    sh 'java ' + javaArgs
+                    retry(conditions: [agent(), nonresumable()], count: 2) {
+                        sh 'java ' + javaArgs
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

Related to https://github.com/jenkins-infra/helpdesk/issues/3462#issuecomment-1477681324

This PR updates the Jenkinfile to add a `retry()` step in the `Run` stage when not in "dry run" mode.

The goal is to avoid expired RPU tokens which are valid 5 hours: as the build runs every 3 hours, any build failure usually ends in HTTP/401 for releases.

Retrying the stage `Run`, which is the most prone to fail due to GitHub API HTTP/5xx errors, is a tentative of improvement.

