### PR TITLE
Let markwaite adopt authorize-project plugin again

### DIFF
--- a/permissions/plugin-authorize-project.yml
+++ b/permissions/plugin-authorize-project.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/authorize-project"
 developers:
   - "ikedam"
+  - "markewaite"
   # Not a maintainer, just tables-to-divs fixes
   - "oleg_nenashev"


### PR DESCRIPTION
## Let markewaite adopt authorize-projects plugin

I'd like to adopt https://github.com/jenkinsci/authorize-project-plugin again so that I can release the configuration as code support that was initially implemented by @daxriggs and refined by @basil with improvements and additional tests.

I had adopted the plugin previously and submitted the following pull requests to improve it:

* https://github.com/jenkinsci/authorize-project-plugin/pull/106
* https://github.com/jenkinsci/authorize-project-plugin/pull/107
* https://github.com/jenkinsci/authorize-project-plugin/pull/108
* https://github.com/jenkinsci/authorize-project-plugin/pull/122

I may also enable automated releases during this adoption, since it simplifies my maintenance of the plugin.

Per https://github.com/jenkinsci/authorize-project-plugin this plugin is up for adoption.

@MarkEWaite is the GitHub user associated with the Jenkins LDAP account markewaite

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
