### PR TITLE
Enable CD on `view-job-filters`

### DIFF
--- a/permissions/plugin-view-job-filters.yml
+++ b/permissions/plugin-view-job-filters.yml
@@ -6,6 +6,8 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/view-job-filters"
   - "org/jvnet/hudson/plugins/view-job-filters"
+cd:
+  enabled: true
 developers:
   - "svenschoenung"
   - "jglick"


### PR DESCRIPTION
# Description

To release e.g. https://github.com/jenkinsci/view-job-filters-plugin/pull/34. CC @amuniz @svenschoenung 

### When enabling automated releases (cd: true)

- [ ] Add a link to the pull request, which enables continuous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

_(coming shortly)_

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
