### PR TITLE
Remove temporary permissions from tables-to-divs migration

### DIFF
--- a/permissions/plugin-authorize-project.yml
+++ b/permissions/plugin-authorize-project.yml
@@ -8,5 +8,3 @@ paths:
 developers:
   - "ikedam"
   - "markewaite"
-  # Not a maintainer, just tables-to-divs fixes
-  - "oleg_nenashev"

--- a/permissions/plugin-createjobadvanced.yml
+++ b/permissions/plugin-createjobadvanced.yml
@@ -5,6 +5,4 @@ issues:
   - jira: '15737'  # createjobadvanced-plugin
 paths:
   - "org/jenkins-ci/plugins/createjobadvanced"
-developers:
-  # Not a maintainer, just tables-to-divs fixes
-  - "oleg_nenashev"
+developers: []

--- a/permissions/plugin-join.yml
+++ b/permissions/plugin-join.yml
@@ -7,5 +7,3 @@ paths:
   - "org/jenkins-ci/plugins/join"
 developers:
   - "mdonohue"
-  # Not a maintainer, just tables-to-divs fixes
-  - "oleg_nenashev"

--- a/permissions/plugin-publish-over-dropbox.yml
+++ b/permissions/plugin-publish-over-dropbox.yml
@@ -7,5 +7,3 @@ paths:
   - "org/jenkins-ci/plugins/publish-over-dropbox"
 developers:
   - "rcgroot"
-  # Not a maintainer, just tables-to-divs fixes
-  - "oleg_nenashev"

--- a/permissions/plugin-publish-over-ftp.yml
+++ b/permissions/plugin-publish-over-ftp.yml
@@ -8,5 +8,3 @@ paths:
   - "org/jvnet/hudson/plugins/publish-over-ftp"
 developers:
   - "gmcdonald"
-  # Not a maintainer, just tables-to-divs fixes
-  - "oleg_nenashev"


### PR DESCRIPTION
# Description

Reverts #1853. That PR introduced a set of temporary permissions needed to adapt to the tables-to-divs migration. That migration is long since complete and successful, so these temporary permissions are no longer needed.

- https://github.com/jenkinsci/authorize-project-plugin
- https://github.com/jenkinsci/createjobadvanced-plugin
- https://github.com/jenkinsci/join-plugin
- https://github.com/jenkinsci/publish-over-dropbox-plugin
- https://github.com/jenkinsci/publish-over-ftp-plugin

CC @oleg-nenashev 

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [ ] Add a link to the pull request, which enables continuous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### When adding new uploaders (this includes newly created permissions files)

- [ ] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
