### PR TITLE
Revert "Block future releases of Compuware plugins with non-free license"

### DIFF
--- a/permissions/plugin-compuware-common-configuration.yml
+++ b/permissions/plugin-compuware-common-configuration.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/compuware-common-configuration-plugin"
 issues:
   - jira: '23140'  # compuware-common-configuration-plugin
 paths:
-  # New releases blocked due to non-free license, see 2023-03-20 project meeting
-  - "com/compuware/jenkins/compuware-common-configuration-releaseblock"
+  - "com/compuware/jenkins/compuware-common-configuration"
 developers:
   - "cpwr_jenkins"

--- a/permissions/plugin-compuware-ispw-operations.yml
+++ b/permissions/plugin-compuware-ispw-operations.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/compuware-ispw-operations-plugin"
 issues:
   - jira: '23423'  # compuware-ispw-operations-plugin
 paths:
-  # New releases blocked due to non-free license, see 2023-03-20 project meeting
-  - "com/compuware/jenkins/compuware-ispw-operations-releaseblock"
+  - "com/compuware/jenkins/compuware-ispw-operations"
 developers:
   - "cpwr_jenkins"

--- a/permissions/plugin-compuware-scm-downloader.yml
+++ b/permissions/plugin-compuware-scm-downloader.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/compuware-scm-downloader-plugin"
 issues:
   - jira: '21125'  # compuware-scm-downloader-plugin
 paths:
-  # New releases blocked due to non-free license, see 2023-03-20 project meeting
-  - "com/compuware/jenkins/compuware-scm-downloader-releaseblock"
+  - "com/compuware/jenkins/compuware-scm-downloader"
 developers:
   - "cpwr_jenkins"

--- a/permissions/plugin-compuware-strobe-measurement.yml
+++ b/permissions/plugin-compuware-strobe-measurement.yml
@@ -4,7 +4,6 @@ github: "jenkinsci/compuware-strobe-measurement-plugin"
 issues:
   - jira: '27126'  # compuware-strobe-measurement-plugin
 paths:
-  # New releases blocked due to non-free license, see 2023-03-20 project meeting
-  - "com/compuware/jenkins/compuware-strobe-measurement-releaseblock"
+  - "com/compuware/jenkins/compuware-strobe-measurement"
 developers:
   - "cpwr_jenkins"


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#3201.

Plugins are now MIT licensed again.

See https://github.com/jenkins-infra/update-center2/pull/692#issuecomment-1479425572