### PR TITLE
Revert "Do not need to deploy `groovy-cps-dgm-builder` after all (#3217)"

### DIFF
--- a/permissions/component-groovy-cps-dgm-builder.yml
+++ b/permissions/component-groovy-cps-dgm-builder.yml
@@ -1,0 +1,22 @@
+---
+name: "groovy-cps-dgm-builder"
+github: "jenkinsci/workflow-cps-plugin"
+paths:
+  - "com/cloudbees/groovy-cps-dgm-builder"
+developers:
+  - "jglick"
+  - "kohsuke"
+  - "abayer"
+  - "svanoort"
+  - "rsandell"
+  - "dnusbaum"
+  - "carroll"
+  - "bitwiseman"
+  - "kshultz"
+  - "jtaboada"
+  - "teilo"
+security:
+  contacts:
+    jira: "cloudbees_security_members"
+cd:
+  enabled: true


### PR DESCRIPTION
# Description

Reverting #3217 pending further study of how to avoid deploying this under some conditions.

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
