### PR TITLE
Add markewaite as a testcomplete maintainer

### DIFF
--- a/permissions/plugin-TestComplete.yml
+++ b/permissions/plugin-TestComplete.yml
@@ -6,3 +6,4 @@ paths:
 developers:
   - "igor_filin"
   - "rinconedgar"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as a testcomplete maintainer

**Plugin:** https://github.com/jenkinsci/testcomplete-plugin/

@rinconedgar and @Igor-Filin are testcomplete plugin maintainers from SmartBear.  @rinconedgar has approved pull request https://github.com/jenkinsci/testcomplete-plugin/pull/12 that modernizes the plugin and resolves an already disclosed vulnerability https://www.jenkins.io/security/advisory/2023-01-24/#SECURITY-2741 .  They would like to merge and release a new version of the plugin with that fix, but @rinconedgar does not have merge permission to the GitHub repository.

Allowing me as a temporary maintainer may also grant merge permission to @rinconedgar.  If it does not, then we'll need someone to investigate why the people listed in the repository permissions updater do not have merge permission to the repository.

https://github.com/jenkinsci/testcomplete-plugin/pull/12 is the pull request that I plan to merge.

@rinconedgar or @Igor-Filin could you reply to this pull request with either your approval of the proposal or your rejection of it?

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [x] Add a link to the pull request, which enables continuous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
