### PR TITLE
Add markewaite as a pipeline metadata utils maintainer

### DIFF
--- a/permissions/component-pipeline-metadata-utils.yml
+++ b/permissions/component-pipeline-metadata-utils.yml
@@ -6,3 +6,4 @@ developers:
   - "abayer"
   - "kwhetstone"
   - "jm_meessen"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as a pipeline metadata utils maintainer

https://github.com/jenkins-infra/pipeline-metadata-utils is the repository.

https://github.com/jenkins-infra/jenkins.io/issues/6355 investigation may need a new release of the utilities in order to include Jenkins pom version 1.98 in a release that can be consumed by the pipeline steps doc generator.

@abayer, @kwhetstone, or @jm_meessen approval needed

https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/ was broken when the Pipeline steps doc generator updated to Jenkins pom 1.98.  I've not found the root cause yet.  Investigation is ongoing in https://github.com/jenkins-infra/jenkins.io/issues/6355 but one theory is that the metadata utilities used by the docs generator may need to be using Jenkins pom 1.98.  There are many dependency updates pending for the metadata utilities, so it is a good time to release a new version.

# Submitter checklist for adding or changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] Make sure to `@`mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [x] [All newly added users have logged in to Artifactory and Jira at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
