### PR TITLE
Prevent further releases of autocomplete-parameter

### DIFF
--- a/permissions/plugin-autocomplete-parameter.yml
+++ b/permissions/plugin-autocomplete-parameter.yml
@@ -4,7 +4,8 @@ github: &GH "jenkinsci/autocomplete-parameter-plugin"
 issues:
   - github: *GH
 paths:
-  - "org/jenkins-ci/plugins/autocomplete-parameter"
+# Block creation of new releases. If you want to release the plugin, contact the Jenkins security team about SECURITY-3157
+  - "org/jenkins-ci/plugins/autocomplete-parameter-releaseblock"
 developers:
   - "taksan"
   - "takeuchi"


### PR DESCRIPTION
Suspended as per https://www.jenkins.io/security/plugins/#suspensions