### PR TITLE
Enable CD for `config-file-provider`

### DIFF
--- a/permissions/plugin-config-file-provider.yml
+++ b/permissions/plugin-config-file-provider.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '16140'  # config-file-provider-plugin
 paths:
   - "org/jenkins-ci/plugins/config-file-provider"
+cd:
+  enabled: true
 developers:
   - "imod"
   - "egutierrez"


### PR DESCRIPTION
# Description

https://github.com/jenkinsci/config-file-provider-plugin/pull/267#issuecomment-1526283988

For whatever reason, I have write (but not admin) access to this repo, so with CD enabled we could get routine stuff like this shipped more readily. CC @alecharp @batmat @rsandell @jmMeessen @imod 

### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
