### PR TITLE
Prevent further releases of team-views

### DIFF
--- a/permissions/plugin-team-views.yml
+++ b/permissions/plugin-team-views.yml
@@ -4,5 +4,6 @@ github: &GH "jenkinsci/team-views-plugin"
 issues:
   - github: *GH
 paths:
-  - "com/sonymobile/jenkins/plugins/teamviews/team-views"
+# Block creation of new releases. If you want to release the plugin, contact the Jenkins security team about SECURITY-1649
+  - "com/sonymobile/jenkins/plugins/teamviews/team-views-releaseblock"
 developers: []


### PR DESCRIPTION
Like https://github.com/jenkins-infra/repository-permissions-updater/pull/2603, preventing release of a suspended plugin, just in case.