### PR TITLE
Block CD releases for plugins without maintainers

### DIFF
--- a/permissions/plugin-any-buildstep.yml
+++ b/permissions/plugin-any-buildstep.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/any-buildstep"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-anything-goes-formatter.yml
+++ b/permissions/plugin-anything-goes-formatter.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/anything-goes-formatter"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-backup-interrupt-plugin.yml
+++ b/permissions/plugin-backup-interrupt-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "jenkins/ci/plugins/backup/backup-interrupt-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-build-cause-run-condition.yml
+++ b/permissions/plugin-build-cause-run-condition.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/build-cause-run-condition"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-build-keeper-plugin.yml
+++ b/permissions/plugin-build-keeper-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/build-keeper-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-console-tail.yml
+++ b/permissions/plugin-console-tail.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/console-tail"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-copy-project-link.yml
+++ b/permissions/plugin-copy-project-link.yml
@@ -7,5 +7,6 @@ paths:
   - "hudson/plugins/copyProjectLink/copy-project-link"
   - "org/jenkins-ci/plugins/copy-project-link"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-create-fingerprint.yml
+++ b/permissions/plugin-create-fingerprint.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/create-fingerprint"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-downstream-buildview.yml
+++ b/permissions/plugin-downstream-buildview.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/downstream-buildview"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-downstream-ext.yml
+++ b/permissions/plugin-downstream-ext.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/downstream-ext"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-envfile.yml
+++ b/permissions/plugin-envfile.yml
@@ -7,5 +7,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/envfile"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-fail-the-build-plugin.yml
+++ b/permissions/plugin-fail-the-build-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/fail-the-build-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-favorite-view.yml
+++ b/permissions/plugin-favorite-view.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/favorite-view"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-groovy-remote.yml
+++ b/permissions/plugin-groovy-remote.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkinsci/plugins/groovy-remote"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-hsts-filter-plugin.yml
+++ b/permissions/plugin-hsts-filter-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/hsts-filter-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-jqs-monitoring.yml
+++ b/permissions/plugin-jqs-monitoring.yml
@@ -7,5 +7,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/jqs-monitoring"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-kpp-management-plugin.yml
+++ b/permissions/plugin-kpp-management-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "sic/software/kpp-management-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-nant.yml
+++ b/permissions/plugin-nant.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/nant"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-openid4java.yml
+++ b/permissions/plugin-openid4java.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/openid4java"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-progress-bar-column-plugin.yml
+++ b/permissions/plugin-progress-bar-column-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/progress-bar-column-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-project-stats-plugin.yml
+++ b/permissions/plugin-project-stats-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/project-stats-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-sbt.yml
+++ b/permissions/plugin-sbt.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/sbt"
   - "org/jvnet/hudson/plugins/sbt"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-scoring-load-balancer.yml
+++ b/permissions/plugin-scoring-load-balancer.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "jp/ikedam/jenkins/plugins/scoring-load-balancer"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-slave-status.yml
+++ b/permissions/plugin-slave-status.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/slave-status"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-statusmonitor.yml
+++ b/permissions/plugin-statusmonitor.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/statusmonitor"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-svn-revert-plugin.yml
+++ b/permissions/plugin-svn-revert-plugin.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/svn-revert-plugin"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-svncompat14.yml
+++ b/permissions/plugin-svncompat14.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/svncompat14"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-template-workflows.yml
+++ b/permissions/plugin-template-workflows.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins/plugin/templateWorkflows/template-workflows"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-text-finder-run-condition.yml
+++ b/permissions/plugin-text-finder-run-condition.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/text-finder-run-condition"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true

--- a/permissions/plugin-windows-exe-runner.yml
+++ b/permissions/plugin-windows-exe-runner.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/windows-exe-runner"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true


### PR DESCRIPTION
JEP-229 CD allows committers to create new releases, so technically, no maintainer is needed.

This creates problems for plugin governance however, as nobody is a known maintainer of the plugin. While committers may end up adopting plugins in case the need arises from their POV, that's not a solution when maintainers need to be contacted. In particular this is a problem for the security team, which assigns vulnerability reports to the maintainers listed here. All of these plugins may be actively maintained, but as nobody is a listed as maintainer, we have nobody to contact.

If the intention of this combination of options is to explicitly do not allow anyone to perform manual releases, that should be accomplished through an extension of the YAML format.

I would also ask that folks merging PRs in this repo ensure that the combination of an empty `developers` list and CD `enabled: true` not be accepted for plugin components in the future. (`component-stapler.yml` has the same problem, but it's irrelevant there.)