### PR TITLE
Remove jm-meessen as maintainer of several plugins

### DIFF
--- a/permissions/plugin-docker-plugin.yml
+++ b/permissions/plugin-docker-plugin.yml
@@ -12,6 +12,5 @@ developers:
   - "integer"
   - "magnayn"
   - "pjdarton"
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"

--- a/permissions/plugin-gitlab-plugin.yml
+++ b/permissions/plugin-gitlab-plugin.yml
@@ -9,7 +9,6 @@ paths:
   - "org/jenkins-ci/plugins/gitlab-plugin"
 developers:
   - "elbidouilleur"  # jenkins.io/jira Username MaximeMazet Github username
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"
   - "krisstern"

--- a/permissions/plugin-lockable-resources.yml
+++ b/permissions/plugin-lockable-resources.yml
@@ -14,7 +14,6 @@ developers:
   - "tgr"
   - "robinjarry"
   - "jimklimov"
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"
   - "mpokornyetm"

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -16,7 +16,6 @@ developers:
   - "mramonleon"
   - "rsandell"
   - "dnusbaum"
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"
 security:

--- a/permissions/plugin-msbuild.yml
+++ b/permissions/plugin-msbuild.yml
@@ -13,7 +13,6 @@ developers:
   - carroll
   - olamy
   - teilo
-  - "jm_meessen"
   - "poddingue"
 security:
   contacts:

--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -13,7 +13,6 @@ developers:
   - "svanoort"
   - "wolfs"
   - "olamy"
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"
 security:

--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -15,7 +15,6 @@ developers:
   - "wolfs"
   - "dnusbaum"
   - "teilo"
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"
 security:

--- a/permissions/plugin-run-condition.yml
+++ b/permissions/plugin-run-condition.yml
@@ -8,7 +8,6 @@ paths:
 developers:
   - "imod"
   - "timja"
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"
   - "zack_aayush"

--- a/permissions/plugin-test-results-analyzer.yml
+++ b/permissions/plugin-test-results-analyzer.yml
@@ -7,5 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/test-results-analyzer"
 developers:
   - "menonvarun"
-  - "jm_meessen"
   - "poddingue"

--- a/permissions/plugin-versionnumber.yml
+++ b/permissions/plugin-versionnumber.yml
@@ -8,6 +8,5 @@ paths:
 developers:
   - "bahadir"
   - "rosberglinhares"
-  - "jm_meessen"
   - "markewaite"
   - "poddingue"

--- a/permissions/plugin-windows-slaves.yml
+++ b/permissions/plugin-windows-slaves.yml
@@ -15,7 +15,6 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "mramonleon"
-  - "jm_meessen"
   - "poddingue"
 security:
   contacts:


### PR DESCRIPTION

# Description

PR to remove myself as maintainer for several plugins. 

I was added as maintainer for these repositories together with @MarkEWaite and @gounthar as part of the DevOps World workshop on plugins. This workshop will not take place anymore. These accesses are thus not required anymore.

Plugins withdrawn of:
- docker plugin
- versionnumber plugin
- test-result-analyzer plugin
- msbuild plugin
- gitlab plugin
- mercurial plugin
- parameterized-trigger plugin
- run-condition plugin
- windows-slave plugin
- promoted-build plugin