### PR TITLE
Enable CD Permissions for plugin-libvirt-slave

### DIFF
--- a/permissions/plugin-libvirt-slave.yml
+++ b/permissions/plugin-libvirt-slave.yml
@@ -6,6 +6,8 @@ issues:
 paths:
   - "hudson/plugins/libvirt/libvirt-slave"
   - "org/jenkins-ci/plugins/libvirt-slave"
+cd:
+  enabled: true
 developers:
   - "gkr"
   - "magnayn"


### PR DESCRIPTION
<!-- This PR template only applies to permission changes. Ignore it for changes to the tool updating permissions in Artifactory -->

# Description

Enables CD permissions for [libvirt-agents](https://github.com/jenkinsci/libvirt-slave-plugin) plugin.
[PR that enabled incrementals](https://github.com/jenkinsci/libvirt-slave-plugin/pull/29).

# Submitter checklist for adding or changing permissions

<!--
Make sure to implement all relevant entries (see section headers to when they apply) and mark them as checked (by replacing the space between brackets with an "x").
-->

### Always

- [x] Add link to plugin/component Git repository in description above

### When enabling automated releases (cd: true)

- [x] Add a link to the pull request, which enables continuous delivery for your plugin or component.  
Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly.


### Reviewer checklist (not for requesters!)

- [ ] Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
