### PR TITLE
Let markewaite adopt http-request plugin

### DIFF
--- a/permissions/plugin-http_request.yml
+++ b/permissions/plugin-http_request.yml
@@ -7,4 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/http_request"
 developers:
   - "janario"
+  - "markewaite"
   - "oleg_nenashev"


### PR DESCRIPTION
## Let markewaite adopt http-request plugin

The http-request plugin https://github.com/jenkinsci/http-request-plugin needs a new release to deliver the features and bug fixes that have accumulated since its last release in Aug 2022.  Some of those new features and bug fixes include:

* https://github.com/jenkinsci/http-request-plugin/pull/128
* https://github.com/jenkinsci/http-request-plugin/pull/113
* https://github.com/jenkinsci/http-request-plugin/pull/111
* https://github.com/jenkinsci/http-request-plugin/pull/148

Documentation improvements include:

* https://github.com/jenkinsci/http-request-plugin/pull/141
* https://github.com/jenkinsci/http-request-plugin/pull/74
* https://github.com/jenkinsci/http-request-plugin/pull/133
* https://github.com/jenkinsci/http-request-plugin/pull/130
* https://github.com/jenkinsci/http-request-plugin/pull/122

Maintenance improvements include:

* https://github.com/jenkinsci/http-request-plugin/pull/149

https://github.com/jenkinsci/http-request-plugin/pull/150 is the pull request that prompted this adoption request

Reverts part of pull request:

* #2950

Existing team member approval is not required because this plugin is "up for adoption" based on the "adopt-this-plugin" label on the GitHub repository.

# When modifying release permission

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.


### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
