### PR TITLE
Enable auto-release for scm-filter-jervis-plugin

### DIFF
--- a/permissions/plugin-scm-filter-jervis.yml
+++ b/permissions/plugin-scm-filter-jervis.yml
@@ -7,3 +7,5 @@ paths:
   - "io/jenkins/plugins/scm-filter-jervis"
 developers:
   - "sag47"
+cd:
+  enabled: true


### PR DESCRIPTION
Repository link
---------------

https://github.com/jenkinsci/scm-filter-jervis-plugin

Enabling auto-release
---------------------

See my PR; please review https://github.com/jenkinsci/scm-filter-jervis-plugin/pull/6

My checklist:

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

Reviewer checklist
------------------

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.