### PR TITLE
Update maintainers list

### DIFF
--- a/permissions/plugin-crowdstrike-security.yml
+++ b/permissions/plugin-crowdstrike-security.yml
@@ -6,5 +6,6 @@ paths:
 developers:
 - "crwd_etatarevic"
 - "crwdsmullz"
+- "crwdlemos"
 issues:
   - github: *GH


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/crowdstrike-security-plugin

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.



