### PR TITLE
Add markewaite as a pollscm maintainer

### DIFF
--- a/permissions/plugin-pollscm.yml
+++ b/permissions/plugin-pollscm.yml
@@ -6,4 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/pollscm"
 developers:
+  - "markewaite"
   - "vlatombe"


### PR DESCRIPTION
## Add markewaite as a pollscm plugin maintainer

https://github.com/jenkinsci/pollscm-plugin is a plugin that I use as a convenient way to force polling of a git repository.  I'd like to modernize the plugin and merge https://github.com/jenkinsci/pollscm-plugin/pull/3 and https://github.com/jenkinsci/pollscm-plugin/pull/4 so that Prototype.js is removed from the plugin.  That will also provide a Jenkinsfile for CI and allow further improvements like moving the documentation and the changelog to GitHub.

@Vlatombe would you approve my adopting this plugin?

# When modifying release permission

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
