### PR TITLE
Update list of maintainers for ease-plugin

### DIFF
--- a/permissions/plugin-ease-plugin.yml
+++ b/permissions/plugin-ease-plugin.yml
@@ -6,9 +6,7 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/ease-plugin"
 developers:
-  - "kwilson6744"
-  - "oleksiyp"
-  - "rfriedman"
   - "afinley"
   - "jrodriguez"
+  - "matt_pelaggi"
   - "puri"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/ease-plugin

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.