### PR TITLE
chore(Jenkinsfile) only use pollScm, every 5 minutes, on trusted.ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,7 @@ def props = [
         buildDiscarder(logRotator(numToKeepStr: '10'))
 ]
 
-def triggers = [
-        pollSCM('H/2 * * * *')
-]
+def triggers = []
 
 def dryRun = true
 
@@ -13,6 +11,9 @@ if (!env.CHANGE_ID && (!env.BRANCH_NAME || env.BRANCH_NAME == 'master')) {
         // only on trusted.ci, running on master is not a dry-run
         dryRun = false
 
+        // Check for code change every 5 minutes as there are no webhooks on trusted.ci.jenkins.io
+        // The goal is to run RPU as soon as possible for any code change
+        triggeres += pollSCM('H/5 * * * *')
         // Run every 3 hours
         triggers += cron('H H/3 * * *')
     } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ if (!env.CHANGE_ID && (!env.BRANCH_NAME || env.BRANCH_NAME == 'master')) {
 
         // Check for code change every 5 minutes as there are no webhooks on trusted.ci.jenkins.io
         // The goal is to run RPU as soon as possible for any code change
-        triggeres += pollSCM('H/5 * * * *')
+        triggers += pollSCM('H/5 * * * *')
         // Run every 3 hours
         triggers += cron('H H/3 * * *')
     } else {


### PR DESCRIPTION
Caught by @NotMyFault and mentionned in IRC, the pollSCM  should bnot be aenabled on ci.jenkins.io toi avoid build duplication.

On trusted, I changed from 2 to 5 minute to decrease the pressure on the controller as a preventive measure/