### PR TITLE
Rebrand 'maven-jellydoc-plugin'

### DIFF
--- a/permissions/component-jellydoc-annotations.yml
+++ b/permissions/component-jellydoc-annotations.yml
@@ -1,7 +1,7 @@
 ---
 name: "jellydoc-annotations"
-github: "jenkinsci/maven-jellydoc-plugin"
+github: "jenkinsci/jellydoc-maven-plugin"
 paths:
-  - "org/jvnet/maven-jellydoc-plugin/jellydoc-annotations"
+  - "io/jenkins/tools/maven/jellydoc-maven-plugin/jellydoc-annotations"
 developers:
   - "@core"

--- a/permissions/component-jellydoc-maven-plugin.yml
+++ b/permissions/component-jellydoc-maven-plugin.yml
@@ -1,0 +1,7 @@
+---
+name: "jellydoc-maven-plugin"
+github: "jenkinsci/jellydoc-maven-plugin"
+paths:
+  - "io/jenkins/tools/maven/jellydoc-maven-plugin/jellydoc-maven-plugin"
+developers:
+  - "@core"

--- a/permissions/component-maven-jellydoc-plugin.yml
+++ b/permissions/component-maven-jellydoc-plugin.yml
@@ -1,7 +1,0 @@
----
-name: "maven-jellydoc-plugin"
-github: "jenkinsci/maven-jellydoc-plugin"
-paths:
-  - "org/jvnet/maven-jellydoc-plugin/maven-jellydoc-plugin"
-developers:
-  - "@core"

--- a/permissions/component-taglib-xml-writer.yml
+++ b/permissions/component-taglib-xml-writer.yml
@@ -1,7 +1,7 @@
 ---
 name: "taglib-xml-writer"
-github: "jenkinsci/maven-jellydoc-plugin"
+github: "jenkinsci/jellydoc-maven-plugin"
 paths:
-  - "org/jvnet/maven-jellydoc-plugin/taglib-xml-writer"
+  - "io/jenkins/tools/maven/jellydoc-maven-plugin/taglib-xml-writer"
 developers:
   - "@core"

--- a/permissions/pom-jellydoc.yml
+++ b/permissions/pom-jellydoc.yml
@@ -1,7 +1,7 @@
 ---
 name: "jellydoc"
-github: "jenkinsci/maven-jellydoc-plugin"
+github: "jenkinsci/jellydoc-maven-plugin"
 paths:
-  - "org/jvnet/maven-jellydoc-plugin/jellydoc"
+  - "io/jenkins/tools/maven/jellydoc-maven-plugin/jellydoc"
 developers:
   - "@core"


### PR DESCRIPTION
Depends on https://github.com/jenkinsci/maven-jellydoc-plugin/pull/52