### PR TITLE
Remove 'core' from jmp components

### DIFF
--- a/permissions/component-jellydoc-annotations.yml
+++ b/permissions/component-jellydoc-annotations.yml
@@ -4,7 +4,5 @@ github: "jenkinsci/jellydoc-maven-plugin"
 paths:
   - "io/jenkins/tools/maven"
   - "io/jenkins/tools/maven/jellydoc-annotations"
-developers:
-  - "@core"
 cd:
   enabled: true

--- a/permissions/component-jellydoc-maven-plugin.yml
+++ b/permissions/component-jellydoc-maven-plugin.yml
@@ -4,7 +4,5 @@ github: "jenkinsci/jellydoc-maven-plugin"
 paths:
   - "io/jenkins/tools/maven"
   - "io/jenkins/tools/maven/jellydoc-maven-plugin"
-developers:
-  - "@core"
 cd:
   enabled: true

--- a/permissions/component-taglib-xml-writer.yml
+++ b/permissions/component-taglib-xml-writer.yml
@@ -4,7 +4,5 @@ github: "jenkinsci/jellydoc-maven-plugin"
 paths:
   - "io/jenkins/tools/maven"
   - "io/jenkins/tools/maven/taglib-xml-writer"
-developers:
-  - "@core"
 cd:
   enabled: true

--- a/permissions/pom-jellydoc.yml
+++ b/permissions/pom-jellydoc.yml
@@ -4,7 +4,5 @@ github: "jenkinsci/jellydoc-maven-plugin"
 paths:
   - "io/jenkins/tools/maven"
   - "io/jenkins/tools/maven/jellydoc"
-developers:
-  - "@core"
 cd:
   enabled: true


### PR DESCRIPTION
With having CD enabled, we can drop the permissions for manual releases for artifactory.