### PR TITLE
Removing myself (fcamblor) from nodejs & scm-sync-configuration plugins

### DIFF
--- a/permissions/plugin-nodejs.yml
+++ b/permissions/plugin-nodejs.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/nodejs"
 developers:
-  - "fcamblor"
   - "nfalco"
 security:
   contacts:

--- a/permissions/plugin-scm-sync-configuration.yml
+++ b/permissions/plugin-scm-sync-configuration.yml
@@ -8,6 +8,5 @@ paths:
   - "org/jenkins-ci/plugins/scm-sync-configuration"
   - "org/jvnet/hudson/plugins/scm-sync-configuration"
 developers:
-  - "fcamblor"
   - "rodrigc"
   - "palacgui"


### PR DESCRIPTION
Hello here 👋

I'm not a maintainer any longer (for years :-P) on `nodejs` and `scm-sync-configuration` plugins
=> this PR aims at removing me from these

Not sure if some other places need to be updated to reflect this change.

Thanks in advance :-)