### PR TITLE
Enable CD for `pipeline-cloudwatch-logs`

### DIFF
--- a/permissions/plugin-pipeline-cloudwatch-logs.yml
+++ b/permissions/plugin-pipeline-cloudwatch-logs.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '23949'  # pipeline-cloudwatch-logs-plugin
 paths:
   - "io/jenkins/plugins/pipeline-cloudwatch-logs"
+cd:
+  true
 developers:
   - "jglick"
   - "csanchez"

--- a/permissions/plugin-pipeline-cloudwatch-logs.yml
+++ b/permissions/plugin-pipeline-cloudwatch-logs.yml
@@ -6,7 +6,7 @@ issues:
 paths:
   - "io/jenkins/plugins/pipeline-cloudwatch-logs"
 cd:
-  true
+  enabled: true
 developers:
   - "jglick"
   - "csanchez"


### PR DESCRIPTION
# Link to GitHub repository

Just in case I want to release something like https://github.com/jenkinsci/pipeline-cloudwatch-logs-plugin/pull/64.

BTW https://github.com/jenkins-infra/helpdesk/issues/3669

### Link to the PR enabling CD in your plugin

(coming)

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
