### PR TITLE
Add maintainer to crowd2 plugin

### DIFF
--- a/permissions/plugin-crowd2.yml
+++ b/permissions/plugin-crowd2.yml
@@ -10,3 +10,4 @@ developers:
   - "mreinhardt"
   - "pingunaut"
   - "dumam"
+  - "akouznetchik"


### PR DESCRIPTION
Hello,
I would like to be add by invitation of the current maintainer.

https://github.com/jenkinsci/crowd2-plugin
https://github.com/jenkinsci/crowd2-plugin/pull/169#issuecomment-1643767142


@DuMaM 


```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
