### PR TITLE
Add markewaite to jenkins-infra-test plugin

### DIFF
--- a/permissions/plugin-jenkins-infra-test.yml
+++ b/permissions/plugin-jenkins-infra-test.yml
@@ -11,3 +11,4 @@ developers:
   - "timja"
   - "olblak"
   - "jglick"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite to jenkins-infra-test-plugin

Use the jenkins-infra-test plugin for Artifactory repository bandwidth reduction experiments instead of releasing many versions of one or more production plugins that I maintain.

https://github.com/jenkinsci/jenkins-infra-test-plugin says

> Anyone can request access to this plugin via repository-permission-updater if they're working in this area

# Link to GitHub repository

https://github.com/jenkinsci/jenkins-infra-test-plugin

### Mention other developers for approval

@dduportal and @smerle33 and @lemeurherve are involved in the bandwidth reduction project as well

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
