### PR TITLE
add upload permissions for redhat-codeready-dependency-analysis-plugin

### DIFF
--- a/permissions/plugin-redhat-codeready-dependency-analysis.yml
+++ b/permissions/plugin-redhat-codeready-dependency-analysis.yml
@@ -6,5 +6,6 @@ paths:
 developers:
   - "yzainee"
   - "vbelouso"
+  - "olavtar"
 issues:
   - github: *GH


### PR DESCRIPTION
# Link to GitHub repository
https://github.com/jenkinsci/redhat-codeready-dependency-analysis-plugin

<!-- Provide a link to the plugin or component repository you want to modify -->

# When modifying release permission

The plugin maintainer (yzainee) quit the company.
I need to continue working on support and releases for the plugin

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
