### PR TITLE
feat(cd): Setting up automated plugin release for the run-condition plugin

### DIFF
--- a/permissions/plugin-run-condition-plugin.yml
+++ b/permissions/plugin-run-condition-plugin.yml
@@ -1,0 +1,2 @@
+cd:
+  enabled: true


### PR DESCRIPTION
The plugin has already been incrementalified.
`pom.xml` contains `<version>${revision}${changelist}</version>` and the files `.mvn/extensions.xml` and `.mvn/maven.config` exist.

# Link to GitHub repository

https://github.com/jenkinsci/run-condition-plugin/blob/master/pom.xml

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:


## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/run-condition-plugin/commit/2590976a438f78d215214fd65358cce381736cb9

### CD checklist (for submitters)
- [X] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 

### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
