### PR TITLE
Adopt plugin: plugin-http_request.yml

### DIFF
--- a/permissions/plugin-http_request.yml
+++ b/permissions/plugin-http_request.yml
@@ -6,6 +6,4 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/http_request"
 developers:
-  - "janario"
-  - "markewaite"
-  - "oleg_nenashev"
+  - "sandi2382"

--- a/permissions/plugin-http_request.yml
+++ b/permissions/plugin-http_request.yml
@@ -6,4 +6,7 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/http_request"
 developers:
+  - "janario"
+  - "markewaite"
+  - "oleg_nenashev"
   - "sandi2382"


### PR DESCRIPTION
Adopt a plugin.

@oleg-nenashev @MarkEWaite I would like to adopt this plugin, since it's marked for adoption and I am actively using it in many pipelines.

### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
