### PR TITLE
Leave note about redhat-dependency-analytics

### DIFF
--- a/permissions/plugin-redhat-codeready-dependency-analysis.yml
+++ b/permissions/plugin-redhat-codeready-dependency-analysis.yml
@@ -3,9 +3,6 @@ name: "redhat-codeready-dependency-analysis"
 github: &GH "jenkinsci/redhat-codeready-dependency-analysis-plugin"
 paths:
   - "redhat/jenkins/plugins/redhat-codeready-dependency-analysis"
-developers:
-  - "yzainee"
-  - "vbelouso"
-  - "olavtar"
+developers: [] # Suspended in favor of redhat-dependency-analytics
 issues:
   - github: *GH


### PR DESCRIPTION
Leaves a note about the existing plugin in favor of https://github.com/jenkins-infra/repository-permissions-updater/issues/3503