### PR TITLE
add security contact for gitlab-branch-source

### DIFF
--- a/permissions/plugin-gitlab-branch-source.yml
+++ b/permissions/plugin-gitlab-branch-source.yml
@@ -14,3 +14,6 @@ developers:
   - "justinharringa"
   - "jetersen"
   - "surenpi"
+security:
+  contacts:
+    jira: "cloudbees_security_members"


### PR DESCRIPTION
# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->
https://github.com/jenkinsci/gitlab-branch-source-plugin

CloudBees would like to assist the `gitlab-branch-source` developers with regards to security maintenance.  Our team will be able to react on security issue reports, by definition time-sensitive. This way we can be notified on the event of a security report to help on the resolution, collaboration with the security team, synchronization, etc.

We have done this for a number of plugins:
https://github.com/search?q=repo%3Ajenkins-infra%2Frepository-permissions-updater+cloudbees_security_members&type=code

If anybody sees a problem with this, please let me know.

Thank you.

Repo implied: https://github.com/jenkinsci/gitlab-branch-source-plugin

CC @justinharringa  @LinuxSuRen @jeffpearce @jetersen @baymac for approval from an existing maintainer.
ping @Wadeck as the security officer


```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
