### PR TITLE
Revert "add security contact for gitlab-branch-source"

### DIFF
--- a/permissions/plugin-gitlab-branch-source.yml
+++ b/permissions/plugin-gitlab-branch-source.yml
@@ -14,6 +14,3 @@ developers:
   - "justinharringa"
   - "jetersen"
   - "surenpi"
-security:
-  contacts:
-    jira: "cloudbees_security_members"


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#3536

see https://github.com/jenkins-infra/repository-permissions-updater/pull/3536#issuecomment-1727961279