### PR TITLE
Request to add security contact for gitlab-branch-source

### DIFF
--- a/permissions/plugin-gitlab-branch-source.yml
+++ b/permissions/plugin-gitlab-branch-source.yml
@@ -14,3 +14,6 @@ developers:
   - "justinharringa"
   - "jetersen"
   - "surenpi"
+security:
+  contacts:
+    jira: "cloudbees_security_members"


### PR DESCRIPTION
re-request for gitlab-branch-source. See #3537 
# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->
https://github.com/jenkinsci/gitlab-branch-source-plugin

CloudBees would like to assist the gitlab-branch-source developers with regards to security maintenance. Our team will be able to react on security issue reports, by definition time-sensitive. This way we can be notified on the event of a security report to help on the resolution, collaboration with the security team, synchronization, etc.

We have done this for a number of plugins:
https://github.com/search?q=repo%3Ajenkins-infra%2Frepository-permissions-updater+cloudbees_security_members&type=code

If anybody sees a problem with this, please let me know.

Thank you.

Repo implied: https://github.com/jenkinsci/gitlab-branch-source-plugin

ping maintainers: @justinharringa @LinuxSuRen @jeffpearce @jetersen @baymac 
ping security officer: @Wadeck 

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
