### PR TITLE
feat(startup-trigger): Adds poddingue as a co-maintainer.

### DIFF
--- a/permissions/plugin-startup-trigger-plugin.yml
+++ b/permissions/plugin-startup-trigger-plugin.yml
@@ -9,3 +9,4 @@ paths:
 developers:
   - "gbois"
   - "ejpenney"
+  - "poddingue"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/startup-trigger-plugin

The plugin last release on GitHub was in 2021, and the last commits were also from two years ago.
Strangely, it's marked as released 5 years ago on [plugins.jenkins.io](https://plugins.jenkins.io/startup-trigger-plugin/).
The plugin is not marked as abandoned or up for adoption, but it has not moved in a while.
@ejpenney and @gboissinot are the main developers.

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)
- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [X] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [X] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
