### PR TITLE
adding judovana as comaintainer to tap plugin

### DIFF
--- a/permissions/plugin-tap.yml
+++ b/permissions/plugin-tap.yml
@@ -7,3 +7,4 @@ paths:
   - "org/tap4j/tap"
 developers:
   - "kinow"
+  - "judovana"


### PR DESCRIPTION
# Link to GitHub repository
https://github.com/jenkinsci/tap-plugin

# Unresponsive owner
Currently tap-plugin have only one maintainer, who is not exactly responsive:
 * The plug-in is terribly old and needs updates to work with properly with new Jenkins parent,which becomes necessary
 * my work on this plugin started year ago via https://github.com/jenkinsci/tap-plugin/pull/29, you can see that therw was sparse communication at begginig but it faded away.
 * you can also see in https://github.com/jenkinsci/tap-plugin/pulls  that this history repeats itself  from 2013...
 * I'm working on both fixing the pending cve (https://www.jenkins.io/security/advisory/2023-09-06/#SECURITY-3190) and on moving the plugin to newer jenkins parent. Seeing the communication rat, those two will not be doable.
