### PR TITLE
Updated permissions for plugin-groovy-events-listener.yml

### DIFF
--- a/permissions/plugin-groovy-events-listener-plugin-master.yml
+++ b/permissions/plugin-groovy-events-listener-plugin-master.yml
@@ -4,3 +4,4 @@ paths:
   - "org/jenkins-ci/plugins/groovy-events-listener-plugin-master"
 developers:
   - "jequals5"
+  - "raymondwu"

--- a/permissions/plugin-groovy-events-listener-plugin.yml
+++ b/permissions/plugin-groovy-events-listener-plugin.yml
@@ -8,3 +8,4 @@ paths:
   - "org/jenkins-ci/plugins/groovy-events-listener-plugin"
 developers:
   - "jequals5"
+  - "raymondwu"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/groovy-events-listener-plugin

Requesting permissions for this repository to release a new version that contains a fix for groovy compatibility issues that occur when using a newer LTS version of Jenkins. This plugin is currently up for adoption. FYI to previous maintainer @markyjackson-taulia 

Jenkins dev mailing list email: https://groups.google.com/g/jenkinsci-dev/c/AF6_PcMC1eM/m/c6cyQ6nBKgAJ

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [X] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
