### PR TITLE
Add markewaite as maintainer of ivy plugin

### DIFF
--- a/permissions/plugin-ivy.yml
+++ b/permissions/plugin-ivy.yml
@@ -7,4 +7,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/ivy"
   - "org/jvnet/hudson/plugins/ivy"
-developers: []
+developers:
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as maintainer of ivy plugin

I'm not a user of the plugin but I want to adopt the plugin so that I can merge https://github.com/jenkinsci/ivy-plugin/pull/87 and include Java 21 testing in the regular development of the plugin.

With no current maintainers, that pull request won't be merged.  I'd rather merge it and reduce the number of open pull requests.

That pull request replaces multiple other pull requests, including:

* https://github.com/jenkinsci/ivy-plugin/pull/86
* https://github.com/jenkinsci/ivy-plugin/pull/85
* https://github.com/jenkinsci/ivy-plugin/pull/83
* https://github.com/jenkinsci/ivy-plugin/pull/80

# Link to GitHub repository

https://github.com/jenkinsci/ivy-plugin

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
