### PR TITLE
Add markewaite as a mapdb-api-plugin maintainer

### DIFF
--- a/permissions/plugin-mapdb-api.yml
+++ b/permissions/plugin-mapdb-api.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/mapdb-api"
 developers:
   - "@cloudbees-developers"
+  - "markewaite"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
## Add markewaite as a mapdb-api-plugin maintainer

https://github.com/jenkinsci/mapdb-api-plugin/pull/26 is a pull request that I proposed a month ago to add Java 21 testing.  I'd like to merge that pull request and merge a few other dependency pull requests.

I don't plan to attempt to upgrade from mapdb API 1.0.8 (Jul 8, 2015) to mapdb API 3.0.10 (Aug 31, 2023).

# Link to GitHub repository

https://github.com/jenkinsci/mapdb-api-plugin

# When modifying release permission

Current maintainers of the repository include @alecharp , @aneveux , @car-roll , @mikecirioli , @olamy , @raul-arabaolaza , and @rsandell .

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

@mikecirioli and @teilo and @rsandell should all be valid maintainers of this plugin.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
