### PR TITLE
Block CD releases of jobConfigHistory as it has no maintainers

### DIFF
--- a/permissions/plugin-jobConfigHistory.yml
+++ b/permissions/plugin-jobConfigHistory.yml
@@ -6,5 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/jobConfigHistory"
 developers: []
-cd:
-  enabled: true
+#CD blocked for lack of maintainers
+#cd:
+#  enabled: true


### PR DESCRIPTION
Amends https://github.com/jenkins-infra/repository-permissions-updater/pull/3313

Probably a useful addition to the tool instead of fixing this in data, but that's for some other time.