### PR TITLE
Support exclusive CD mode, disallow CD releases if there are no maintainers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,7 @@ node('maven-11') {
         }
     } finally {
         stage ('Archive') {
-            archiveArtifacts 'permissions/*.yml'
-            archiveArtifacts 'json/*.json'
+            archiveArtifacts 'json/**'
             if (infra.isTrusted()) {
                 dir('json') {
                     publishReports ([ 'issues.index.json', 'maintainers.index.json' ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,8 @@ node('maven-11') {
         }
     } finally {
         stage ('Archive') {
-            archiveArtifacts 'json/**'
+            archiveArtifacts 'permissions/*.yml'
+            archiveArtifacts 'json/*.json'
             if (infra.isTrusted()) {
                 dir('json') {
                     publishReports ([ 'issues.index.json', 'maintainers.index.json' ])

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Be sure to check [which users have commit access](https://www.jenkins.io/doc/dev
 Additionally, the users listed in this repository still serve as the contacts for security issues and plugin/component governance questions.
 In particular, the Jenkins security team will _not_ make an effort to reach out to GitHub committers when maintainers (and security contacts, see below) are unresponsive before [announcing vulnerabilities without a fix](https://www.jenkins.io/security/plugins/#unresolved).
 
+It is also possible to enable JEP-229 CD exclusively, i.e., the listed users will not be able to create new releases, but remain contacts for security issues and plugin/component governance questions. 
+
+```yaml
+cd:
+  enabled: true
+  exclusive: true
+```
+
 
 Managing Security Process
 -------------------------

--- a/README.md
+++ b/README.md
@@ -98,11 +98,15 @@ cd:
   enabled: true
 ```
 
+For this to work, there needs to be at least one developers listed.
+If the list of developers is empty or missing entirely (e.g., after the last maintainer steps down), no new releases can be published through JEP-229 CD.
+
 **IMPORTANT:**
 When using JEP-229 CD, [every committer to your repository](https://www.jenkins.io/doc/developer/publishing/source-code-hosting/) can create new releases by merging pull requests.
 As a result, the list of maintainer accounts maintained in your plugin's YAML file is no longer the single reference on who can publish new releases.
 Be sure to check [which users have commit access](https://www.jenkins.io/doc/developer/publishing/source-code-hosting/) to your repository and remove any that are unexpected before enabling CD, as well as any unexpected [deploy keys](https://docs.github.com/en/developers/overview/managing-deploy-keys).
 Additionally, the users listed in this repository still serve as the contacts for security issues and plugin/component governance questions.
+For that reason, CD permissions are also only granted to components with at least one maintainer.
 In particular, the Jenkins security team will _not_ make an effort to reach out to GitHub committers when maintainers (and security contacts, see below) are unresponsive before [announcing vulnerabilities without a fix](https://www.jenkins.io/security/plugins/#unresolved).
 
 It is also possible to enable JEP-229 CD exclusively, i.e., the listed users will not be able to create new releases, but remain contacts for security issues and plugin/component governance questions. 

--- a/permissions/component-core-annotation-processors.yml
+++ b/permissions/component-core-annotation-processors.yml
@@ -3,6 +3,8 @@ name: "core-annotation-processors"
 github: "jenkinsci/core-annotation-processors"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/core-annotation-processors"
-developers: []
+developers:
+  - "@core"

--- a/permissions/component-jellydoc-annotations.yml
+++ b/permissions/component-jellydoc-annotations.yml
@@ -6,3 +6,6 @@ paths:
   - "io/jenkins/tools/maven/jellydoc-annotations"
 cd:
   enabled: true
+  exclusive: true
+developers:
+  - "@core"

--- a/permissions/component-jellydoc-maven-plugin.yml
+++ b/permissions/component-jellydoc-maven-plugin.yml
@@ -6,3 +6,6 @@ paths:
   - "io/jenkins/tools/maven/jellydoc-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
+developers:
+  - "@core"

--- a/permissions/component-license-maven-plugin.yml
+++ b/permissions/component-license-maven-plugin.yml
@@ -8,3 +8,6 @@ paths:
   - "io/jenkins/tools/maven/license-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
+developers:
+  - "@core"

--- a/permissions/component-stapler-maven-plugin.yml
+++ b/permissions/component-stapler-maven-plugin.yml
@@ -7,3 +7,6 @@ paths:
   - "io/jenkins/tools/maven/stapler-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
+developers:
+  - "@core"

--- a/permissions/component-stapler.yml
+++ b/permissions/component-stapler.yml
@@ -3,6 +3,8 @@ name: "stapler"
 github: "jenkinsci/stapler"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/kohsuke/stapler/stapler*"
-developers: []
+developers:
+  - "@core"

--- a/permissions/component-taglib-xml-writer.yml
+++ b/permissions/component-taglib-xml-writer.yml
@@ -6,3 +6,6 @@ paths:
   - "io/jenkins/tools/maven/taglib-xml-writer"
 cd:
   enabled: true
+  exclusive: true
+developers:
+  - "@core"

--- a/permissions/plugin-any-buildstep.yml
+++ b/permissions/plugin-any-buildstep.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/any-buildstep"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-anything-goes-formatter.yml
+++ b/permissions/plugin-anything-goes-formatter.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/anything-goes-formatter"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-backup-interrupt-plugin.yml
+++ b/permissions/plugin-backup-interrupt-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "jenkins/ci/plugins/backup/backup-interrupt-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-build-cause-run-condition.yml
+++ b/permissions/plugin-build-cause-run-condition.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/build-cause-run-condition"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-build-keeper-plugin.yml
+++ b/permissions/plugin-build-keeper-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/build-keeper-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-console-tail.yml
+++ b/permissions/plugin-console-tail.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/console-tail"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-copy-project-link.yml
+++ b/permissions/plugin-copy-project-link.yml
@@ -7,6 +7,5 @@ paths:
   - "hudson/plugins/copyProjectLink/copy-project-link"
   - "org/jenkins-ci/plugins/copy-project-link"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-create-fingerprint.yml
+++ b/permissions/plugin-create-fingerprint.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/create-fingerprint"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-downstream-buildview.yml
+++ b/permissions/plugin-downstream-buildview.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/downstream-buildview"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-downstream-ext.yml
+++ b/permissions/plugin-downstream-ext.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/downstream-ext"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-envfile.yml
+++ b/permissions/plugin-envfile.yml
@@ -7,6 +7,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/envfile"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-fail-the-build-plugin.yml
+++ b/permissions/plugin-fail-the-build-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/fail-the-build-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-favorite-view.yml
+++ b/permissions/plugin-favorite-view.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/favorite-view"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-groovy-remote.yml
+++ b/permissions/plugin-groovy-remote.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkinsci/plugins/groovy-remote"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-hsts-filter-plugin.yml
+++ b/permissions/plugin-hsts-filter-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/hsts-filter-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-jqs-monitoring.yml
+++ b/permissions/plugin-jqs-monitoring.yml
@@ -7,6 +7,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/jqs-monitoring"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-kpp-management-plugin.yml
+++ b/permissions/plugin-kpp-management-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "sic/software/kpp-management-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-nant.yml
+++ b/permissions/plugin-nant.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/nant"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-openid4java.yml
+++ b/permissions/plugin-openid4java.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/openid4java"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-progress-bar-column-plugin.yml
+++ b/permissions/plugin-progress-bar-column-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/progress-bar-column-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-project-stats-plugin.yml
+++ b/permissions/plugin-project-stats-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/project-stats-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-sbt.yml
+++ b/permissions/plugin-sbt.yml
@@ -7,6 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/sbt"
   - "org/jvnet/hudson/plugins/sbt"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-scoring-load-balancer.yml
+++ b/permissions/plugin-scoring-load-balancer.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "jp/ikedam/jenkins/plugins/scoring-load-balancer"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-slave-status.yml
+++ b/permissions/plugin-slave-status.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/slave-status"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-statusmonitor.yml
+++ b/permissions/plugin-statusmonitor.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/statusmonitor"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-svn-revert-plugin.yml
+++ b/permissions/plugin-svn-revert-plugin.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/svn-revert-plugin"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-svncompat14.yml
+++ b/permissions/plugin-svncompat14.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/svncompat14"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-template-workflows.yml
+++ b/permissions/plugin-template-workflows.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins/plugin/templateWorkflows/template-workflows"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-text-finder-run-condition.yml
+++ b/permissions/plugin-text-finder-run-condition.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/text-finder-run-condition"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/plugin-windows-exe-runner.yml
+++ b/permissions/plugin-windows-exe-runner.yml
@@ -6,6 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/windows-exe-runner"
 developers: []
-#CD blocked for lack of maintainers
-#cd:
-#  enabled: true
+cd:
+  enabled: true

--- a/permissions/pom-jellydoc.yml
+++ b/permissions/pom-jellydoc.yml
@@ -6,3 +6,6 @@ paths:
   - "io/jenkins/tools/maven/jellydoc"
 cd:
   enabled: true
+  exclusive: true
+developers:
+  - "@core"

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -234,6 +234,7 @@ class ArtifactoryPermissionsUpdater {
                 principals {
                     if (definition.developers.length == 0) {
                         users [:]
+                        groups [:]
                         if (definition.cd?.enabled) {
                             LOGGER.log(Level.INFO, "Skipping CD group definition for " + definition.name + " as there are no maintainers")
                         }

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -239,7 +239,7 @@ class ArtifactoryPermissionsUpdater {
                             LOGGER.log(Level.INFO, "Skipping CD group definition for " + definition.name + " as there are no maintainers")
                         }
                     } else {
-                        if (!definition.getCd().exclusive) {
+                        if (!definition.cd?.exclusive) {
                             users definition.developers.collectEntries { developer ->
                                 def existsInArtifactory = KnownUsers.existsInArtifactory(developer)
                                 def existsInJira = KnownUsers.existsInJira(developer) || JiraAPI.getInstance().isUserPresent(developer)

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -10,6 +10,7 @@ public class Definition {
 
     public static class CD {
         public boolean enabled;
+        public boolean exclusive;
     }
 
     public static class Security {


### PR DESCRIPTION
Amends/reverts https://github.com/jenkins-infra/repository-permissions-updater/pull/3313. Obsoletes https://github.com/jenkins-infra/repository-permissions-updater/pull/3615.

Two major new features:

1. Remove CD release permissions if there are no maintainers, obsoleting PRs like https://github.com/jenkins-infra/repository-permissions-updater/pull/3313 or https://github.com/jenkins-infra/repository-permissions-updater/pull/3615.
2. Add support for _exclusive CD_. In this mode, we keep track of maintainers for governance purposes, but they don't get upload permissions.

The latter is required to support the former, as some core(ish) components and libraries have CD but no maintainers defined, and would get their CD permissions revoked. We could add maintainers, but they would then get permission to upload releases. In those cases, I just added the `@core` group to the maintainers list, as these appear to be generally collectively maintained, rather than by specific individuals (even though it might boil down to that in practice).

## Testing

Based on comparing JSON output of PR builds, permissons etc. have no differences compared to `master` except it pre-empts #3615.

Happy to do a real run in the development involving Artifactory permissions if desired, but that's so annoying to set up I'd prefer to do that only if this otherwise looks reasonable. It's also easily reverted if things go wrong unexpectedly, IMO.

CC @NotMyFault @basil as most active recent contributors to the components I added `@core` for in case that does not reflect how you see their maintenance model.

`on-hold`: I'm going to be out for a few days and will be unable to amend if needed, so would prefer this not be merged until Nov 21.