### PR TITLE
Archive all JSON output files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,7 @@ node('maven-11') {
         }
     } finally {
         stage ('Archive') {
-            archiveArtifacts 'permissions/*.yml'
-            archiveArtifacts 'json/*.json'
+            archiveArtifacts 'json/**'
             if (infra.isTrusted()) {
                 dir('json') {
                     publishReports ([ 'issues.index.json', 'maintainers.index.json' ])


### PR DESCRIPTION
To get reference files for #3616. No intention to have this merged (but we could, IMO, archiving YAMLs is unnecessary).