### PR TITLE
Leave `promoted-builds`

### DIFF
--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -10,7 +10,6 @@ developers:
   - "batmat"
   - "carroll"
   - "dnozay"
-  - "jglick"
   - "oleg_nenashev"
   - "wolfs"
   - "dnusbaum"


### PR DESCRIPTION
# Link to GitHub repository

I just removed myself from https://github.com/orgs/jenkinsci/teams/promoted-builds-plugin-developers (since this plugin predates Pipeline) and so I guess this is the matching change. It would be really better if we managed teams as code…

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
