### PR TITLE
Let markewaite adopt git-parameter plugin

### DIFF
--- a/permissions/plugin-git-parameter.yml
+++ b/permissions/plugin-git-parameter.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/git-parameter"
   - "org/jenkins-ci/tools/git-parameter"
 developers:
+  - "markewaite"
   - "klimas7"
   - "ngiger"


### PR DESCRIPTION
## Let markewaite adopt git parameter plugin

I want to merge pull request https://github.com/jenkinsci/git-parameter-plugin/pull/117 to add testing of Java 21.

I use the plugin in my installation, so there is some motivation to maintain it.

I may do some additional modernization of the plugin.  I do not plan to make major changes.

# Link to GitHub repository

https://github.com/jenkinsci/git-parameter-plugin

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
