### PR TITLE
Adding permissions for amazon inspector scanning plugin

### DIFF
--- a/permissions/plugin-amazon-inspector-jenkins-plugin.yml
+++ b/permissions/plugin-amazon-inspector-jenkins-plugin.yml
@@ -1,0 +1,7 @@
+---
+name: "amazon-inspector-jenkins-plugin"
+github: "amazon-inspector-container-image-scanner-jenkins-plugin"
+paths:
+  - "com/amazon/inspector/jenkins"
+developers:
+  - "inspector-opensource"


### PR DESCRIPTION
# Link to GitHub repository

Note that the repository is currently private, I'm waiting to submit the PR until the repo becomes public soon.

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [X] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
