### PR TITLE
`cd.exclusive=true` for my plugins

### DIFF
--- a/permissions/plugin-build-token-root.yml
+++ b/permissions/plugin-build-token-root.yml
@@ -3,8 +3,9 @@ name: "build-token-root"
 github: "jenkinsci/build-token-root-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
-  - jira: '17622'  # build-token-root-plugin
+  - jira: '17622' # build-token-root-plugin
 paths:
   - "org/jenkins-ci/plugins/build-token-root"
 developers:

--- a/permissions/plugin-groovy.yml
+++ b/permissions/plugin-groovy.yml
@@ -2,9 +2,10 @@
 name: "groovy"
 github: "jenkinsci/groovy-plugin"
 issues:
-  - jira: '15549'  # groovy-plugin
+  - jira: '15549' # groovy-plugin
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/groovy"
   - "org/jvnet/hudson/plugins/groovy"

--- a/permissions/plugin-log-cli.yml
+++ b/permissions/plugin-log-cli.yml
@@ -3,8 +3,9 @@ name: "log-cli"
 github: "jenkinsci/log-cli-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
-  - jira: '23228'  # log-cli-plugin
+  - jira: '23228' # log-cli-plugin
 paths:
   - "org/jenkins-ci/plugins/log-cli"
 developers:

--- a/permissions/plugin-mock-slave.yml
+++ b/permissions/plugin-mock-slave.yml
@@ -3,8 +3,9 @@ name: "mock-slave"
 github: "jenkinsci/mock-slave-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
-  - jira: '17334'  # mock-slave-plugin
+  - jira: '17334' # mock-slave-plugin
 paths:
   - "org/jenkinci/plugins/mock-slave"
   - "org/jenkins-ci/plugins/mock-slave"


### PR DESCRIPTION
```bash
(for y in *.yml; do if [[ $(yq '(.developers|length)==1 and .developers[0]=="jglick" and .cd.enabled==true' $y) == true ]]; then echo $y; fi; done) | xargs -n 1 yq -i '.cd.exclusive=true'
```

https://github.com/jenkins-infra/repository-permissions-updater/pull/3616#pullrequestreview-1732324222
