### PR TITLE
Adopt `project-inheritance`

### DIFF
--- a/permissions/plugin-project-inheritance.yml
+++ b/permissions/plugin-project-inheritance.yml
@@ -3,4 +3,5 @@ name: "project-inheritance"
 paths:
   - "hudson/plugins/project-inheritance"
 developers:
+  - "basil"
   - "mhschroe"


### PR DESCRIPTION
See https://github.com/jenkins-infra/helpdesk/issues/3842. This plugin has a deployed POM that uses HTTP instead of HTTPS, so consumers (including `promoted-builds`) can't switch off the JCenter version (which JFrog has asked us to stop caching) until `project-inheritance` is republished with HTTPS.