### PR TITLE
Let markewaite adopt scp plugin to deprecate it

### DIFF
--- a/permissions/plugin-scp.yml
+++ b/permissions/plugin-scp.yml
@@ -6,4 +6,5 @@ issues:
   - github: *gh
 paths:
   - "org/jvnet/hudson/plugins/scp"
-developers: []
+developers:
+  - "markewaite"


### PR DESCRIPTION
## Let markewaite adopt scp plugin to deprecate it

The scp plugin was last released 13 years ago.  The last commit with any code change was almost 10 years ago.

There are two open security vulnerabilities.  The plain text credentials storage security vulnerability was published over 5 years ago.  The CSRF security vulnerability was published 18 months ago.

The last successful build on ci.jenkins.io was over 3 years ago.  The plugin does not build currently.

The `scp` command is available on all the operating systems that Jenkins supports.  Unix variants include `scp` with the OpenSSH commands.  Windows includes `scp` with their port of OpenSSH.

The installation counts of the plugin have decreased over the last 12 months.  Let's deprecate it as one more indicator for users that they should switch to more portable ways of performing scp.  Deprecation does not prevent users from installing it, but gives them another reason to consider removing the plugin from their installation.

Any one of those concerns would not be enough to justify deprecation of the plugin, but considering them all together, I think the plugin should be deprecated.

# Link to GitHub repository

https://github.com/jenkinsci/scp-plugin/tree/master

# Link to PR to be merged

* https://github.com/jenkinsci/scp-plugin/pull/23

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
