### PR TITLE
add cristiancotovanu as uipath-automation-package plugin developer

### DIFF
--- a/permissions/plugin-uipath-automation-package.yml
+++ b/permissions/plugin-uipath-automation-package.yml
@@ -9,3 +9,4 @@ paths:
 developers:
   - "ganeshborle"
   - "al3xanndru"
+  - "cristiancotovanu"


### PR DESCRIPTION
Adding `cristiancotovanu` as a developer of `uipath-automation-package` in order to have upload permissions to https://repo.jenkins-ci.org/ui/packages/gav:%2F%2Forg.jenkins-ci.plugins:uipath-automation-package .