### PR TITLE
Leave `matrix-project`

### DIFF
--- a/permissions/plugin-matrix-project.yml
+++ b/permissions/plugin-matrix-project.yml
@@ -9,7 +9,6 @@ cd:
   enabled: true
 developers:
   - "amuniz"
-  - "jglick"
   - "oleg_nenashev"
   - "olivergondza"
   - "batmat"


### PR DESCRIPTION
# Link to GitHub repository

I should be removed from https://github.com/orgs/jenkinsci/teams/matrix-project-plugin-developers as in #3620 as I do not wish to receive notifications for things like https://github.com/jenkinsci/matrix-project-plugin/pull/182.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
