### PR TITLE
Rename GH repository of ssh-agents-plugin

### DIFF
--- a/permissions/plugin-ssh-slaves.yml
+++ b/permissions/plugin-ssh-slaves.yml
@@ -1,6 +1,6 @@
 ---
 name: "ssh-slaves"
-github: "jenkinsci/ssh-slaves-plugin"
+github: "jenkinsci/ssh-agents-plugin"
 issues:
   - jira: '15578'  # ssh-slaves-plugin
 paths:


### PR DESCRIPTION
The GH repository is now named ssh-agents-plugin