### PR TITLE
updating deprecated group ID for groovy-all

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: monthly
     ignore:
       # Managed dependencies for jira-api
-      - dependency-name: "org.codehaus.groovy:groovy-all"
+      - dependency-name: "org.apache.groovy:groovy-all"
       - dependency-name: "com.atlassian.plugins:atlassian-plugins-core"
       - dependency-name: "ch.qos.logback:logback-classic"
       - dependency-name: "org.springframework:spring-beans"

--- a/permissions/component-groovy-all.yml
+++ b/permissions/component-groovy-all.yml
@@ -1,7 +1,7 @@
 ---
 name: "groovy-all"
 paths:
-  - "org/codehaus/groovy/groovy-all"
+  - "org/apache/groovy/groovy-all"
   - "org/jenkins-ci/groovy/groovy-all"
 developers:
   - "daspilker"

--- a/permissions/component-groovy-all.yml
+++ b/permissions/component-groovy-all.yml
@@ -1,7 +1,7 @@
 ---
 name: "groovy-all"
 paths:
-  - "org/apache/groovy/groovy-all"
+  - "org/codehaus/groovy/groovy-all"
   - "org/jenkins-ci/groovy/groovy-all"
 developers:
   - "daspilker"

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
                 </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
-                        <version>2.5.22</version>
+                        <version>4.0.16</version>
                         <scope>runtime</scope>
                         <type>pom</type>
                     </dependency>
@@ -147,9 +147,9 @@
             <version>1.33</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.5.22</version>
+            <version>4.0.16</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
                     <dependency>
                         <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
-                        <version>4.0.16</version>
+                        <version>4.0.11</version>
                         <scope>runtime</scope>
                         <type>pom</type>
                     </dependency>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>4.0.16</version>
+            <version>4.0.11</version>
             <type>pom</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
groovy-all artifact is moved to org.apache.groovy, hence made needed file changes