### PR TITLE
add upload permissions for plugin-redhat-dependency-analytics

### DIFF
--- a/permissions/plugin-redhat-dependency-analytics.yml
+++ b/permissions/plugin-redhat-dependency-analytics.yml
@@ -6,6 +6,7 @@ paths:
 developers:
 - "olavtar"
 - "vbelouso"
+- "zgrinber"
 issues:
   - jira: 29221
 cd:


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/redhat-dependency-analytics-plugin

# When modifying release permission
I Need to be an extra authorized maintainer of the plugin in order to do release new versions of this plugin from time to time, when the other maintainers are on vacations or holidays.

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
