### PR TITLE
Add markewaite as a gitee plugin maintainer

### DIFF
--- a/permissions/plugin-gitee.yml
+++ b/permissions/plugin-gitee.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/gitee"
 developers:
   - "yashin"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as a gitee plugin maintainer

I want to merge and release

* https://github.com/jenkinsci/gitee-plugin/pull/4 

The Jackson 2 API plugin 2.16.1 has removed two constants that were deprecated long ago. The removal of those constants will break compilation of the gitee plugin and are expected to break runtime of the gitee plugin as well.

The targeted pull request upgrades from Jackson 2 API 2.15.2 to Jackson 2 API 2.16.1 so that the API deletion of the constants is visible at compile time.  A Jenkins controller with the Jackson 2 API plugin 2.16.1-373.ve709c6871598 installed may already make this change visible to a gitee plugin at run time without any change to the plugin source code.

https://github.com/FasterXML/jackson-databind/pull/4162 removed the constants from the Jackson 2 API after a long period of deprecation.  The changes were released in Jackson databind 2.16.0 and first included in the matching Jenkins API plugin 2.16.1-373.ve709c6871598.

A similar change was needed in the GitLab plugin and is implemented in https://github.com/jenkinsci/gitlab-plugin/pull/1606.

If @yashin-luo merges that pull request and releases the gitee plugin, then I don't need to be added as a maintainer.  I've started this pull request just in case @yashin-luo is not available and I need to wait two weeks for plugin adoption.

https://issues.jenkins.io/browse/JENKINS-72482 is the bug report.

# Link to GitHub repository

https://github.com/jenkinsci/gitee-plugin

# When modifying release permission

@yashin-luo if you're willing to have my help with the plugin, you can post a comment to this pull request that you approve of this change.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
