### PR TITLE
upgrading dependencies to remove vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.10</version>
+            <version>1.4.14</version>
         </dependency>
         <dependency>
             <groupId>org.kocakosm</groupId>


### PR DESCRIPTION
snakeyaml version 1.33 and logback-classic version 1.2.10 have vulnerabilities, hence upgrading them to latest safe version.