### PR TITLE
Adaopt abandoned PR monitor plugin

### DIFF
--- a/permissions/plugin-pull-request-monitoring.yml
+++ b/permissions/plugin-pull-request-monitoring.yml
@@ -7,3 +7,5 @@ developers:
   - "simonsymhoven"
 issues:
   - github: *GH
+cd:
+  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/pull-request-monitoring-plugin/pull/279

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
