### PR TITLE
Enable CD for misra-compliance-report-generator

### DIFF
--- a/permissions/plugin-misra-compliance-report-generator.yml
+++ b/permissions/plugin-misra-compliance-report-generator.yml
@@ -7,3 +7,5 @@ paths:
   - "io/jenkins/plugins/misra-compliance-report-generator"
 developers:
   - "oyvindlr"
+cd:
+  enabled: true


### PR DESCRIPTION
Enabled continuous delivery for plugin misra-compliance-report-generator

[# Link to GitHub repository](https://github.com/jenkinsci/misra-compliance-report-generator-plugin)



### Link to the PR enabling CD in your plugin

[Pull request enabling CD](https://github.com/jenkinsci/misra-compliance-report-generator-plugin/pull/10)

```[tasklist]
### CD checklist (for submitters)
- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
