### PR TITLE
Add upload permissions for asm-api-plugin (#3732)

### DIFF
--- a/permissions/plugin-android-emulator.yml
+++ b/permissions/plugin-android-emulator.yml
@@ -12,3 +12,4 @@ developers:
   - "orrc"
   - "nfalco"
   - "poddingue"
+  - "mPokornyETM"

--- a/permissions/plugin-anything-goes-formatter.yml
+++ b/permissions/plugin-anything-goes-formatter.yml
@@ -5,6 +5,7 @@ issues:
   - jira: '17568'  # anything-goes-formatter-plugin
 paths:
   - "org/jenkins-ci/plugins/anything-goes-formatter"
-developers: []
+developers:
+  - "mPokornyETM"
 cd:
   enabled: true

--- a/permissions/plugin-artifactdeployer.yml
+++ b/permissions/plugin-artifactdeployer.yml
@@ -9,3 +9,4 @@ developers:
   - "alecharp"
   - "gbois"
   - "seanturner83"
+  - "mPokornyETM"

--- a/permissions/plugin-badge.yml
+++ b/permissions/plugin-badge.yml
@@ -8,3 +8,4 @@ paths:
   - "org/jenkins-ci/plugins/badge"
 developers:
   - "bakito"
+  - "mPokornyETM"

--- a/permissions/plugin-categorized-view.yml
+++ b/permissions/plugin-categorized-view.yml
@@ -9,3 +9,4 @@ paths:
 developers:
   - "taksan"
   - "takeuchi"
+  - "mPokornyETM"

--- a/permissions/plugin-chucknorris.yml
+++ b/permissions/plugin-chucknorris.yml
@@ -8,5 +8,6 @@ paths:
 developers:
   - "batmat"
   - "oleg_nenashev"
+  - "mPokornyETM"
 cd:
   enabled: true

--- a/permissions/plugin-collapsing-console-sections.yml
+++ b/permissions/plugin-collapsing-console-sections.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/collapsing-console-sections"
 developers:
   - "oleg_nenashev"
+  - "mPokornyETM"

--- a/permissions/plugin-copyartifact.yml
+++ b/permissions/plugin-copyartifact.yml
@@ -11,6 +11,7 @@ developers:
   - "wolfs"
   - "markewaite"
   - "allancth"
+  - "mPokornyETM"
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-custom-tools-plugin.yml
+++ b/permissions/plugin-custom-tools-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers:
   - "oleg_nenashev"
   - "rhernandezm"
+  - "mPokornyETM"

--- a/permissions/plugin-favorite-view.yml
+++ b/permissions/plugin-favorite-view.yml
@@ -5,6 +5,7 @@ issues:
   - jira: '17569'  # favorite-view-plugin
 paths:
   - "org/jenkins-ci/plugins/favorite-view"
-developers: []
+developers:
+  - "mPokornyETM"
 cd:
   enabled: true

--- a/permissions/plugin-hudson-wsclean-plugin.yml
+++ b/permissions/plugin-hudson-wsclean-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers:
   - "aheritier"
   - "pjdarton"
+  - "mPokornyETM"

--- a/permissions/plugin-jqs-monitoring.yml
+++ b/permissions/plugin-jqs-monitoring.yml
@@ -6,6 +6,7 @@ issues:
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/jqs-monitoring"
-developers: []
+developers:
+  - "mPokornyETM"
 cd:
   enabled: true

--- a/permissions/plugin-ownership.yml
+++ b/permissions/plugin-ownership.yml
@@ -8,3 +8,4 @@ paths:
   - "com/synopsys/jenkinsci/ownership"
 developers:
   - "oleg_nenashev"
+  - "mPokornyETM"

--- a/permissions/plugin-perfpublisher.yml
+++ b/permissions/plugin-perfpublisher.yml
@@ -9,3 +9,4 @@ paths:
 developers:
   - "eschava"
   - "langers2k"
+  - "mPokornyETM"

--- a/permissions/plugin-port-allocator.yml
+++ b/permissions/plugin-port-allocator.yml
@@ -8,3 +8,4 @@ paths:
   - "org/jvnet/hudson/plugins/port-allocator"
 developers:
   - "markewaite"
+  - "mPokornyETM"

--- a/permissions/plugin-pull-request-monitoring.yml
+++ b/permissions/plugin-pull-request-monitoring.yml
@@ -5,6 +5,7 @@ paths:
   - "io/jenkins/plugins/pull-request-monitoring"
 developers:
   - "simonsymhoven"
+  - "mPokornyETM"
 issues:
   - github: *GH
 cd:

--- a/permissions/plugin-test-results-analyzer.yml
+++ b/permissions/plugin-test-results-analyzer.yml
@@ -8,3 +8,4 @@ paths:
 developers:
   - "menonvarun"
   - "poddingue"
+  - "mPokornyETM"

--- a/permissions/plugin-tool-labels-plugin.yml
+++ b/permissions/plugin-tool-labels-plugin.yml
@@ -4,3 +4,4 @@ paths:
   - "org/jenkins-ci/plugins/tool-labels-plugin"
 developers:
   - "kazssym"
+  - "mPokornyETM"


### PR DESCRIPTION
# Link to GitHub repository

It might looks crazy, but I have a motivation:

+ As we use many of this plugins, and we shall use only maintained plugins, I decide to adopt (add me as maintainer) "few" of them.
+ Few of them are fine for my ideas with my current plugins

I will do my best, to update the plugins (one by one / step by step) to current state of the art:

+ security first
+ do all the steps to modernize plugins
+ update UI elements, that jenkins looks consitently
+ update missed documentation
+ ...

I know it is a lot of work, but 2024 started only few days ago ;-), So why not.

Here the links (alfa numeric sorted)
All are checked and works

https://github.com/jenkinsci/android-emulator-plugin
https://github.com/jenkinsci/anything-goes-formatter-plugin
https://github.com/jenkinsci/artifactdeployer-plugin
https://github.com/jenkinsci/badge-plugin
https://github.com/jenkinsci/categorized-view-plugin
https://github.com/jenkinsci/collapsing-console-sections-plugin
https://github.com/jenkinsci/copyartifact-plugin
https://github.com/jenkinsci/custom-tools-plugin
https://github.com/jenkinsci/favorite-view-plugin
https://github.com/jenkinsci/wsclean-plugin
https://github.com/jenkinsci/jqs-monitoring-plugin
https://github.com/jenkinsci/ownership-plugin
https://github.com/jenkinsci/perfpublisher-plugin
https://github.com/jenkinsci/port-allocator-plugin
https://github.com/jenkinsci/pull-request-monitoring-plugin
https://github.com/jenkinsci/test-results-analyzer-plugin


and especially this one, because I love the idea
https://github.com/jenkinsci/chucknorris-plugin

The plugin permissions/plugin-tool-labels-plugin.yml shall be set to deprecated or better remove from list,
because the links to repo and forum in this docu https://plugins.jenkins.io/tool-labels-plugin/
are also broken. But I will try to contact origin developer and we will see. I like the plugin idea as well.

