### PR TITLE
Remove marcomiller as a plugin maintainer

### DIFF
--- a/permissions/plugin-description-setter.yml
+++ b/permissions/plugin-description-setter.yml
@@ -7,5 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/description-setter"
   - "org/jvnet/hudson/plugins/description-setter"
 developers:
-  - "marcomiller"
   - "michael1010"

--- a/permissions/plugin-ldapemail.yml
+++ b/permissions/plugin-ldapemail.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '15556'  # ldapemail-plugin
 paths:
   - "com/mtvi/plateng/hudson/ldapemail"
-developers:
-  - "marcomiller"
+developers: []


### PR DESCRIPTION
## Remove marcomiller as a plugin maintainer

https://github.com/jenkinsci/description-setter-plugin/pull/26#issuecomment-1887337876 is a comment from Marco Miller that indicates he's been inactive on there types of projects for many years.  Rather than including Marco as a maintainer, let's acknowledge that he's no longer maintaining those plugins.

@marco-miller, I'd appreciate a "+1" or another comment indicating that you approve this change.

# Link to GitHub repository

The GitHub repositories are:

* https://github.com/jenkinsci/description-setter-plugin
* https://github.com/jenkinsci/ldapemail-plugin

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
