### PR TITLE
Updated yaml for adoption w/ juradodiego

### DIFF
--- a/permissions/plugin-selenium.yml
+++ b/permissions/plugin-selenium.yml
@@ -9,3 +9,4 @@ paths:
 developers:
   - "darkrift"
   - "mobrockers"
+  - "juradodiego"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/selenium-plugin/tree/master

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- juradodiego

This is needed in order to cut releases of the plugin or component.