### PR TITLE
chore: publish `github.index.json` to `reports.jenkins.io`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ node('maven-11') {
             archiveArtifacts 'json/*.json'
             if (infra.isTrusted()) {
                 dir('json') {
-                    publishReports ([ 'issues.index.json', 'maintainers.index.json' ])
+                    publishReports ([ 'issues.index.json', 'maintainers.index.json', 'github.index.json' ])
                 }
             }
         }


### PR DESCRIPTION
Goal: ensure that we have a trusted publication of this file to use on another services