### PR TITLE
Adopt openid plugin to make again working on jenkins latest version

### DIFF
--- a/permissions/plugin-openid.yml
+++ b/permissions/plugin-openid.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '15793'  # openid-plugin
 paths:
   - "org/jenkins-ci/plugins/openid"
-developers: []
+developers:
+  - "panicking"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/openid-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- panicking