### PR TITLE
Add slf4j-simple to suppress SLF4J warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.11</version>
+                <version>2.0.12</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -213,12 +213,17 @@
             <artifactId>maven-model</artifactId>
             <version>3.9.6</version>
         </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>5.10.1</version>
-        <scope>test</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.12</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Closes #3029 

Adding slf4j-simple to the classpath will make the warning disappear.
https://www.slf4j.org/manual.html#hello_world

### Before:
```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/home/runner/work/repository-permissions-updater/repository-permissions-updater/target/repository-permissions-updater-1.0-SNAPSHOT-bin/logback-classic-1.2.[10](https://github.com/jenkins-infra/repository-permissions-updater/actions/runs/3711745757/jobs/6292512472#step:6:11).jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```

### After:
![Screenshot 2024-02-28 101546](https://github.com/jenkins-infra/repository-permissions-updater/assets/107404972/852908d4-5013-4410-962f-0e385018400d)
