### PR TITLE
Preparing plugin adoption

### DIFF
--- a/permissions/plugin-delivery-pipeline-plugin.yml
+++ b/permissions/plugin-delivery-pipeline-plugin.yml
@@ -10,3 +10,5 @@ developers:
   - "mrfatstrat"
   - "patbos"
   - "tommysdk"
+  - "rzanner"
+  - "gsoffredini"

--- a/permissions/plugin-delivery-pipeline-plugin.yml
+++ b/permissions/plugin-delivery-pipeline-plugin.yml
@@ -6,9 +6,5 @@ issues:
 paths:
   - "se/diabol/jenkins/pipeline/delivery-pipeline-plugin"
 developers:
-  - "diabol_jenkins"
-  - "mrfatstrat"
-  - "patbos"
-  - "tommysdk"
   - "rzanner"
   - "gsoffredini"


### PR DESCRIPTION
# Link to GitHub repository

As discussed with @NotMyFault, we consider this plugin abandoned by the current maintainers @diabol_jenkins, @mrfatstrat, @patbos and @tommysdk.
I want to adopt and integrate it into the jenkinsci github repository, so this would be https://github.com/jenkinsci/delivery-pipeline-plugin, I guess.

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@rzanner`
- `@gianluca-soffredini`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```
