### PR TITLE
plugin-openid: Enable CD Permissions

### DIFF
--- a/permissions/plugin-openid.yml
+++ b/permissions/plugin-openid.yml
@@ -7,3 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/openid"
 developers:
   - "panicking"
+cd:
+  enabled: true


### PR DESCRIPTION
Prepare plugin delivery using jenkins CI. Follow the documentation found at:

https://www.jenkins.io/doc/developer/publishing/releasing-cd/

# Link to GitHub repository

https://github.com/jenkinsci/openid-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- panicking

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/). panicking
team to approve this request.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/openid-plugin/commit/a02cb1347d4e0d3aa749f04d00e104144808f61a

