### PR TITLE
Set homepage as plugins.jenkins.io for new plugins and update defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.318</version>
+            <version>1.319</version>
         </dependency>
         <dependency>
             <groupId>org.javatuples</groupId>

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -251,6 +251,7 @@ public class Hoster {
     private static void setupRepository(GHRepository r, boolean useGHIssues) throws IOException {
         r.enableIssueTracker(useGHIssues);
         r.enableWiki(false);
+        r.setHomepage("https://plugins.jenkins.io/" + r.getName().replace("-plugin", "") + "/");
     }
 
     /**

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -252,7 +252,6 @@ public class Hoster {
         r.enableIssueTracker(useGHIssues);
         r.enableWiki(false);
         r.setHomepage("https://plugins.jenkins.io/" + r.getName().replace("-plugin", "") + "/");
-        r.setEmailServiceHook("jenkinsci-commits@googlegroups.com");
         if (!r.getDefaultBranch().equals("main")) {
             r.setDefaultBranch("main");
         }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -253,7 +253,9 @@ public class Hoster {
         r.enableWiki(false);
         r.setHomepage("https://plugins.jenkins.io/" + r.getName().replace("-plugin", "") + "/");
         r.setEmailServiceHook("jenkinsci-commits@googlegroups.com");
-        r.setDefaultBranch("main");
+        if (!r.getDefaultBranch().equals("main")) {
+            r.setDefaultBranch("main");
+        }
     }
 
     /**

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -252,6 +252,8 @@ public class Hoster {
         r.enableIssueTracker(useGHIssues);
         r.enableWiki(false);
         r.setHomepage("https://plugins.jenkins.io/" + r.getName().replace("-plugin", "") + "/");
+        r.setEmailServiceHook("jenkinsci-commits@googlegroups.com");
+        r.setDefaultBranch("main");
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/repository-permissions-updater/issues/3573 
