### PR TITLE
Disable new Jira issues for Theme Manager plugin

### DIFF
--- a/permissions/plugin-theme-manager.yml
+++ b/permissions/plugin-theme-manager.yml
@@ -4,6 +4,7 @@ github: &gh "jenkinsci/theme-manager-plugin"
 issues:
   - github: *gh
   - jira: '27322'  # theme-manager-plugin
+    report: false
 paths:
   - "io/jenkins/plugins/theme-manager"
 developers:


### PR DESCRIPTION
The component is archived.

Without this, the plugin continues to offer to report issues in Jira.

@timja 

(Also, if more components were archived, please likewise fix these for the respective plugins.)