### PR TITLE
Adding vpasupathi as a publisher

### DIFF
--- a/permissions/plugin-fortify-on-demand-uploader.yml
+++ b/permissions/plugin-fortify-on-demand-uploader.yml
@@ -11,3 +11,4 @@ developers:
   - "c0d3m0nky"
   - "aishkotni"
   - "ciuppinho"
+  - "vpasupathi"


### PR DESCRIPTION
I am the lead dev on this plugin and need to give vpasupathi rights to publish to refactory

[fortify-on-demand-uploader plugin](https://github.com/jenkinsci/fortify-on-demand-uploader-plugin)

List the GitHub usernames of the users who should have commit permissions below:
- @pvivekdev

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```
