### PR TITLE
Restore hostability

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -249,9 +249,6 @@ public class Hoster {
         r.enableIssueTracker(useGHIssues);
         r.enableWiki(false);
         r.setHomepage("https://plugins.jenkins.io/" + r.getName().replace("-plugin", "") + "/");
-        if (!r.getDefaultBranch().equals("main")) {
-            r.setDefaultBranch("main");
-        }
     }
 
     /**


### PR DESCRIPTION
![Screenshot 2024-03-15 at 07 23 14](https://github.com/jenkins-infra/repository-permissions-updater/assets/13383509/2f4b09b9-df44-4227-93e8-55b4386b96ee)

Looks like this doesn't work here. Removing to restore functionality.