### PR TITLE
Update libvirt GH repository name

### DIFF
--- a/permissions/plugin-libvirt-slave.yml
+++ b/permissions/plugin-libvirt-slave.yml
@@ -1,6 +1,6 @@
 ---
 name: "libvirt-slave"
-github: "jenkinsci/libvirt-slave-plugin"
+github: "jenkinsci/libvirt-agent-plugin"
 issues:
   - jira: '15985'  # libvirt-slave-plugin
 paths:


### PR DESCRIPTION
The repository is now available under the -agent- name.