### PR TITLE
Remove `basil` from `jaxb`

### DIFF
--- a/permissions/plugin-jaxb.yml
+++ b/permissions/plugin-jaxb.yml
@@ -7,7 +7,6 @@ issues:
 paths:
   - "io/jenkins/plugins/jaxb"
 developers:
-  - "basil"
   - "kohsuke"
   - "oleg_nenashev"
   - "batmat"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/jaxb-plugin

# When modifying release permission

The changes I wanted to release have long been released, so my work here is done.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
