### PR TITLE
Remove `basil` from `commons-httpclient3-api`

### DIFF
--- a/permissions/plugin-commons-httpclient3-api.yml
+++ b/permissions/plugin-commons-httpclient3-api.yml
@@ -3,7 +3,6 @@ name: "commons-httpclient3-api"
 github: &GH "jenkinsci/commons-httpclient3-api-plugin"
 paths:
 - "io/jenkins/plugins/commons-httpclient3-api"
-developers:
-- "basil"
+developers: []
 issues:
   - jira: 29120


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/commons-httpclient3-api-plugin

# When modifying release permission

This plugin has been deprecated since its inception, and its only consumers are deprecated plugins. I do not wish to continue maintaining it.

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
