### PR TITLE
Remove `basil` from `jnr-posix-api`

### DIFF
--- a/permissions/plugin-jnr-posix-api.yml
+++ b/permissions/plugin-jnr-posix-api.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '23822'  # jnr-posix-api-plugin
 paths:
   - "io/jenkins/plugins/jnr-posix-api"
-developers:
-  - "basil"
+developers: []


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/jnr-posix-api-plugin

# When modifying release permission

While in the Java 8 days this was used to support the PAM Authentication plugin, it is no longer used by anything of significance in the Java 11+ days, and I do not wish to continue maintaining it.

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
