### PR TITLE
Remove `component-jnr-ffi.yml`

### DIFF
--- a/permissions/component-jnr-ffi.yml
+++ b/permissions/component-jnr-ffi.yml
@@ -1,5 +1,0 @@
----
-name: "jnr-ffi"
-paths:
-  - "com/github/jnr/jnr-ffi"
-developers: []


### PR DESCRIPTION
# Link to GitHub repository

Unknown

# When modifying release permission

Not sure about the history of this component, but we certainly don't ship a fork of it today.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
