### PR TITLE
Enable exclusive CD for Remoting

### DIFF
--- a/permissions/component-remoting.yml
+++ b/permissions/component-remoting.yml
@@ -5,10 +5,7 @@ paths:
   - "org/jenkins-ci/main/remoting"
   - "org/jvnet/hudson/main/remoting"
 developers:
-  - "kohsuke"
-  - "oleg_nenashev"
-  - "jthompson"
-  - "releasebot"
   - "@core"
 cd:
   enabled: true
+  exclusive: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/remoting

# When modifying release permission

Cleaning up these components by enabling exclusive CD and removing inactive maintainers.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
