### PR TITLE
Enable exclusive CD for `jersey2-api`

### DIFF
--- a/permissions/plugin-jersey2-api.yml
+++ b/permissions/plugin-jersey2-api.yml
@@ -4,7 +4,6 @@ github: &GH "jenkinsci/jersey2-api-plugin"
 paths:
   - "io/jenkins/plugins/jersey2-api"
 developers:
-  - "basil"
   - "@cloudbees-developers"
 security:
   contacts:
@@ -13,3 +12,4 @@ issues:
   - jira: 28832
 cd:
   enabled: true
+  exclusive: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/jersey2-api-plugin

# When modifying release permission

Cleaning up these components by enabling exclusive CD and removing inactive maintainers.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
