### PR TITLE
Reassign `process-utils` to core

### DIFF
--- a/permissions/component-process-utils.yml
+++ b/permissions/component-process-utils.yml
@@ -4,6 +4,4 @@ github: "jenkinsci/lib-process-utils"
 paths:
   - "org/jenkins-ci/process-utils"
 developers:
-  - "basil"
-  - "kohsuke"
-  - "olivergondza"
+  - "@core"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/lib-process-utils

# When modifying release permission

Consistent of assignment for other core components.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
