### PR TITLE
Remove `component-jclouds-shaded.yml` and `pom-jclouds-jenkins-parent.yml`

### DIFF
--- a/permissions/component-jclouds-shaded.yml
+++ b/permissions/component-jclouds-shaded.yml
@@ -1,8 +1,0 @@
----
-name: "jclouds-shaded"
-github: "jenkinsci/jclouds-plugin"
-paths:
-  - "org/jenkins-ci/plugins/jclouds-shaded"
-developers:
-  - "mikefero"
-  - "felfert"

--- a/permissions/pom-jclouds-jenkins-parent.yml
+++ b/permissions/pom-jclouds-jenkins-parent.yml
@@ -1,8 +1,0 @@
----
-name: "jclouds-jenkins-parent"
-github: "jenkinsci/jclouds-plugin"
-paths:
-  - "org/jenkins-ci/plugins/jclouds-jenkins-parent"
-developers:
-  - "mikefero"
-  - "felfert"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/jclouds-plugin

# When modifying release permission

Obsolete as of https://github.com/jenkinsci/jclouds-plugin/pull/151.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
