### PR TITLE
Consistent core release permissions

### DIFF
--- a/permissions/component-cli.yml
+++ b/permissions/component-cli.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/cli"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/component-jenkins-bom.yml
+++ b/permissions/component-jenkins-bom.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-bom"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/component-jenkins-core.yml
+++ b/permissions/component-jenkins-core.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-core"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/component-jenkins-war.yml
+++ b/permissions/component-jenkins-war.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-war"
 developers:
-  - "kohsuke"
   - "releasebot"

--- a/permissions/pom-jenkins-parent.yml
+++ b/permissions/pom-jenkins-parent.yml
@@ -4,5 +4,4 @@ github: "jenkinsci/jenkins"
 paths:
   - "org/jenkins-ci/main/jenkins-parent"
 developers:
-  - "kohsuke"
   - "releasebot"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/jenkins

# When modifying release permission

Permissions are inconsistent: newer modules have just `releasebot`, but older ones have both Kohsuke and `releasebot`. In practice, Kohsuke has not performed a release in many years, and would not be able to today due to the newer modules. So make the older modules consistent with the newer modules by removing Kohsuke.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
