### PR TITLE
Remove `component-dom4j.yml`

### DIFF
--- a/permissions/component-dom4j.yml
+++ b/permissions/component-dom4j.yml
@@ -1,8 +1,0 @@
----
-name: "dom4j"
-github: "jenkinsci/dom4j"
-paths:
-  - "org/jenkins-ci/dom4j/dom4j"
-  - "org/jvnet/hudson/dom4j/dom4j"
-developers:
-  - "kohsuke"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/dom4j

# When modifying release permission

As noted in https://github.com/jenkins-infra/helpdesk/issues/4010 this repository seems to be unused. We no longer maintain a fork of dom4j.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
