### PR TITLE
Update `remoting-test-client` release permissions

### DIFF
--- a/permissions/component-remoting-test-client.yml
+++ b/permissions/component-remoting-test-client.yml
@@ -1,9 +1,7 @@
 ---
 name: "remoting-test-client"
+github: "jenkinsci/remoting-test-client"
 paths:
   - "org/jenkins-ci/remoting-test-client"
 developers:
-  - "kohsuke"
-  - "oleg_nenashev"
-  - "jthompson"
-  - "releasebot"
+  - "@core"


### PR DESCRIPTION
# Link to GitHub repository

I extracted the Remoting test client to https://github.com/jenkinsci/remoting-test-client

# When modifying release permission

Making the permissions consistent with https://github.com/jenkinsci/remoting by allowing all core maintainers to cut releass

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
