### PR TITLE
Enable exclusive CD for BOM

### DIFF
--- a/permissions/pom-bom.yml
+++ b/permissions/pom-bom.yml
@@ -3,6 +3,7 @@ name: "bom"
 github: "jenkinsci/bom"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "io/jenkins/tools/bom/bom-*"
 developers:


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/bom

# When modifying release permission

BOM releases are not done manually anymore.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
