### PR TITLE
Remove `basil` from `email-ext`

### DIFF
--- a/permissions/plugin-email-ext.yml
+++ b/permissions/plugin-email-ext.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/email-ext"
   - "org/jvnet/hudson/plugins/email-ext"
 developers:
-  - "basil"
   - "slide_o_mix"
 security:
   contacts:


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/email-ext-plugin

# When modifying release permission

I no longer have the time to maintain this plugin.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
