### PR TITLE
Enable exclusive CD for plugins with more than 100,000 installations whose last release used CD

### DIFF
--- a/permissions/component-groovy-cps-dgm-builder.yml
+++ b/permissions/component-groovy-cps-dgm-builder.yml
@@ -20,3 +20,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/component-groovy-cps.yml
+++ b/permissions/component-groovy-cps.yml
@@ -20,3 +20,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/component-lib-durable-task.yml
+++ b/permissions/component-lib-durable-task.yml
@@ -14,3 +14,4 @@ developers:
   - "mramonleon"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-ant.yml
+++ b/permissions/plugin-ant.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/ant"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "armfergom"
   - "jglick"

--- a/permissions/plugin-antisamy-markup-formatter.yml
+++ b/permissions/plugin-antisamy-markup-formatter.yml
@@ -18,3 +18,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-apache-httpcomponents-client-4-api.yml
+++ b/permissions/plugin-apache-httpcomponents-client-4-api.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/apache-httpcomponents-client-4-api"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "oleg_nenashev"
   - "dnusbaum"

--- a/permissions/plugin-authentication-tokens.yml
+++ b/permissions/plugin-authentication-tokens.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/authentication-tokens"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "alecharp"
   - "batmat"

--- a/permissions/plugin-branch-api.yml
+++ b/permissions/plugin-branch-api.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/branch-api"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "recena"

--- a/permissions/plugin-caffeine-api.yml
+++ b/permissions/plugin-caffeine-api.yml
@@ -15,6 +15,7 @@ issues:
   - jira: 28622
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-cloudbees-folder.yml
+++ b/permissions/plugin-cloudbees-folder.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/cloudbees-folder"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "kohsuke"

--- a/permissions/plugin-command-launcher.yml
+++ b/permissions/plugin-command-launcher.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/command-launcher"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "oleg_nenashev"

--- a/permissions/plugin-commons-lang3-api.yml
+++ b/permissions/plugin-commons-lang3-api.yml
@@ -10,6 +10,7 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-commons-text-api.yml
+++ b/permissions/plugin-commons-text-api.yml
@@ -9,6 +9,7 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-config-file-provider.yml
+++ b/permissions/plugin-config-file-provider.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/config-file-provider"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "imod"
   - "egutierrez"

--- a/permissions/plugin-credentials-binding.yml
+++ b/permissions/plugin-credentials-binding.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/credentials-binding"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "jvz"

--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/credentials"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "kohsuke"

--- a/permissions/plugin-display-url-api.yml
+++ b/permissions/plugin-display-url-api.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-docker-commons.yml
+++ b/permissions/plugin-docker-commons.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/docker-commons"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "kohsuke"

--- a/permissions/plugin-docker-workflow.yml
+++ b/permissions/plugin-docker-workflow.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/docker-workflow"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "oleg_nenashev"

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -24,3 +24,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-git-server.yml
+++ b/permissions/plugin-git-server.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/git-server"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "kohsuke"

--- a/permissions/plugin-github-api.yml
+++ b/permissions/plugin-github-api.yml
@@ -3,6 +3,7 @@ name: "github-api"
 github: "jenkinsci/github-api-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '17496'  # github-api-plugin
 paths:

--- a/permissions/plugin-github-branch-source.yml
+++ b/permissions/plugin-github-branch-source.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-instance-identity.yml
+++ b/permissions/plugin-instance-identity.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/modules/instance-identity"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "@core"
 security:

--- a/permissions/plugin-ionicons-api.yml
+++ b/permissions/plugin-ionicons-api.yml
@@ -9,6 +9,7 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-jackson2-api.yml
+++ b/permissions/plugin-jackson2-api.yml
@@ -3,6 +3,7 @@ name: "jackson2-api"
 github: "jenkinsci/jackson2-api-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '23528'  # jackson2-api-plugin
 paths:

--- a/permissions/plugin-javadoc.yml
+++ b/permissions/plugin-javadoc.yml
@@ -17,3 +17,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jdk-tool.yml
+++ b/permissions/plugin-jdk-tool.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/jdk-tool"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "dnusbaum"
   - "jglick"

--- a/permissions/plugin-jjwt-api.yml
+++ b/permissions/plugin-jjwt-api.yml
@@ -3,6 +3,7 @@ name: "jjwt-api"
 github: &gh "jenkinsci/jjwt-api-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *gh
 paths:

--- a/permissions/plugin-jsch.yml
+++ b/permissions/plugin-jsch.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/jsch"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "zregvart"
   - "ljader"

--- a/permissions/plugin-junit.yml
+++ b/permissions/plugin-junit.yml
@@ -24,3 +24,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-ldap.yml
+++ b/permissions/plugin-ldap.yml
@@ -15,3 +15,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-lockable-resources.yml
+++ b/permissions/plugin-lockable-resources.yml
@@ -3,6 +3,7 @@ name: "lockable-resources"
 github: &gh "jenkinsci/lockable-resources-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *gh
 paths:

--- a/permissions/plugin-mailer.yml
+++ b/permissions/plugin-mailer.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/mailer"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "andresrc"
   - "jglick"

--- a/permissions/plugin-matrix-project.yml
+++ b/permissions/plugin-matrix-project.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/matrix-project"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "amuniz"
   - "oleg_nenashev"

--- a/permissions/plugin-okhttp-api.yml
+++ b/permissions/plugin-okhttp-api.yml
@@ -3,6 +3,7 @@ name: "okhttp-api"
 github: "jenkinsci/okhttp-api-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '27251'  # okhttp-api-plugin
 paths:

--- a/permissions/plugin-pipeline-build-step.yml
+++ b/permissions/plugin-pipeline-build-step.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/pipeline-build-step"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "abayer"

--- a/permissions/plugin-pipeline-github-lib.yml
+++ b/permissions/plugin-pipeline-github-lib.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/pipeline-github-lib"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "abayer"

--- a/permissions/plugin-pipeline-graph-analysis.yml
+++ b/permissions/plugin-pipeline-graph-analysis.yml
@@ -19,3 +19,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-groovy-lib.yml
+++ b/permissions/plugin-pipeline-groovy-lib.yml
@@ -5,6 +5,7 @@ paths:
   - "io/jenkins/plugins/pipeline-groovy-lib"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "dnusbaum"

--- a/permissions/plugin-pipeline-input-step.yml
+++ b/permissions/plugin-pipeline-input-step.yml
@@ -20,3 +20,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-milestone-step.yml
+++ b/permissions/plugin-pipeline-milestone-step.yml
@@ -19,3 +19,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -18,3 +18,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-model-extensions.yml
+++ b/permissions/plugin-pipeline-model-extensions.yml
@@ -18,3 +18,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-stage-step.yml
+++ b/permissions/plugin-pipeline-stage-step.yml
@@ -19,3 +19,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-stage-tags-metadata.yml
+++ b/permissions/plugin-pipeline-stage-tags-metadata.yml
@@ -18,3 +18,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-plain-credentials.yml
+++ b/permissions/plugin-plain-credentials.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/plain-credentials"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "@security"

--- a/permissions/plugin-scm-api.yml
+++ b/permissions/plugin-scm-api.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/scm-api"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "recena"

--- a/permissions/plugin-script-security.yml
+++ b/permissions/plugin-script-security.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/script-security"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "kohsuke"

--- a/permissions/plugin-snakeyaml-api.yml
+++ b/permissions/plugin-snakeyaml-api.yml
@@ -16,3 +16,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-ssh-credentials.yml
+++ b/permissions/plugin-ssh-credentials.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/ssh-credentials"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "oleg_nenashev"

--- a/permissions/plugin-ssh-slaves.yml
+++ b/permissions/plugin-ssh-slaves.yml
@@ -16,3 +16,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-sshd.yml
+++ b/permissions/plugin-sshd.yml
@@ -15,3 +15,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-structs.yml
+++ b/permissions/plugin-structs.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-token-macro.yml
+++ b/permissions/plugin-token-macro.yml
@@ -10,3 +10,4 @@ developers:
   - "slide_o_mix"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-trilead-api.yml
+++ b/permissions/plugin-trilead-api.yml
@@ -13,3 +13,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-variant.yml
+++ b/permissions/plugin-variant.yml
@@ -12,6 +12,7 @@ developers:
   - "jetersen"
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-workflow-aggregator.yml
+++ b/permissions/plugin-workflow-aggregator.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/workflow/workflow-aggregator"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "kohsuke"

--- a/permissions/plugin-workflow-api.yml
+++ b/permissions/plugin-workflow-api.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-basic-steps.yml
+++ b/permissions/plugin-workflow-basic-steps.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-cps-global-lib.yml
+++ b/permissions/plugin-workflow-cps-global-lib.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-cps.yml
+++ b/permissions/plugin-workflow-cps.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-durable-task-step.yml
+++ b/permissions/plugin-workflow-durable-task-step.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-job.yml
+++ b/permissions/plugin-workflow-job.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-multibranch.yml
+++ b/permissions/plugin-workflow-multibranch.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-scm-step.yml
+++ b/permissions/plugin-workflow-scm-step.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-step-api.yml
+++ b/permissions/plugin-workflow-step-api.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-workflow-support.yml
+++ b/permissions/plugin-workflow-support.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/pom-pipeline-model-parent.yml
+++ b/permissions/pom-pipeline-model-parent.yml
@@ -12,3 +12,4 @@ developers:
   - "carroll"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/pom-workflow-cps-parent.yml
+++ b/permissions/pom-workflow-cps-parent.yml
@@ -20,3 +20,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true


### PR DESCRIPTION
# Link to GitHub repository

Too many to list.

# When modifying release permission

Seems like as good a slice as any of low-hanging fruit. I can't see a good reason for a plugin that many installations to _not_ have exclusive CD enabled. If, for some reason, someone objects, it can always be corrected later. If this PR is notionally intractable, the PR can simply be closed. :man_shrugging:

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
