### PR TITLE
Switch People View plugin to Jira for issues

### DIFF
--- a/permissions/plugin-people-view.yml
+++ b/permissions/plugin-people-view.yml
@@ -6,4 +6,4 @@ paths:
 developers:
 - "danielbeck"
 issues:
-  - github: *GH
+  - jira: '29420' # people-view-plugin


### PR DESCRIPTION
Given the feature was essentially detached from core, this will make it easier to migrate issues filed against core.