### PR TITLE
Let markewaite adopt pegdown plugin to deprecate it

### DIFF
--- a/permissions/plugin-pegdown-formatter.yml
+++ b/permissions/plugin-pegdown-formatter.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '15899'  # pegdown-formatter-plugin
 paths:
   - "org/jenkins-ci/plugins/pegdown-formatter"
-developers: []
+developers:
+  - "markewaite"


### PR DESCRIPTION
## Let markewaite adopt pegdown plugin to deprecate it

The [Pegdown formatter plugin](https://plugins.jenkins.io/pegdown-formatter/) provides markdown formatting for Jenkins job descriptions and other text fields.  However, it was last released 12 years ago, has no active maintainer, and has an [open security vulnerability](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-142) .  The pegdown library is [deprecated](https://github.com/sirthias/pegdown).

The [markdown formatter plugin](https://plugins.jenkins.io/markdown-formatter/) provides markdown formatting for Jenkins job descriptions and other text fields.  It is a reasonable replacement for the Pegdown formatter plugin, though without the many configuration options available from the Pegdown formatter plugin.  The markdown formatter plugin is actively maintained and used by Mark Waite.  It has over 800 installations and the number of instalations is growing.

Let's deprecate the Pegdown formatter and include a link to the markdown formatter in the deprecation so that users can continue using markdown formatting and have a plugin without a security vulnerability.

Add @MarkEWaite as a maintainer so that he can merge:

* https://github.com/jenkinsci/pegdown-formatter-plugin/pull/2

Once I have merge permission, I'll apply the "deprecated" label to the Pegdown formatter plugin repository and request that it be archived.

https://www.jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/ is the instructions that I'm following for the deprecation process.

# Link to GitHub repository

* https://github.com/jenkinsci/pegdown-formatter-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- @markewaite

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request. (no current maintainers of the plugin to mention)
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
