### PR TITLE
Enable exclusive CD for any plugin whose last release was done with CD

### DIFF
--- a/permissions/component-configuration-as-code-parent.yml
+++ b/permissions/component-configuration-as-code-parent.yml
@@ -10,6 +10,7 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "jetersen"

--- a/permissions/component-configuration-as-code-test-harness.yml
+++ b/permissions/component-configuration-as-code-test-harness.yml
@@ -10,6 +10,7 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "jetersen"

--- a/permissions/component-docker-fixtures.yml
+++ b/permissions/component-docker-fixtures.yml
@@ -5,6 +5,7 @@ paths:
   - "org/jenkins-ci/test/docker-fixtures"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "andresrc"
   - "jglick"

--- a/permissions/component-pipeline-maven-api.yml
+++ b/permissions/component-pipeline-maven-api.yml
@@ -3,6 +3,7 @@ name: "pipeline-maven-api"
 github: "jenkinsci/pipeline-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/pipeline-maven-api"
 developers:

--- a/permissions/component-pipeline-maven-database.yml
+++ b/permissions/component-pipeline-maven-database.yml
@@ -3,6 +3,7 @@ name: "pipeline-maven-database"
 github: "jenkinsci/pipeline-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/pipeline-maven-database"
 developers:

--- a/permissions/component-pipeline-maven-spy.yml
+++ b/permissions/component-pipeline-maven-spy.yml
@@ -3,6 +3,7 @@ name: "pipeline-maven-spy"
 github: "jenkinsci/pipeline-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/pipeline-maven-spy"
 developers:

--- a/permissions/component-plugins-compat-tester.yml
+++ b/permissions/component-plugins-compat-tester.yml
@@ -5,6 +5,7 @@ paths:
   - "org/jenkins-ci/tests/plugins-compat-tester-cli"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "kwhetstone"
   - "jglick"

--- a/permissions/component-trilead-ssh2.yml
+++ b/permissions/component-trilead-ssh2.yml
@@ -10,3 +10,4 @@ developers:
   - "ifernandezcalvo"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-JiraTestResultReporter.yml
+++ b/permissions/plugin-JiraTestResultReporter.yml
@@ -11,3 +11,4 @@ developers:
   - "imontero"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-NegotiateSSO.yml
+++ b/permissions/plugin-NegotiateSSO.yml
@@ -9,3 +9,4 @@ developers:
   - "farmgeek4life"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-TestFairy.yml
+++ b/permissions/plugin-TestFairy.yml
@@ -11,3 +11,4 @@ developers:
   - "yan123"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-accelq-ci-connect.yml
+++ b/permissions/plugin-accelq-ci-connect.yml
@@ -3,6 +3,7 @@ name: "accelq-ci-connect"
 github: &GH "jenkinsci/accelq-ci-connect-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "com/aq/accelq-ci-connect"
 developers:

--- a/permissions/plugin-add-changes-to-build-changelog.yml
+++ b/permissions/plugin-add-changes-to-build-changelog.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-additional-metrics.yml
+++ b/permissions/plugin-additional-metrics.yml
@@ -9,3 +9,4 @@ developers:
   - "chadiem"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-adobe-cloud-manager.yml
+++ b/permissions/plugin-adobe-cloud-manager.yml
@@ -7,6 +7,7 @@ paths:
   - "io/jenkins/plugins/adobe-cloud-manager"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "ahmedmusallam"
   - "stopp"

--- a/permissions/plugin-agent-maintenance.yml
+++ b/permissions/plugin-agent-maintenance.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 28837
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-amazon-ecr.yml
+++ b/permissions/plugin-amazon-ecr.yml
@@ -11,3 +11,4 @@ developers:
   - "tgr"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-amazon-inspector-image-scanner.yml
+++ b/permissions/plugin-amazon-inspector-image-scanner.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-android-emulator.yml
+++ b/permissions/plugin-android-emulator.yml
@@ -8,6 +8,7 @@ paths:
   - "org/jvnet/hudson/plugins/android-emulator"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "orrc"
   - "nfalco"

--- a/permissions/plugin-antexec.yml
+++ b/permissions/plugin-antexec.yml
@@ -9,3 +9,4 @@ developers:
   - "svasek"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-any-buildstep.yml
+++ b/permissions/plugin-any-buildstep.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-anything-goes-formatter.yml
+++ b/permissions/plugin-anything-goes-formatter.yml
@@ -9,3 +9,4 @@ developers:
   - "mPokornyETM"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-aribot.yml
+++ b/permissions/plugin-aribot.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 29129
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-artifact-manager-s3.yml
+++ b/permissions/plugin-artifact-manager-s3.yml
@@ -7,6 +7,7 @@ paths:
   - "io/jenkins/plugins/artifact-manager-s3"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "csanchez"

--- a/permissions/plugin-artifactz.yml
+++ b/permissions/plugin-artifactz.yml
@@ -3,6 +3,7 @@ name: "artifactz"
 github: &GH "jenkinsci/artifactz-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "io/jenkins/plugins/artifactz"
 developers:

--- a/permissions/plugin-asm-api.yml
+++ b/permissions/plugin-asm-api.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-audit-trail.yml
+++ b/permissions/plugin-audit-trail.yml
@@ -12,3 +12,4 @@ developers:
   - "pierrebtz"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-autify.yml
+++ b/permissions/plugin-autify.yml
@@ -5,6 +5,7 @@ paths:
   - "io/jenkins/plugins/autify"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "riywo"
   - "nate_autify"

--- a/permissions/plugin-aws-global-configuration.yml
+++ b/permissions/plugin-aws-global-configuration.yml
@@ -7,6 +7,7 @@ paths:
   - "io/jenkins/plugins/aws-global-configuration"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "csanchez"

--- a/permissions/plugin-aws-secrets-manager-credentials-provider.yml
+++ b/permissions/plugin-aws-secrets-manager-credentials-provider.yml
@@ -11,3 +11,4 @@ developers:
   - "chriskilding"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-aws-secrets-manager-secret-source.yml
+++ b/permissions/plugin-aws-secrets-manager-secret-source.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-azure-ad.yml
+++ b/permissions/plugin-azure-ad.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/azure-ad"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "zooopx"
   - "timja"

--- a/permissions/plugin-azure-artifact-manager.yml
+++ b/permissions/plugin-azure-artifact-manager.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/azure-artifact-manager"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "zooopx"
   - "timja"

--- a/permissions/plugin-azure-container-agents.yml
+++ b/permissions/plugin-azure-container-agents.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/azure-container-agents"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "zooopx"
   - "timja"

--- a/permissions/plugin-azure-cosmosdb.yml
+++ b/permissions/plugin-azure-cosmosdb.yml
@@ -5,6 +5,7 @@ paths:
   - "io/jenkins/plugins/azure-cosmosdb"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "timja"
 issues:

--- a/permissions/plugin-azure-credentials.yml
+++ b/permissions/plugin-azure-credentials.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/azure-credentials"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "zooopx"
   - "timja"

--- a/permissions/plugin-azure-keyvault.yml
+++ b/permissions/plugin-azure-keyvault.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/azure-keyvault"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "timja"

--- a/permissions/plugin-azure-kubernetes-credentials.yml
+++ b/permissions/plugin-azure-kubernetes-credentials.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 29322
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-azure-sdk.yml
+++ b/permissions/plugin-azure-sdk.yml
@@ -3,6 +3,7 @@ name: "azure-sdk"
 github: &GH "jenkinsci/azure-sdk-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "io/jenkins/plugins/azure-sdk"
 developers:

--- a/permissions/plugin-azure-vm-agents.yml
+++ b/permissions/plugin-azure-vm-agents.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/azure-vm-agents"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "zooopx"
   - "timja"

--- a/permissions/plugin-backup-interrupt-plugin.yml
+++ b/permissions/plugin-backup-interrupt-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-batch-task.yml
+++ b/permissions/plugin-batch-task.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/batch-task"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "lacostej"

--- a/permissions/plugin-beer.yml
+++ b/permissions/plugin-beer.yml
@@ -9,3 +9,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-benchmark.yml
+++ b/permissions/plugin-benchmark.yml
@@ -10,3 +10,4 @@ developers:
   - "damercie"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-bevigil-ci.yml
+++ b/permissions/plugin-bevigil-ci.yml
@@ -3,6 +3,7 @@ name: "bevigil-ci"
 github: &GH "jenkinsci/bevigil-ci-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
 - "io/jenkins/plugins/bevigil-ci"
 developers:

--- a/permissions/plugin-bigpanda-jenkins.yml
+++ b/permissions/plugin-bigpanda-jenkins.yml
@@ -14,3 +14,4 @@ developers:
   - "lukej7"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-bitbucket-pullrequests-filter.yml
+++ b/permissions/plugin-bitbucket-pullrequests-filter.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-bitbucket-scm-filter-aged-refs.yml
+++ b/permissions/plugin-bitbucket-scm-filter-aged-refs.yml
@@ -9,3 +9,4 @@ developers:
   - "tgr"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-bitbucket.yml
+++ b/permissions/plugin-bitbucket.yml
@@ -9,3 +9,4 @@ developers:
   - "tzach_solomon"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-bmc-cfa.yml
+++ b/permissions/plugin-bmc-cfa.yml
@@ -3,6 +3,7 @@ name: "bmc-cfa"
 github: &GH "jenkinsci/bmc-cfa-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "com/bmc/ims/bmc-cfa"
 developers:

--- a/permissions/plugin-bmc-change-manager-imstm.yml
+++ b/permissions/plugin-bmc-change-manager-imstm.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-build-alias-setter.yml
+++ b/permissions/plugin-build-alias-setter.yml
@@ -9,3 +9,4 @@ developers:
   - "olivergondza"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-build-discarder.yml
+++ b/permissions/plugin-build-discarder.yml
@@ -11,3 +11,4 @@ developers:
   - "akessoj71"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-build-history-metrics-plugin.yml
+++ b/permissions/plugin-build-history-metrics-plugin.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-build-keeper-plugin.yml
+++ b/permissions/plugin-build-keeper-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-build-monitor-plugin.yml
+++ b/permissions/plugin-build-monitor-plugin.yml
@@ -11,3 +11,4 @@ developers:
   - "dcendents"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-build-time-blame.yml
+++ b/permissions/plugin-build-time-blame.yml
@@ -9,3 +9,4 @@ developers:
   - "ltegtmeier"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-build-with-parameters.yml
+++ b/permissions/plugin-build-with-parameters.yml
@@ -9,3 +9,4 @@ developers:
   - "sugonyak_ivan"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-buildtriggerbadge.yml
+++ b/permissions/plugin-buildtriggerbadge.yml
@@ -9,3 +9,4 @@ developers:
   - "batmat"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-casdoor-auth.yml
+++ b/permissions/plugin-casdoor-auth.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-catlight.yml
+++ b/permissions/plugin-catlight.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-cctray-xml.yml
+++ b/permissions/plugin-cctray-xml.yml
@@ -9,3 +9,4 @@ developers:
   - "rahulsom"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-cdevents.yml
+++ b/permissions/plugin-cdevents.yml
@@ -3,6 +3,7 @@ name: "cdevents"
 github: &GH "jenkinsci/cdevents-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
 - "io/jenkins/plugins/cdevents"
 developers:

--- a/permissions/plugin-checkmarx-ast-scanner.yml
+++ b/permissions/plugin-checkmarx-ast-scanner.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-chucknorris.yml
+++ b/permissions/plugin-chucknorris.yml
@@ -11,3 +11,4 @@ developers:
   - "mPokornyETM"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-claim.yml
+++ b/permissions/plugin-claim.yml
@@ -10,3 +10,4 @@ developers:
   - "greybird"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-clearcase-ucm-plugin.yml
+++ b/permissions/plugin-clearcase-ucm-plugin.yml
@@ -11,3 +11,4 @@ developers:
   - "praqma"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-clif-performance-testing.yml
+++ b/permissions/plugin-clif-performance-testing.yml
@@ -9,3 +9,4 @@ developers:
   - "dillense"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-cloudbees-bitbucket-branch-source.yml
+++ b/permissions/plugin-cloudbees-bitbucket-branch-source.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-cloudbees-disk-usage-simple.yml
+++ b/permissions/plugin-cloudbees-disk-usage-simple.yml
@@ -12,3 +12,4 @@ developers:
   - "pierrebtz"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-cloudbees-feature-management.yml
+++ b/permissions/plugin-cloudbees-feature-management.yml
@@ -3,6 +3,7 @@ name: "cloudbees-feature-management"
 github: &GH "jenkinsci/cloudbees-feature-management-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "io/jenkins/plugins/cloudbees-feature-management"
 developers:

--- a/permissions/plugin-cloudbees-jenkins-advisor.yml
+++ b/permissions/plugin-cloudbees-jenkins-advisor.yml
@@ -16,3 +16,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-clover.yml
+++ b/permissions/plugin-clover.yml
@@ -10,3 +10,4 @@ developers:
   - "marekparf"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-codebuild-cloud.yml
+++ b/permissions/plugin-codebuild-cloud.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-codethreat-scanner.yml
+++ b/permissions/plugin-codethreat-scanner.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-compact-columns.yml
+++ b/permissions/plugin-compact-columns.yml
@@ -9,3 +9,4 @@ developers:
   - "tgr"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-compress-artifacts.yml
+++ b/permissions/plugin-compress-artifacts.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/compress-artifacts"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "olivergondza"

--- a/permissions/plugin-compressed_files_viewer.yml
+++ b/permissions/plugin-compressed_files_viewer.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-configuration-as-code.yml
+++ b/permissions/plugin-configuration-as-code.yml
@@ -14,6 +14,7 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *GH
   - jira: 23170  # configuration-as-code-plugin

--- a/permissions/plugin-configurationslicing.yml
+++ b/permissions/plugin-configurationslicing.yml
@@ -3,6 +3,7 @@ name: "configurationslicing"
 github: &gh "jenkinsci/configurationslicing-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '15597'  # configurationslicing-plugin
   - github: *gh

--- a/permissions/plugin-conflict-aware-ondemand-strategy.yml
+++ b/permissions/plugin-conflict-aware-ondemand-strategy.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 28838
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-console-tail.yml
+++ b/permissions/plugin-console-tail.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-container-image-link.yml
+++ b/permissions/plugin-container-image-link.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 28921
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-copy-project-link.yml
+++ b/permissions/plugin-copy-project-link.yml
@@ -9,3 +9,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-copyartifact.yml
+++ b/permissions/plugin-copyartifact.yml
@@ -17,3 +17,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-create-fingerprint.yml
+++ b/permissions/plugin-create-fingerprint.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-custom-build-properties.yml
+++ b/permissions/plugin-custom-build-properties.yml
@@ -9,3 +9,4 @@ developers:
   - "shasait"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-custom-markup-formatter.yml
+++ b/permissions/plugin-custom-markup-formatter.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-customizable-header.yml
+++ b/permissions/plugin-customizable-header.yml
@@ -9,4 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
-  
+  exclusive: true

--- a/permissions/plugin-customize-build-now.yml
+++ b/permissions/plugin-customize-build-now.yml
@@ -11,3 +11,4 @@ developers:
   - "mawinter69"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-cyberchief-security-scanner.yml
+++ b/permissions/plugin-cyberchief-security-scanner.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 29321
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-dagshub-branch-source.yml
+++ b/permissions/plugin-dagshub-branch-source.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-dashboard-view.yml
+++ b/permissions/plugin-dashboard-view.yml
@@ -15,3 +15,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-database-h2.yml
+++ b/permissions/plugin-database-h2.yml
@@ -9,3 +9,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-database-postgresql.yml
+++ b/permissions/plugin-database-postgresql.yml
@@ -9,3 +9,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-database.yml
+++ b/permissions/plugin-database.yml
@@ -10,3 +10,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-deepcrawl-test.yml
+++ b/permissions/plugin-deepcrawl-test.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-deployer-framework.yml
+++ b/permissions/plugin-deployer-framework.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-deployment-notification.yml
+++ b/permissions/plugin-deployment-notification.yml
@@ -9,3 +9,4 @@ developers:
   - "kohsuke"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-design-library.yml
+++ b/permissions/plugin-design-library.yml
@@ -9,3 +9,4 @@ developers:
   - "@ux"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-devops-portal.yml
+++ b/permissions/plugin-devops-portal.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-digicert-software-trust-code-sign.yml
+++ b/permissions/plugin-digicert-software-trust-code-sign.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 29130
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-digicert-software-trust-gpg-sign.yml
+++ b/permissions/plugin-digicert-software-trust-gpg-sign.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 29131
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-discord-notifier.yml
+++ b/permissions/plugin-discord-notifier.yml
@@ -9,3 +9,4 @@ developers:
   - "kocproz"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-docker-java-api.yml
+++ b/permissions/plugin-docker-java-api.yml
@@ -10,3 +10,4 @@ developers:
   - "ericcitaire"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-dogu-integration.yml
+++ b/permissions/plugin-dogu-integration.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-downstream-buildview.yml
+++ b/permissions/plugin-downstream-buildview.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-downstream-ext.yml
+++ b/permissions/plugin-downstream-ext.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-doxygen.yml
+++ b/permissions/plugin-doxygen.yml
@@ -9,3 +9,4 @@ developers:
   - "gbois"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-ec2.yml
+++ b/permissions/plugin-ec2.yml
@@ -17,3 +17,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-editable-choice.yml
+++ b/permissions/plugin-editable-choice.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 28633
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-eggplant-runner.yml
+++ b/permissions/plugin-eggplant-runner.yml
@@ -12,3 +12,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-envfile.yml
+++ b/permissions/plugin-envfile.yml
@@ -9,3 +9,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-environment-script.yml
+++ b/permissions/plugin-environment-script.yml
@@ -9,3 +9,4 @@ developers:
   - "dawidmalina"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-extended-choice-parameter.yml
+++ b/permissions/plugin-extended-choice-parameter.yml
@@ -3,6 +3,7 @@ name: "extended-choice-parameter"
 github: &GH jenkinsci/extended-choice-parameter-plugin
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *GH # The preferred issue tracker
   - jira: '16004'  # extended-choice-parameter-plugin

--- a/permissions/plugin-extended-read-permission.yml
+++ b/permissions/plugin-extended-read-permission.yml
@@ -11,3 +11,4 @@ developers:
   - "oleg_nenashev"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-external-monitor-job.yml
+++ b/permissions/plugin-external-monitor-job.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/external-monitor-job"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "recena"

--- a/permissions/plugin-fail-the-build-plugin.yml
+++ b/permissions/plugin-fail-the-build-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-favorite-view.yml
+++ b/permissions/plugin-favorite-view.yml
@@ -9,3 +9,4 @@ developers:
   - "mPokornyETM"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-favorite.yml
+++ b/permissions/plugin-favorite.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-file-parameters.yml
+++ b/permissions/plugin-file-parameters.yml
@@ -3,6 +3,7 @@ name: "file-parameters"
 github: &gh "jenkinsci/file-parameters-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *gh
 paths:

--- a/permissions/plugin-flexdeploy.yml
+++ b/permissions/plugin-flexdeploy.yml
@@ -10,3 +10,4 @@ developers:
   - "flexagon9"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-forticwp-cicd.yml
+++ b/permissions/plugin-forticwp-cicd.yml
@@ -9,3 +9,4 @@ developers:
   - "forticontainer"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-generic-event.yml
+++ b/permissions/plugin-generic-event.yml
@@ -5,6 +5,7 @@ paths:
   - "io/jenkins/plugins/generic-event"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "johnniang"
 issues:

--- a/permissions/plugin-genexus.yml
+++ b/permissions/plugin-genexus.yml
@@ -3,6 +3,7 @@ name: "genexus"
 github: &gh "jenkinsci/genexus-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '23446'  # genexus-plugin
   - github: *gh

--- a/permissions/plugin-gerrit-checks-api.yml
+++ b/permissions/plugin-gerrit-checks-api.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-git-push.yml
+++ b/permissions/plugin-git-push.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-gitea-checks.yml
+++ b/permissions/plugin-gitea-checks.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-gitea-pat-kubernetes-credentials.yml
+++ b/permissions/plugin-gitea-pat-kubernetes-credentials.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-github-checks.yml
+++ b/permissions/plugin-github-checks.yml
@@ -12,3 +12,4 @@ developers:
   - "drulli"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-github-oauth.yml
+++ b/permissions/plugin-github-oauth.yml
@@ -3,6 +3,7 @@ name: "github-oauth"
 github: "jenkinsci/github-oauth-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '15900'  # github-oauth-plugin
 paths:

--- a/permissions/plugin-github-pr-comment-build.yml
+++ b/permissions/plugin-github-pr-comment-build.yml
@@ -10,3 +10,4 @@ developers:
   - "bksaville"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-github-release.yml
+++ b/permissions/plugin-github-release.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-github-scm-filter-aged-refs.yml
+++ b/permissions/plugin-github-scm-filter-aged-refs.yml
@@ -9,3 +9,4 @@ developers:
   - "tgr"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-github-scm-trait-notification-context.yml
+++ b/permissions/plugin-github-scm-trait-notification-context.yml
@@ -5,6 +5,7 @@ issues:
   - jira: '23429'  # github-scm-trait-notification-context-plugin
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/github-scm-trait-notification-context"
 developers:

--- a/permissions/plugin-gitlab-api.yml
+++ b/permissions/plugin-gitlab-api.yml
@@ -7,6 +7,7 @@ paths:
   - "io/jenkins/plugins/gitlab-api"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "baymac"
   - "surenpi"

--- a/permissions/plugin-gitlab-branch-source.yml
+++ b/permissions/plugin-gitlab-branch-source.yml
@@ -8,6 +8,7 @@ paths:
   - "io/jenkins/plugins/gitlab-branch-source"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "baymac"
   - "jequals5"

--- a/permissions/plugin-gitlab-scm-filter-aged-refs.yml
+++ b/permissions/plugin-gitlab-scm-filter-aged-refs.yml
@@ -9,3 +9,4 @@ developers:
   - "tgr"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-global-build-stats.yml
+++ b/permissions/plugin-global-build-stats.yml
@@ -9,3 +9,4 @@ developers:
   - "victor_yousician"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-global-yaml-properties.yml
+++ b/permissions/plugin-global-yaml-properties.yml
@@ -11,4 +11,4 @@ issues:
   - jira: 29132
 cd:
   enabled: true
-
+  exclusive: true

--- a/permissions/plugin-google-analyze-code-security.yml
+++ b/permissions/plugin-google-analyze-code-security.yml
@@ -9,4 +9,5 @@ developers:
 issues:
   - jira: 29324
 cd:
- enabled: true
+  enabled: true
+  exclusive: true

--- a/permissions/plugin-google-chat-notification.yml
+++ b/permissions/plugin-google-chat-notification.yml
@@ -11,3 +11,4 @@ developers:
   - "thiagoc"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-google-compute-engine.yml
+++ b/permissions/plugin-google-compute-engine.yml
@@ -26,3 +26,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-google-kubernetes-engine.yml
+++ b/permissions/plugin-google-kubernetes-engine.yml
@@ -23,3 +23,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-google-login.yml
+++ b/permissions/plugin-google-login.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/google-login"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "recampbell"
   - "vlatombe"

--- a/permissions/plugin-google-oauth-plugin.yml
+++ b/permissions/plugin-google-oauth-plugin.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-google-storage-plugin.yml
+++ b/permissions/plugin-google-storage-plugin.yml
@@ -22,3 +22,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-h2-api.yml
+++ b/permissions/plugin-h2-api.yml
@@ -10,3 +10,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-handy-uri-templates-2-api.yml
+++ b/permissions/plugin-handy-uri-templates-2-api.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/handy-uri-templates-2-api"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jetersen"
   - "dnusbaum"

--- a/permissions/plugin-harbor.yml
+++ b/permissions/plugin-harbor.yml
@@ -5,6 +5,7 @@ paths:
 - "io/jenkins/plugins/harbor"
 cd:
   enabled: true
+  exclusive: true
 developers:
 - "cnhttpd"
 issues:

--- a/permissions/plugin-hashicorp-vault-plugin.yml
+++ b/permissions/plugin-hashicorp-vault-plugin.yml
@@ -12,3 +12,4 @@ developers:
   - "dineshba"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-hetzner-cloud.yml
+++ b/permissions/plugin-hetzner-cloud.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-horreum.yml
+++ b/permissions/plugin-horreum.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-hsts-filter-plugin.yml
+++ b/permissions/plugin-hsts-filter-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-huaweicloud-ecs.yml
+++ b/permissions/plugin-huaweicloud-ecs.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-hubot-steps.yml
+++ b/permissions/plugin-hubot-steps.yml
@@ -9,3 +9,4 @@ developers:
   - "nrayapati"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-immuniweb.yml
+++ b/permissions/plugin-immuniweb.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-inodes-monitor.yml
+++ b/permissions/plugin-inodes-monitor.yml
@@ -10,3 +10,4 @@ developers:
   - "janasrikanth"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-instant-messaging.yml
+++ b/permissions/plugin-instant-messaging.yml
@@ -10,3 +10,4 @@ developers:
   - "jimklimov"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-ircbot.yml
+++ b/permissions/plugin-ircbot.yml
@@ -11,3 +11,4 @@ developers:
   - "jimklimov"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jenkins-cloudformation-plugin.yml
+++ b/permissions/plugin-jenkins-cloudformation-plugin.yml
@@ -13,3 +13,4 @@ developers:
   - "bitle0"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jenkins-infra-test.yml
+++ b/permissions/plugin-jenkins-infra-test.yml
@@ -7,6 +7,7 @@ paths:
   - "io/jenkins/plugins/jenkins-infra-test"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "timja"
   - "olblak"

--- a/permissions/plugin-jenkins-multijob-plugin.yml
+++ b/permissions/plugin-jenkins-multijob-plugin.yml
@@ -13,3 +13,4 @@ developers:
   - "victor_yousician"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jetbrains-space.yml
+++ b/permissions/plugin-jetbrains-space.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jira-ext.yml
+++ b/permissions/plugin-jira-ext.yml
@@ -9,3 +9,4 @@ developers:
   - "dalvizu"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jira-integration.yml
+++ b/permissions/plugin-jira-integration.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jira-steps.yml
+++ b/permissions/plugin-jira-steps.yml
@@ -9,3 +9,4 @@ developers:
   - "nrayapati"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jobConfigHistory.yml
+++ b/permissions/plugin-jobConfigHistory.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jobtag.yml
+++ b/permissions/plugin-jobtag.yml
@@ -7,5 +7,6 @@ developers:
   - "nistal97"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *GH

--- a/permissions/plugin-jqs-monitoring.yml
+++ b/permissions/plugin-jqs-monitoring.yml
@@ -10,3 +10,4 @@ developers:
   - "mPokornyETM"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-jsm-alert.yml
+++ b/permissions/plugin-jsm-alert.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-json-editor-parameter.yml
+++ b/permissions/plugin-json-editor-parameter.yml
@@ -5,6 +5,7 @@ paths:
 - "io/jenkins/plugins/json-editor-parameter"
 cd:
   enabled: true
+  exclusive: true
 developers:
 - "chas"
 issues:

--- a/permissions/plugin-junit-realtime-test-reporter.yml
+++ b/permissions/plugin-junit-realtime-test-reporter.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/junit-realtime-test-reporter"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "timja"

--- a/permissions/plugin-junit-sql-storage.yml
+++ b/permissions/plugin-junit-sql-storage.yml
@@ -10,3 +10,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-keeper-secrets-manager.yml
+++ b/permissions/plugin-keeper-secrets-manager.yml
@@ -7,5 +7,6 @@ developers:
   - "jsupun"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *GH

--- a/permissions/plugin-kobiton-integration.yml
+++ b/permissions/plugin-kobiton-integration.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-kpp-management-plugin.yml
+++ b/permissions/plugin-kpp-management-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-kubernetes-credentials-provider.yml
+++ b/permissions/plugin-kubernetes-credentials-provider.yml
@@ -7,6 +7,7 @@ paths:
   - "com/cloudbees/jenkins/plugins/kubernetes-credentials-provider"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "teilo"
   - "agentgonzo"

--- a/permissions/plugin-levo.yml
+++ b/permissions/plugin-levo.yml
@@ -5,6 +5,7 @@ paths:
   - "io/jenkins/plugins/levo"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "mauroatlevo"
 issues:

--- a/permissions/plugin-libvirt-slave.yml
+++ b/permissions/plugin-libvirt-slave.yml
@@ -8,6 +8,7 @@ paths:
   - "org/jenkins-ci/plugins/libvirt-slave"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "gkr"
   - "magnayn"

--- a/permissions/plugin-loadrunner-cloud.yml
+++ b/permissions/plugin-loadrunner-cloud.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-localization-zh-cn.yml
+++ b/permissions/plugin-localization-zh-cn.yml
@@ -10,3 +10,4 @@ developers:
   - "surenpi"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-log-file-filter.yml
+++ b/permissions/plugin-log-file-filter.yml
@@ -10,3 +10,4 @@ developers:
   - "andreasmandel"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-logstash.yml
+++ b/permissions/plugin-logstash.yml
@@ -10,3 +10,4 @@ developers:
   - "jbochenski"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-lucene-search.yml
+++ b/permissions/plugin-lucene-search.yml
@@ -11,3 +11,4 @@ developers:
   - "tdraebing"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-mapdb-api.yml
+++ b/permissions/plugin-mapdb-api.yml
@@ -13,3 +13,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-maplelabs-apm.yml
+++ b/permissions/plugin-maplelabs-apm.yml
@@ -11,3 +11,4 @@ issues:
   - jira: 29224
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-mask-passwords.yml
+++ b/permissions/plugin-mask-passwords.yml
@@ -12,3 +12,4 @@ developers:
   - "markewaite"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-matomo-analytics.yml
+++ b/permissions/plugin-matomo-analytics.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-matrix-communication.yml
+++ b/permissions/plugin-matrix-communication.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-maven-snapshot-check.yml
+++ b/permissions/plugin-maven-snapshot-check.yml
@@ -8,5 +8,6 @@ paths:
   - "org/jenkins-ci/plugins/maven-snapshot-check"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "donhui"

--- a/permissions/plugin-mend-cloud-native-security-scanner.yml
+++ b/permissions/plugin-mend-cloud-native-security-scanner.yml
@@ -7,5 +7,6 @@ developers:
 - "yuval_nahari_mend"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: 29127

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -8,6 +8,7 @@ paths:
   - "org/jvnet/hudson/plugins/mercurial"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "batmat"

--- a/permissions/plugin-metrics.yml
+++ b/permissions/plugin-metrics.yml
@@ -15,3 +15,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-mock-security-realm.yml
+++ b/permissions/plugin-mock-security-realm.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/mock-security-realm"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "rarabaolaza"

--- a/permissions/plugin-multibranch-build-strategy-extension.yml
+++ b/permissions/plugin-multibranch-build-strategy-extension.yml
@@ -10,3 +10,4 @@ developers:
   - "legall_benoit"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-naginator.yml
+++ b/permissions/plugin-naginator.yml
@@ -5,6 +5,7 @@ issues:
   - jira: '15560'  # naginator-plugin
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/naginator"
 developers:

--- a/permissions/plugin-nant.yml
+++ b/permissions/plugin-nant.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-node-iterator-api.yml
+++ b/permissions/plugin-node-iterator-api.yml
@@ -17,3 +17,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-oauth-credentials.yml
+++ b/permissions/plugin-oauth-credentials.yml
@@ -14,3 +14,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-oes-template.yml
+++ b/permissions/plugin-oes-template.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-oic-auth.yml
+++ b/permissions/plugin-oic-auth.yml
@@ -12,3 +12,4 @@ developers:
   - "mdoubez"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-oidc-provider.yml
+++ b/permissions/plugin-oidc-provider.yml
@@ -9,5 +9,6 @@ developers:
   - "fcojfernandez"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - github: *GH

--- a/permissions/plugin-openshift-client.yml
+++ b/permissions/plugin-openshift-client.yml
@@ -12,3 +12,4 @@ security:
     jira: "coreydaley"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-openshift-login.yml
+++ b/permissions/plugin-openshift-login.yml
@@ -12,3 +12,4 @@ security:
     jira: "coreydaley"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-openshift-sync.yml
+++ b/permissions/plugin-openshift-sync.yml
@@ -12,3 +12,4 @@ security:
     jira: "coreydaley"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-opentelemetry.yml
+++ b/permissions/plugin-opentelemetry.yml
@@ -11,3 +11,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-paginated-builds.yml
+++ b/permissions/plugin-paginated-builds.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-parameterized-scheduler.yml
+++ b/permissions/plugin-parameterized-scheduler.yml
@@ -11,3 +11,4 @@ developers:
   - "raihaan"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -17,6 +17,7 @@ developers:
   - "poddingue"
 cd:
   enabled: true
+  exclusive: true
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-peass-ci.yml
+++ b/permissions/plugin-peass-ci.yml
@@ -3,6 +3,7 @@ name: "peass-ci"
 github: &GH "jenkinsci/peass-ci-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "de/peass/peass-ci"
 developers:

--- a/permissions/plugin-performance.yml
+++ b/permissions/plugin-performance.yml
@@ -3,6 +3,7 @@ name: "performance"
 github: "jenkinsci/performance-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '15803'  # performance-plugin
 paths:

--- a/permissions/plugin-pipeline-agent-build-history.yml
+++ b/permissions/plugin-pipeline-agent-build-history.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-gcp.yml
+++ b/permissions/plugin-pipeline-gcp.yml
@@ -9,3 +9,4 @@ developers:
   - "enigo"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-githubnotify-step.yml
+++ b/permissions/plugin-pipeline-githubnotify-step.yml
@@ -3,6 +3,7 @@ name: "pipeline-githubnotify-step"
 github: "jenkinsci/pipeline-githubnotify-step-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '21944'  # pipeline-githubnotify-step-plugin
 paths:

--- a/permissions/plugin-pipeline-graph-view.yml
+++ b/permissions/plugin-pipeline-graph-view.yml
@@ -5,6 +5,7 @@ paths:
   - "io/jenkins/plugins/pipeline-graph-view"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "timja"
 issues:

--- a/permissions/plugin-pipeline-input-notification.yml
+++ b/permissions/plugin-pipeline-input-notification.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-maven.yml
+++ b/permissions/plugin-pipeline-maven.yml
@@ -3,6 +3,7 @@ name: "pipeline-maven"
 github: "jenkinsci/pipeline-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
 issues:
   - jira: '21669'  # pipeline-maven-plugin
 paths:

--- a/permissions/plugin-pipeline-project-env.yml
+++ b/permissions/plugin-pipeline-project-env.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pipeline-reporter-by-redpen.yml
+++ b/permissions/plugin-pipeline-reporter-by-redpen.yml
@@ -1,6 +1,7 @@
 ---
 cd:
   enabled: true
+  exclusive: true
 name: "pipeline-reporter-by-redpen"
 github: &GH "jenkinsci/pipeline-reporter-by-redpen-plugin"
 paths:

--- a/permissions/plugin-portshift-scanner.yml
+++ b/permissions/plugin-portshift-scanner.yml
@@ -8,3 +8,4 @@ developers:
   - "d_neduva"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-postbuildscript.yml
+++ b/permissions/plugin-postbuildscript.yml
@@ -10,3 +10,4 @@ developers:
   - "dheid"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-postgresql-api.yml
+++ b/permissions/plugin-postgresql-api.yml
@@ -10,3 +10,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-progress-bar-column-plugin.yml
+++ b/permissions/plugin-progress-bar-column-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-project-stats-plugin.yml
+++ b/permissions/plugin-project-stats-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-provar-automation.yml
+++ b/permissions/plugin-provar-automation.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-pull-request-monitoring.yml
+++ b/permissions/plugin-pull-request-monitoring.yml
@@ -10,3 +10,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-quali-torque.yml
+++ b/permissions/plugin-quali-torque.yml
@@ -3,6 +3,7 @@ name: "quali-torque"
 github: &GH "jenkinsci/quali-torque-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "io/jenkins/plugins/quali-torque"
 developers:

--- a/permissions/plugin-rebuild.yml
+++ b/permissions/plugin-rebuild.yml
@@ -12,3 +12,4 @@ developers:
   - "gustafl"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-redhat-dependency-analytics.yml
+++ b/permissions/plugin-redhat-dependency-analytics.yml
@@ -11,3 +11,4 @@ issues:
   - jira: 29221
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-remote-result-trigger.yml
+++ b/permissions/plugin-remote-result-trigger.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-role-strategy.yml
+++ b/permissions/plugin-role-strategy.yml
@@ -13,3 +13,4 @@ developers:
   - "mawinter69"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-s3.yml
+++ b/permissions/plugin-s3.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/s3"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "dmbeer"
   - "jimilian"

--- a/permissions/plugin-saml.yml
+++ b/permissions/plugin-saml.yml
@@ -16,3 +16,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-sbt.yml
+++ b/permissions/plugin-sbt.yml
@@ -9,3 +9,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-scm-filter-jervis.yml
+++ b/permissions/plugin-scm-filter-jervis.yml
@@ -9,3 +9,4 @@ developers:
   - "sag47"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-scmskip.yml
+++ b/permissions/plugin-scmskip.yml
@@ -10,3 +10,4 @@ developers:
   - "zbynek"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-scriptler.yml
+++ b/permissions/plugin-scriptler.yml
@@ -8,5 +8,6 @@ paths:
   - "org/jvnet/hudson/plugins/scriptler"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "mtughan"

--- a/permissions/plugin-secone-security.yml
+++ b/permissions/plugin-secone-security.yml
@@ -10,3 +10,4 @@ issues:
   - jira: 29323
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-secure-requester-whitelist.yml
+++ b/permissions/plugin-secure-requester-whitelist.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/secure-requester-whitelist"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "andresrc"

--- a/permissions/plugin-security-inspector.yml
+++ b/permissions/plugin-security-inspector.yml
@@ -10,3 +10,4 @@ developers:
   - "oleg_nenashev"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-simple-theme-plugin.yml
+++ b/permissions/plugin-simple-theme-plugin.yml
@@ -10,3 +10,4 @@ developers:
   - "tgr"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-slack.yml
+++ b/permissions/plugin-slack.yml
@@ -8,6 +8,7 @@ paths:
   - "org/jenkins-ci/plugins/slack"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "timja"
   - "jetersen"

--- a/permissions/plugin-slave-status.yml
+++ b/permissions/plugin-slave-status.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-slsa.yml
+++ b/permissions/plugin-slsa.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-sonar-gerrit.yml
+++ b/permissions/plugin-sonar-gerrit.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/sonar-gerrit"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "reda_alaoui"

--- a/permissions/plugin-soos-sca.yml
+++ b/permissions/plugin-soos-sca.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-ssh-agent.yml
+++ b/permissions/plugin-ssh-agent.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/ssh-agent"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "jglick"
   - "kohsuke"

--- a/permissions/plugin-ssh-steps.yml
+++ b/permissions/plugin-ssh-steps.yml
@@ -11,3 +11,4 @@ developers:
   - "wuchenwang"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-stashNotifier.yml
+++ b/permissions/plugin-stashNotifier.yml
@@ -6,6 +6,7 @@ issues:
   - jira: '17535'  # stashnotifier-plugin
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/stashNotifier"
 developers:

--- a/permissions/plugin-subversion.yml
+++ b/permissions/plugin-subversion.yml
@@ -8,5 +8,6 @@ paths:
   - "org/jvnet/hudson/plugins/subversion"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "didiez"

--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -21,3 +21,4 @@ security:
     jira: "cloudbees_security_members"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-svn-revert-plugin.yml
+++ b/permissions/plugin-svn-revert-plugin.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-template-workflows.yml
+++ b/permissions/plugin-template-workflows.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-testkube-cli.yml
+++ b/permissions/plugin-testkube-cli.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-text-finder-run-condition.yml
+++ b/permissions/plugin-text-finder-run-condition.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-theme-manager.yml
+++ b/permissions/plugin-theme-manager.yml
@@ -11,3 +11,4 @@ developers:
   - "timja"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-thycotic-devops-secrets-vault.yml
+++ b/permissions/plugin-thycotic-devops-secrets-vault.yml
@@ -9,3 +9,4 @@ issues:
   - jira: 28627
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-typetalk.yml
+++ b/permissions/plugin-typetalk.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/typetalk"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "ikikko"
   - "yasuyuki_baba"

--- a/permissions/plugin-uleska.yml
+++ b/permissions/plugin-uleska.yml
@@ -11,3 +11,4 @@ developers:
   - "tomjshore"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-unique-id.yml
+++ b/permissions/plugin-unique-id.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/unique-id"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "andresrc"
   - "oleg_nenashev"

--- a/permissions/plugin-validating-string-parameter.yml
+++ b/permissions/plugin-validating-string-parameter.yml
@@ -10,3 +10,4 @@ developers:
   - "raihaan"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-validating-yaml-parameter.yml
+++ b/permissions/plugin-validating-yaml-parameter.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-view-job-filters.yml
+++ b/permissions/plugin-view-job-filters.yml
@@ -8,6 +8,7 @@ paths:
   - "org/jvnet/hudson/plugins/view-job-filters"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "svenschoenung"
   - "jglick"

--- a/permissions/plugin-windows-azure-storage.yml
+++ b/permissions/plugin-windows-azure-storage.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/windows-azure-storage"
 cd:
   enabled: true
+  exclusive: true
 developers:
   - "zooopx"
   - "timja"

--- a/permissions/plugin-windows-exe-runner.yml
+++ b/permissions/plugin-windows-exe-runner.yml
@@ -8,3 +8,4 @@ paths:
 developers: []
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-wxwork-notification.yml
+++ b/permissions/plugin-wxwork-notification.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-xcode-plugin.yml
+++ b/permissions/plugin-xcode-plugin.yml
@@ -11,3 +11,4 @@ developers:
   - "kazuhidet"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-yaml-axis.yml
+++ b/permissions/plugin-yaml-axis.yml
@@ -9,3 +9,4 @@ developers:
   - "sue445"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/plugin-zos-connector.yml
+++ b/permissions/plugin-zos-connector.yml
@@ -9,3 +9,4 @@ developers:
   - "candiduslynx"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/pom-build-monitor.yml
+++ b/permissions/pom-build-monitor.yml
@@ -7,3 +7,4 @@ developers:
   - "janmolak"
 cd:
   enabled: true
+  exclusive: true

--- a/permissions/pom-pipeline-maven-parent.yml
+++ b/permissions/pom-pipeline-maven-parent.yml
@@ -3,6 +3,7 @@ name: "pipeline-maven-parent"
 github: "jenkinsci/pipeline-maven-plugin"
 cd:
   enabled: true
+  exclusive: true
 paths:
   - "org/jenkins-ci/plugins/pipeline-maven-parent"
 developers:

--- a/permissions/pom-scm-filter-aged-refs-parent.yml
+++ b/permissions/pom-scm-filter-aged-refs-parent.yml
@@ -7,3 +7,4 @@ developers:
   - "tgr"
 cd:
   enabled: true
+  exclusive: true


### PR DESCRIPTION
# Link to GitHub repository

Too many to list.

# When modifying release permission

There weren't any objections to #3858, so from this I conclude that the use case of non-exclusive CD doesn't exist. So this PR enables CD on any plugins whose last release was done with CD, under the assumption that the maintainer(s) have successfully completed the CD process and wish for all future releases to be done with CD.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
