### PR TITLE
Enable exclusive CD by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ In particular, the Jenkins security team will _not_ make an effort to reach out 
 
 ### Exclusively using JEP-229 CD
 
-It is also possible to enable JEP-229 CD exclusively, i.e., the listed users will not be able to create new releases, but remain contacts for security issues and plugin/component governance questions. 
+By default, enabling JEP-229 CD enables it _exclusively;_ i.e., the listed users will not be able to create new releases, but they remain contacts for security issues and plugin/component governance questions.
+
+It is also possible to disable exclusive JEP-229 CD, in which case both users with commit access _and_ the listed users will be able to create new releases, with the listed users remaining contacts for security issues and plugin/component governance questions:
 
 ```yaml
 cd:
   enabled: true
-  exclusive: true
+  exclusive: false
 ```
 
 

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -5,12 +5,15 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@SuppressFBWarnings("UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD")
+@SuppressFBWarnings({
+    "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+    "UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"
+})
 public class Definition {
 
     public static class CD {
         public boolean enabled;
-        public boolean exclusive;
+        public boolean exclusive = true;
     }
 
     public static class Security {


### PR DESCRIPTION
# Link to GitHub repository

Many

# When modifying release permission

Since the vast majority of plugins in this repository are now using exclusive CD, make it the default for all new plugins. This should not cause any regressions, as any plugins not using exclude CD have `exclusive: false` set as of #3878. If this PR is accepted, I will file one last refactoring PR to clean up the repository by removing `exclusive: true` everywhere it is set for brevity.

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
