### PR TITLE
Exclusive CD mode for `pipeline-cloudwatch-logs`

### DIFF
--- a/permissions/plugin-pipeline-cloudwatch-logs.yml
+++ b/permissions/plugin-pipeline-cloudwatch-logs.yml
@@ -7,7 +7,6 @@ paths:
   - "io/jenkins/plugins/pipeline-cloudwatch-logs"
 cd:
   enabled: true
-  exclusive: false
 developers:
   - "jglick"
   - "csanchez"


### PR DESCRIPTION
# Link to GitHub repository

Plan to release https://github.com/jenkinsci/pipeline-cloudwatch-logs-plugin/pull/95 using CD.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
