### PR TITLE
Enable CD for build user vars plugin.

### DIFF
--- a/permissions/plugin-build-user-vars-plugin.yml
+++ b/permissions/plugin-build-user-vars-plugin.yml
@@ -10,3 +10,5 @@ developers:
   - "clifford_jenkins"
   - "oleg_nenashev"
   - "zedasvacas"
+cd:
+  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/build-user-vars-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@fabiodcasilva`

This is needed in order to cut releases of the plugin or component.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/build-user-vars-plugin/pull/128

```[tasklist]
### CD checklist (for submitters)
- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
