### PR TITLE
Remove markewaite from 2 deprecated plugins

### DIFF
--- a/permissions/plugin-scp.yml
+++ b/permissions/plugin-scp.yml
@@ -6,5 +6,4 @@ issues:
   - github: *gh
 paths:
   - "org/jvnet/hudson/plugins/scp"
-developers:
-  - "markewaite"
+developers: [] # archived

--- a/permissions/plugin-workflow-remote-loader.yml
+++ b/permissions/plugin-workflow-remote-loader.yml
@@ -8,4 +8,3 @@ paths:
 developers:
   - "oleg_nenashev"
   - "escoem"
-  - "markewaite"


### PR DESCRIPTION
## Drop markewaite from deprecated scp and workflow remote loader

- **scp publisher repo is archived**
- **Workflow remote loader replaced by Pipeline: Groovy Libraries**

# Link to GitHub repository

Repositories:

* https://github.com/jenkinsci/scp-plugin
* https://github.com/jenkinsci/workflow-remote-loader-plugin

# When modifying release permission

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
