### PR TITLE
Add markewaite as a badge plugin maintainer

### DIFF
--- a/permissions/plugin-badge.yml
+++ b/permissions/plugin-badge.yml
@@ -10,3 +10,4 @@ developers:
   - "bakito"
   - "mPokornyETM"
   - "strangelookingnerd"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as a badge plugin maintainer

I was removed today from the GitHub developer team for this plugin.  That removal is correct because I am not listed in the repository permissions updater for the plugin.

I had removed myself as a maintainer in [November 2022](https://github.com/jenkins-infra/repository-permissions-updater/commit/eb71cad593051f9dea2cfa9eaafe8f66e143a44a) after @gounthar, @jmMeessen, and I had completed a Hacktoberfest initiative to encourage new contributors and to recruit new maintainers.

I've had enough fun with the most recent several pull requests that I think I would enjoy returning as a maintainer of this plugin.

@strangelookingnerd, @mPokornyETM, and @bakito would you accept me as a maintainer?

It is not a problem if you would rather not have me as a maintainer in the repository.  I understand that as well.  Too many maintainers can be disruptive.  Either way is just fine.

# Link to GitHub repository

https://github.com/jenkinsci/badge-plugin/

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- `@MarkEWaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
