### PR TITLE
[JENKINS-73253] Build and test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ props += pipelineTriggers(triggers)
 properties(props)
 
 
-node('maven-11') {
+node('maven-21') {
     try {
         stage ('Clean') {
             deleteDir()


### PR DESCRIPTION
# Build and test with Java 21

Jenkins will require Java 17 or newer in weekly releases beginning June 18, 2024.  Jenkins has supported Java 21 for a long time.  I've been using Java 21 for my local development work without any issue.

The upgrade to Spring Framework 6 will require at least Java 17.  Let's move to Java 21 to prepare for the future.

[JENKINS-67909](https://issues.jenkins.io/browse/JENKINS-67909) is the Jira epic that tracks the Java 11 end of life. [JENKINS-73253](https://issues.jenkins.io/browse/JENKINS-73253) is the issue for this pull request

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
