### PR TITLE
chore(pipeline) fix CD execution on trusted.ci.jenkins.io by using alternative node label and force JDK21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,69 +28,71 @@ props += pipelineTriggers(triggers)
 properties(props)
 
 
-node('maven-21') {
-    try {
-        stage ('Clean') {
-            deleteDir()
-            sh 'ls -lah'
-        }
+node('maven-21 || (java&&linux)') {
+    withEnv(['JAVA_HOME=/opt/jdk-21']) {
+        try {
+            stage ('Clean') {
+                deleteDir()
+                sh 'ls -lah'
+            }
 
-        stage ('Checkout') {
-            checkout scm
-        }
+            stage ('Checkout') {
+                checkout scm
+            }
 
-        stage ('Build') {
-            sh "mvn -U -B -ntp clean verify"
-        }
+            stage ('Build') {
+                sh "mvn -U -B -ntp clean verify"
+            }
 
-        stage ('Run') {
-            def javaArgs = ' -DdefinitionsDir=$PWD/permissions' +
-                        ' -DartifactoryApiTempDir=$PWD/json' +
-                        ' -DartifactoryUserNamesJsonListUrl=https://reports.jenkins.io/artifactory-ldap-users-report.json' +
-                        ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
-                        ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
+            stage ('Run') {
+                def javaArgs = ' -DdefinitionsDir=$PWD/permissions' +
+                            ' -DartifactoryApiTempDir=$PWD/json' +
+                            ' -DartifactoryUserNamesJsonListUrl=https://reports.jenkins.io/artifactory-ldap-users-report.json' +
+                            ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
+                            ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
 
 
-            if (dryRun) {
-                try {
+                if (dryRun) {
+                    try {
+                        withCredentials([
+                                usernamePassword(credentialsId: 'jiraUser', passwordVariable: 'JIRA_PASSWORD', usernameVariable: 'JIRA_USERNAME')
+                                ]) {
+                            sh 'java -DdryRun=true' + javaArgs
+                        }
+                    } catch(ignored) {
+                        if (fileExists('checks-title.txt')) {
+                            def title = readFile file: 'checks-title.txt', encoding: 'utf-8'
+                            def summary = readFile file:'checks-details.txt', encoding:  'utf-8'
+                            publishChecks conclusion: 'ACTION_REQUIRED',
+                                    name: 'Validation',
+                                summary: summary,
+                                title: title
+                        }
+                        throw ignored
+                    }
+                    publishChecks conclusion: 'SUCCESS',
+                            name: 'Validation',
+                            title: 'All checks passed'
+                } else {
                     withCredentials([
-                            usernamePassword(credentialsId: 'jiraUser', passwordVariable: 'JIRA_PASSWORD', usernameVariable: 'JIRA_USERNAME')
-                            ]) {
-                        sh 'java -DdryRun=true' + javaArgs
-                    }
-                } catch(ignored) {
-                    if (fileExists('checks-title.txt')) {
-                        def title = readFile file: 'checks-title.txt', encoding: 'utf-8'
-                        def summary = readFile file:'checks-details.txt', encoding:  'utf-8'
-                        publishChecks conclusion: 'ACTION_REQUIRED',
-                                name: 'Validation',
-                            summary: summary,
-                            title: title
-                    }
-                    throw ignored
-                }
-                publishChecks conclusion: 'SUCCESS',
-                        name: 'Validation',
-                        title: 'All checks passed'
-            } else {
-                withCredentials([
-                        usernamePassword(credentialsId: 'jiraUser', passwordVariable: 'JIRA_PASSWORD', usernameVariable: 'JIRA_USERNAME'),
-                        string(credentialsId: 'artifactoryAdminToken', variable: 'ARTIFACTORY_TOKEN'),
-                        usernamePassword(credentialsId: 'jenkins-infra-bot-github-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
-                ]) {
-                    retry(conditions: [agent(), nonresumable()], count: 2) {
-                        sh 'java ' + javaArgs
+                            usernamePassword(credentialsId: 'jiraUser', passwordVariable: 'JIRA_PASSWORD', usernameVariable: 'JIRA_USERNAME'),
+                            string(credentialsId: 'artifactoryAdminToken', variable: 'ARTIFACTORY_TOKEN'),
+                            usernamePassword(credentialsId: 'jenkins-infra-bot-github-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USERNAME')
+                    ]) {
+                        retry(conditions: [agent(), nonresumable()], count: 2) {
+                            sh 'java ' + javaArgs
+                        }
                     }
                 }
             }
-        }
-    } finally {
-        stage ('Archive') {
-            archiveArtifacts 'permissions/*.yml'
-            archiveArtifacts 'json/*.json'
-            if (infra.isTrusted()) {
-                dir('json') {
-                    publishReports ([ 'issues.index.json', 'maintainers.index.json', 'github.index.json' ])
+        } finally {
+            stage ('Archive') {
+                archiveArtifacts 'permissions/*.yml'
+                archiveArtifacts 'json/*.json'
+                if (infra.isTrusted()) {
+                    dir('json') {
+                        publishReports ([ 'issues.index.json', 'maintainers.index.json', 'github.index.json' ])
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,10 @@ props += pipelineTriggers(triggers)
 
 properties(props)
 
-
+// Temporary until maven-21 agents are available on trusted.ci
 node('maven-21 || (java&&linux)') {
-    withEnv(['JAVA_HOME=/opt/jdk-21']) {
+    // Temporary until maven-21 agents are available on trusted.ci
+    withEnv(['JAVA_HOME=/opt/jdk-21','PATH+JDK21=/opt/jdk-21/bin']) {
         try {
             stage ('Clean') {
                 deleteDir()


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4122

This PR is a follow-up of https://github.com/jenkins-infra/repository-permissions-updater/pull/3953.

It updated the pipeline to ensure that agent are allocated on trusted.ci.jenkins.io (as `maven-21` is not implemented.. yet) on it, and uses the `JAVA_HOME` environment variable to ensure proper execution with JDK21.