### PR TITLE
Allow multiple agent labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,8 @@ props += pipelineTriggers(triggers)
 
 properties(props)
 
-
-node('maven-21') {
+// Temporary until maven-21 agents are available on trusted.ci
+node('maven-21' || 'java' || 'maven-11') {
     try {
         stage ('Clean') {
             deleteDir()
@@ -40,7 +40,8 @@ node('maven-21') {
         }
 
         stage ('Build') {
-            sh "mvn -U -B -ntp clean verify"
+            // Temporary until maven-21 agents are available on trusted.ci
+            sh "[ -d /opt/jdk-21/bin ] && export JAVA_HOME=/opt/jdk-21; mvn -U -B -ntp clean verify"
         }
 
         stage ('Run') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ props += pipelineTriggers(triggers)
 properties(props)
 
 // Temporary until maven-21 agents are available on trusted.ci
-node('maven-21' || 'java' || 'maven-11') {
+node('maven-21 || java || maven-11') {
     try {
         stage ('Clean') {
             deleteDir()


### PR DESCRIPTION
## Allow multiple agent labels

Workaround for:

* https://github.com/jenkins-infra/helpdesk/issues/4122

Run with Java 21 no matter which agent

## Testing done

Confirmed that the command correctly uses the desired Java version no matter which Java version is in my PATH.  Checked with Java 11, Java 17, and Java 21 on my Red Hat Linux 8 with the `bash` shell.  Also tested in Alpine container image.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
