### PR TITLE
add-security-contact-for-apache-httpcomponents-client-5-api

### DIFF
--- a/permissions/plugin-apache-httpcomponents-client-5-api.yml
+++ b/permissions/plugin-apache-httpcomponents-client-5-api.yml
@@ -7,3 +7,6 @@ developers:
 - "strangelookingnerd"
 issues:
   - github: *GH
+security:
+  contacts:
+    jira: "cloudbees_security_members"


### PR DESCRIPTION
# Description
I would like to propose our help with regards to security maintenance.

Our team at CloudBees will be able to react on security issue reports, by definition time-sensitive. This way we can be notified on the event of a security report to help on the resolution, collaboration with the security team, synchronization, etc.

We have done this already for a number of plugins:
[https://github.com/search?q=repo%3Ajenkins-infra%2Frepository-permissions-updater+cloudbees_security_members&type=code](https://github.com/search?q=repo%3Ajenkins-infra%2Frepository-permissions-updater+cloudbees_security_members&type=code) 

If anybody sees a problem with this, please let me know.

Thank you.

Repo implied: [https://github.com/jenkinsci/apache-httpcomponents-client-5-api-plugin](https://github.com/jenkinsci/apache-httpcomponents-client-5-api-plugin)
CC: @strangelookingnerd for approval from an existing maintainer.
CC @Wadeck as the security officer since this PR is changing security contacts.

# Submitter checklist for adding or changing permissions
### Always
- [ ] Add link to plugin/component Git repository in description above
### For a newly hosted plugin only
- [ ] Add link to resolved HOSTING issue in description above
### For a new permissions file only
- [ ]  Make sure the file is created in permissions/ directory
- [ ]  artifactId (pom.xml) is used for name (permissions YAML file).
- [ ]  [groupId / artifactId (pom.xml) are correctly represented in path (permissions YAML file)](https://github.com/jenkins-infra/repository-permissions-updater/#managing-permissions)
- [ ]  Check that the file is named plugin-${artifactId}.yml for plugins
### When adding new uploaders (this includes newly created permissions files)
- [ ]  [Make sure to @mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [ ]  Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [ ]  Make sure to @mention the users being added so their GitHub account names are known if they require GitHub merge access (see below).
- [ ]  [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
### Reviewer checklist (not for requesters!)
- [ ]  Check this if newly added person also needs to be given merge permission to the GitHub repo (please @ the people/person with their GitHub username in this issue as well). If needed, it can be done using an [IRC Bot command](https://jenkins.io/projects/infrastructure/ircbot/#github-repo-management)
- [ ]  Check that the $pluginId Developers team has Admin permissions while granting the access.
- [ ]  In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ]  If security contacts are changed (this includes add/remove), ping the security officer (currently @Wadeck) in this pull request. If an email contact is changed, wait for approval from the security officer.
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it
