### PR TITLE
Bump org.yaml:snakeyaml from 1.33 to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -5,6 +5,7 @@ import groovy.io.FileType
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.constructor.Constructor
@@ -48,7 +49,7 @@ class ArtifactoryPermissionsUpdater {
      * Always returns non null.
      */
     private static Map<String, Set<TeamDefinition>>  loadTeams() {
-        Yaml yaml = new Yaml(new Constructor(TeamDefinition.class))
+        Yaml yaml = new Yaml(new Constructor(TeamDefinition.class, new LoaderOptions()))
         File teamsDir = new File('teams/')
 
         Set<TeamDefinition> teams = [] as Set
@@ -107,7 +108,7 @@ class ArtifactoryPermissionsUpdater {
      * Take the YAML permission definitions and convert them to Artifactory permissions API payloads.
      */
     private static void generateApiPayloads(File yamlSourceDirectory, File apiOutputDir) throws IOException {
-        Yaml yaml = new Yaml(new Constructor(Definition.class))
+        Yaml yaml = new Yaml(new Constructor(Definition.class, new LoaderOptions()))
 
         if (!yamlSourceDirectory.exists()) {
             throw new IOException("Directory ${DEFINITIONS_DIR} does not exist")


### PR DESCRIPTION
Bump `org.yaml:snakeyaml` from 1.33 to 2.2

See https://github.com/jenkins-infra/repository-permissions-updater/pull/3513 and [comment](https://github.com/jenkins-infra/repository-permissions-updater/pull/3513#pullrequestreview-1721492932) by @basil 

The latest version of snakeyaml gets rid of the (unsafe) no-arg constructors and requires `LoadOptions` to be passed. See the [documentation](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Documentation) for more details.

I verified the changes locally by running
```
mvn clean verify

java -DdryRun=true -DdefinitionsDir=".\permissions" -DartifactoryApiTempDir=".\json" -DartifactoryUserNamesJsonListUrl=https://reports.jenkins.io/artifactory-ldap-users-report.json '-Djava.util.logging.SimpleFormatter.format=%1-%1-%1 %1:%1:%1 %4: %5%6%n' -jar .\target\repository-permissions-updater-1.0-SNAPSHOT-bin\repository-permissions-updater-1.0-SNAPSHOT.jar
```