### PR TITLE
Add new maintainers for onepassword-secrets plugin

### DIFF
--- a/permissions/plugin-onepassword-secrets.yml
+++ b/permissions/plugin-onepassword-secrets.yml
@@ -6,5 +6,9 @@ paths:
 developers:
 - "edif2008"
 - "jillianwilson"
+- "abon1p"
+- "vzt"
+- "dustinr1p"
+- "nazibah"
 issues:
   - github: *GH


### PR DESCRIPTION
# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->

https://github.com/jenkinsci/onepassword-secrets-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@michaelabon1p`
- `@volodymyrZotov`
- `@dustin-ruetz`
- `@naziba321`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```