### PR TITLE
Add markewaite as a label-verifier maintainer

### DIFF
--- a/permissions/plugin-label-verifier.yml
+++ b/permissions/plugin-label-verifier.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/label-verifier"
 developers:
   - "oleg_nenashev"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as a label-verifier maintainer

I regularly use the label verifier plugin in my installation to assure that I've correctly labeled agents with the command line git version that they are running.  It helps me run targeted tests on specific versions of command line git.

Pull requests to be merged include:

* https://github.com/jenkinsci/label-verifier-plugin/pull/18
* https://github.com/jenkinsci/label-verifier-plugin/pull/19
* https://github.com/jenkinsci/label-verifier-plugin/pull/20
* https://github.com/jenkinsci/label-verifier-plugin/pull/21
* https://github.com/jenkinsci/label-verifier-plugin/pull/22
* https://github.com/jenkinsci/label-verifier-plugin/pull/23

# Link to GitHub repository

https://plugins.jenkins.io/label-verifier/ shows that the plugin is up for adoption.

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@MarkEWaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.  https://plugins.jenkins.io/label-verifier/ shows that the plugin is up for adoption.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
