### PR TITLE
Update plugin-digitalocean-plugin.yml

### DIFF
--- a/permissions/plugin-digitalocean-plugin.yml
+++ b/permissions/plugin-digitalocean-plugin.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '18831'  # digitalocean-plugin
 paths:
   - "com/dubture/jenkins/digitalocean-plugin"
-developers: []
+developers:
+  - speedythesnail


### PR DESCRIPTION
Add myself (speedythesnail) as a developer for the digitalocean plugin.

# Link to GitHub repository

https://github.com/jenkinsci/digitalocean-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@speedythesnail`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [X] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

# Additional Comments
I am unable to do the last item, the link does not work and I am unable to see teams. I would like to adopt this plugin and will post this PR as described in the adopt a plugin document, to the Google mail group.


