### PR TITLE
Tentative to fix CD deployment of the multi-module plugin-modernizer-tool

### DIFF
--- a/permissions/component-plugin-modernizer-tool.yml
+++ b/permissions/component-plugin-modernizer-tool.yml
@@ -4,7 +4,9 @@ github: &GH "jenkinsci/plugin-modernizer-tool"
 issues:
   - github: *GH
 paths:
-  - "io/jenkins/plugin-modernizer"
+  - "io/jenkins/plugin-modernizer/plugin-modernizer-parent-pom"
+  - "io/jenkins/plugin-modernizer/plugin-modernizer-cli"
+  - "io/jenkins/plugin-modernizer/plugin-modernizer-core"
 developers:
   - "poddingue"
   - "jonesbusy"


### PR DESCRIPTION
# Link to GitHub repository

I'm getting 403 when trying to create our first release of the GSoC 2024 project (midterm).

It's a multi-module project with one parent and 2 module, and I'm getting 403 on the CD action : https://github.com/jenkinsci/plugin-modernizer-tool/actions/runs/9905709871/job/27365817131

Not sure if the cause is because of the path on the RPU file

If not I can open an helpdesk ticket to get some support

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@username1`
- `@username2`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
