### PR TITLE
Fix CD deployment of the multi-module plugin-modernizer-tool

### DIFF
--- a/permissions/component-plugin-modernizer-tool-cli.yml
+++ b/permissions/component-plugin-modernizer-tool-cli.yml
@@ -1,0 +1,12 @@
+---
+name: "plugin-modernizer-cli"
+github: &GH "jenkinsci/plugin-modernizer-tool"
+issues:
+  - github: *GH
+paths:
+  - "io/jenkins/plugin-modernizer/plugin-modernizer-cli"
+developers:
+  - "poddingue"
+  - "jonesbusy"
+cd:
+  enabled: true

--- a/permissions/component-plugin-modernizer-tool-core.yml
+++ b/permissions/component-plugin-modernizer-tool-core.yml
@@ -1,0 +1,12 @@
+---
+name: "plugin-modernizer-core"
+github: &GH "jenkinsci/plugin-modernizer-tool"
+issues:
+  - github: *GH
+paths:
+  - "io/jenkins/plugin-modernizer/plugin-modernizer-core"
+developers:
+  - "poddingue"
+  - "jonesbusy"
+cd:
+  enabled: true

--- a/permissions/component-plugin-modernizer-tool-parent-pom.yml
+++ b/permissions/component-plugin-modernizer-tool-parent-pom.yml
@@ -1,0 +1,12 @@
+---
+name: "plugin-modernizer-parent-pom"
+github: &GH "jenkinsci/plugin-modernizer-tool"
+issues:
+  - github: *GH
+paths:
+  - "io/jenkins/plugin-modernizer/plugin-modernizer-parent-pom"
+developers:
+  - "poddingue"
+  - "jonesbusy"
+cd:
+  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

Looks I was wrong with https://github.com/jenkins-infra/repository-permissions-updater/pull/4005

Each module need is own permission because of some check 

```
13:04:26  2024-07-12 11:04:26.198+0000 [id=1]	WARNING	java_util_logging_Logger$log$1#call: Unexpected path: io/jenkins/plugin-modernizer/plugin-modernizer-parent-pom for artifact ID: plugin-modernizer-tool
13:04:26  2024-07-12 11:04:26.198+0000 [id=1]	WARNING	java_util_logging_Logger$log$1#call: Unexpected path: io/jenkins/plugin-modernizer/plugin-modernizer-cli for artifact ID: plugin-modernizer-tool
13:04:26  2024-07-12 11:04:26.198+0000 [id=1]	WARNING	java_util_logging_Logger$log$1#call: Duplicate maintainers entry for component: io.jenkins.plugin-modernizer:plugin-modernizer-tool
13:04:26  2024-07-12 11:04:26.198+0000 [id=1]	WARNING	java_util_logging_Logger$log$1#call: Unexpected path: io/jenkins/plugin-modernizer/plugin-modernizer-core for artifact ID: plugin-modernizer-tool
13:04:26  2024-07-12 11:04:26.198+0000 [id=1]	WARNING	java_util_logging_Logger$log$1#call: Duplicate maintainers entry for component: io.jenkins.plugin-modernizer:plugin-modernizer-tool
```

Apparently the CD tag is also needed on every module (Like https://github.com/jenkins-infra/repository-permissions-updater/blob/master/permissions/component-pipeline-maven-api.yml)

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@username1`
- `@username2`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
