### PR TITLE
Enable CD for absint-astree plugin

### DIFF
--- a/permissions/plugin-absint-astree.yml
+++ b/permissions/plugin-absint-astree.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '21723'  # absint-astree-plugin
 paths:
   - "org/jenkins-ci/plugins/absint-astree"
+cd:
+  enabled: true
 developers:
   - "jherter"
   - "absint"


### PR DESCRIPTION
https://github.com/jenkinsci/absint-astree-plugin/pull/4

### CD checklist (for submitters)
- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 

### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If
