### PR TITLE
unleash-plugin: Add path "io/jenkins/plugins/unleash"

### DIFF
--- a/permissions/plugin-unleash.yml
+++ b/permissions/plugin-unleash.yml
@@ -5,5 +5,6 @@ issues:
   - jira: '21681'  # unleash-plugin
 paths:
   - "com/itemis/jenkins/plugins/unleash"
+  - "io/jenkins/plugins/unleash"
 developers:
   - "mhoffrog"


### PR DESCRIPTION
@timja Would like to meet most recent plugin groupId policy for upcoming release 3.0.0 by adding path "io/jenkins/plugins/unleash"

# Link to GitHub repository

[https://](https://github.com/jenkinsci/unleash-plugin)

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
