### PR TITLE
Remove fork of servlet API

### DIFF
--- a/permissions/component-javax-servlet-api.yml
+++ b/permissions/component-javax-servlet-api.yml
@@ -1,7 +1,0 @@
----
-name: "javax-servlet-api"
-github: "jenkinsci/javax-servlet-api"
-paths:
-  - "io/jenkins/servlet/javax-servlet-api"
-developers:
-  - "@core"


### PR DESCRIPTION
Since I originally started down this path, I have found a new way of doing this that doesn't involve maintaining a custom fork, so I have archived this repository and we can remove deployment permissions for it here.

# Link to GitHub repository

https://github.com/jenkinsci/javax-servlet-api