### PR TITLE
Rename repository entry to reflect actual repository name of multijob

### DIFF
--- a/permissions/plugin-jenkins-multijob-plugin.yml
+++ b/permissions/plugin-jenkins-multijob-plugin.yml
@@ -1,6 +1,6 @@
 ---
 name: "jenkins-multijob-plugin"
-github: &gh "jenkinsci/tikal-multijob-plugin"
+github: &gh "jenkinsci/jenkins-multijob-plugin"
 issues:
   - jira: '16545'  # multijob-plugin
   - github: *gh


### PR DESCRIPTION
ref https://github.com/jenkinsci/jenkins-multijob-plugin