### PR TITLE
Need permission to deploy reqtify-plugin

### DIFF
--- a/permissions/plugin-reqtify.yml
+++ b/permissions/plugin-reqtify.yml
@@ -7,4 +7,4 @@ paths:
   - "io/jenkins/plugins/reqtify"
 developers:
   - "NKR8"
-  - "rpl16_alt"
+  - "rpl17_alt"

--- a/permissions/plugin-reqtify.yml
+++ b/permissions/plugin-reqtify.yml
@@ -6,4 +6,4 @@ issues:
 paths:
   - "io/jenkins/plugins/reqtify"
 developers:
-  - "NKR8"
+  - "NKR8","rpl17-alt"

--- a/permissions/plugin-reqtify.yml
+++ b/permissions/plugin-reqtify.yml
@@ -6,4 +6,5 @@ issues:
 paths:
   - "io/jenkins/plugins/reqtify"
 developers:
-  - "NKR8","rpl17-alt"
+  - "NKR8"
+  - "rpl16_alt"


### PR DESCRIPTION
# Link to GitHub repository

(https://github.com/jenkinsci/reqtify-plugin.git)

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@NKR`
- `@rpl17_alt`

This PR requests upload permissions for the `reqtify-plugin`. 
I need these permissions to be able to deploy new releases of the plugin to the Jenkins artifact repository. 
My Jenkins username is `your-jenkins-username`.
