### PR TITLE
Add upload permissions

### DIFF
--- a/permissions/plugin-reqtify.yml
+++ b/permissions/plugin-reqtify.yml
@@ -6,4 +6,4 @@ issues:
 paths:
   - "io/jenkins/plugins/reqtify"
 developers:
-  - "NKR8"
+  - "NKR8","rpl17-alt"


### PR DESCRIPTION
# Link to GitHub repository

plugin repo
https://github.com/jenkinsci/reqtify-plugin.git

List the GitHub usernames of the users who should have commit permissions below:
- `@NKR8`
- `@rpl17-alt`


jenkin user rpl17_alt need permission to deploy


