### PR TITLE
Add permissions for security3430-workaround

### DIFF
--- a/permissions/component-security3430-workaround.yml
+++ b/permissions/component-security3430-workaround.yml
@@ -1,6 +1,6 @@
 ---
 name: "security3430-workaround"
-github: "jenkinsci-cert/security3430-workaround"
+github: "jenkinsci-cert/SECURITY-3430"
 paths:
   - "io/jenkins/security/security3430-workaround"
 developers:

--- a/permissions/component-security3430-workaround.yml
+++ b/permissions/component-security3430-workaround.yml
@@ -1,0 +1,7 @@
+---
+name: "security3430-workaround"
+github: "jenkinsci-cert/security3430-workaround"
+paths:
+  - "io/jenkins/security/security3430-workaround"
+developers:
+  - "@security"


### PR DESCRIPTION
Note the unusual org here, consistent with most previous workaround repos (although those were just script console / `init.groovy.d` scripts). I don't know whether we want to support this, but at least it's in the Jenkins project umbrella.

# Link to GitHub repository

https://github.com/jenkinsci-cert/security3430-workaround

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

n/a

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
