### PR TITLE
add a JellyVerifier for inline javascript and style tags

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -44,6 +44,7 @@ public class HostingChecker {
         verifications.add(Triplet.with("GitHub", new GitHubVerifier(), null));
         verifications.add(Triplet.with("Maven", new MavenVerifier(), new FileExistsConditionChecker("pom.xml")));
         verifications.add(Triplet.with("JenkinsProjectUsers", new JenkinsProjectUserVerifier(), null));
+        verifications.add(Triplet.with("Jelly", new JellyVerifier(), null));
 
         final HostingRequest hostingRequest = HostingRequestParser.retrieveAndParse(issueID);
 

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JellyVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JellyVerifier.java
@@ -1,0 +1,141 @@
+package io.jenkins.infra.repository_permissions_updater.hosting;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHContentSearchBuilder;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.PagedSearchIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+public class JellyVerifier implements Verifier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JellyVerifier.class);
+    private static final String INLINE_STYLE = "The jelly file %s contains an inline `<style>` tag";
+    private static final String INLINE_SCRIPT = "The jelly file %s contains a `<script>` tag with inline javascript.";
+    private static final String INLINE_SCRIPT_METHOD = "The jelly file %s potentially uses inline javascript attribute `%s`";
+    private static final String INLINE_TAGLIB_ONCLICK_METHOD = "The jelly file %s potentially uses the `onclick` attribute of a jelly taglib";
+    private static final String LEGACY_CHECK_URL = "The jelly file %s makes use of the legacy `checkUrl` form without using `checkDependsOn`";
+    private static final String CSP_HELP = "One or more usages of inline javascript tags, style tags or event handlers have been identified. See " +
+            "https://www.jenkins.io/doc/developer/security/csp/ for more information how to make your jelly files CSP compliant";
+
+    @Override
+    public void verify(HostingRequest issue, HashSet<VerificationMessage> hostingIssues) throws IOException {
+        GitHub github = GitHub.connect();
+        String forkFrom = issue.getRepositoryUrl();
+        if (StringUtils.isNotBlank(forkFrom)) {
+            Matcher m = Pattern.compile("(?:https://github\\.com/)?(\\S+)/(\\S+)", CASE_INSENSITIVE).matcher(forkFrom);
+            if (m.matches()) {
+                String owner = m.group(1);
+                String repoName = m.group(2);
+
+                GHContentSearchBuilder search = github.searchContent();
+                PagedSearchIterable<GHContent> list = search.q(".jelly").in("path").repo(owner + "/" + repoName).list();
+                List<GHContent> jellyFiles = list.toList().stream()
+                        .filter(item -> item.getPath().endsWith(".jelly") && item.getPath().startsWith("src/main/resources/"))
+                        .toList();
+
+                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                dbf.setNamespaceAware(true);
+                try {
+                    dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                    DocumentBuilder db = dbf.newDocumentBuilder();
+                    for (GHContent jellyFile: jellyFiles) {
+                        InputStream is = jellyFile.read();
+                        try {
+                            Document doc = db.parse(is);
+                            Element root = doc.getDocumentElement();
+                            boolean hasIssues = checkStyleElement(root, hostingIssues, jellyFile.getPath());
+                            hasIssues |= checkScriptElement(root, hostingIssues, jellyFile.getPath());
+                            hasIssues |= checkJavaScriptAttributes(root, hostingIssues, jellyFile.getPath());
+                            if (hasIssues) {
+                                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.INFO, CSP_HELP));
+                            }
+                        } catch (SAXException e) {
+                            LOGGER.warn("Failed to parse jelly {}", jellyFile.getPath());
+                        }
+                    }
+                } catch (ParserConfigurationException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    static boolean checkStyleElement(Element root, HashSet<VerificationMessage> hostingIssues, String jellyPath) {
+        NodeList styleElements = root.getElementsByTagName("style");
+        if (styleElements.getLength() > 0) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, INLINE_STYLE, jellyPath));
+            return true;
+        }
+        return false;
+    }
+
+    static boolean checkScriptElement(Element root, HashSet<VerificationMessage> hostingIssues, String jellyPath) {
+        NodeList scriptElements = root.getElementsByTagName("script");
+        for (int i = 0; i < scriptElements.getLength(); i++) {
+            Node e = scriptElements.item(i);
+            Attr typeAttribute = (Attr) e.getAttributes().getNamedItem("type");
+            if (e.getAttributes().getNamedItem("src") == null && (typeAttribute == null ||
+                    !"application/json".equals(typeAttribute.getValue().toLowerCase(Locale.US)))) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, INLINE_SCRIPT, jellyPath));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean checkJavaScriptAttributes(Element root, HashSet<VerificationMessage> hostingIssues, String jellyPath) {
+        NodeList allElements = root.getElementsByTagName("*");
+        boolean hasIssues = false;
+        for (int i = 0; i < allElements.getLength(); i++) {
+            Node e = allElements.item(i);
+            // ignore namespaced element, those are usually references to taglibs, except for onclick which
+            Attr onclick = (Attr) e.getAttributes().getNamedItem("onclick");
+
+            Attr checkUrl = (Attr) e.getAttributes().getNamedItem("checkUrl");
+            Attr checkDependsOn = (Attr) e.getAttributes().getNamedItem("checkDependsOn");
+            if (checkUrl != null && checkDependsOn == null) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, LEGACY_CHECK_URL, jellyPath));
+                hasIssues = true;
+            }
+            if (onclick != null && e.getNamespaceURI() != null) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.WARNING, INLINE_TAGLIB_ONCLICK_METHOD, jellyPath));
+                hasIssues = true;
+                continue;
+            }
+            if (e.getNamespaceURI() == null && e.hasAttributes()) {
+                NamedNodeMap attributes = e.getAttributes();
+                for (int j = 0; j < attributes.getLength(); j++) {
+                    Attr attr = (Attr) attributes.item(j);
+                    if (attr.getNodeName().startsWith("on")) {
+                        hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.WARNING, INLINE_SCRIPT_METHOD, jellyPath, attr.getName()));
+                        hasIssues = true;
+                    }
+                }
+            }
+        }
+        return hasIssues;
+    }
+
+}

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/hosting/JellyVerifierTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/hosting/JellyVerifierTest.java
@@ -1,0 +1,74 @@
+package io.jenkins.infra.repository_permissions_updater.hosting;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+public class JellyVerifierTest {
+
+    private HashSet<VerificationMessage> hostingIssues;
+
+    @BeforeEach
+    public void reset() {
+        hostingIssues = new HashSet<>();
+    }
+
+    @Test
+    public void inlineStyle() {
+        Element root = loadJelly("inlineStyle");
+        JellyVerifier.checkStyleElement(root, hostingIssues, "inlineStyle");
+        Assertions.assertEquals(1, hostingIssues.size());
+    }
+
+    @Test
+    public void inlineScript() {
+        Element root = loadJelly("inlineScript");
+        JellyVerifier.checkScriptElement(root, hostingIssues, "inlineScript");
+        Assertions.assertEquals(1, hostingIssues.size());
+    }
+
+    @Test
+    public void inlineScriptJson() {
+        Element root = loadJelly("inlineScriptJson");
+        JellyVerifier.checkScriptElement(root, hostingIssues, "inlineScriptJson");
+        Assertions.assertEquals(0, hostingIssues.size());
+    }
+
+    @Test
+    public void checkJavaScriptAttributes() {
+        Element root = loadJelly("inlineScriptAttribute");
+        JellyVerifier.checkJavaScriptAttributes(root, hostingIssues, "inlineScriptAttribute");
+        Assertions.assertEquals(4, hostingIssues.size());
+    }
+
+    @Test
+    public void ok() {
+        Element root = loadJelly("ok");
+        JellyVerifier.checkStyleElement(root, hostingIssues, "ok");
+        JellyVerifier.checkScriptElement(root, hostingIssues, "ok");
+        JellyVerifier.checkJavaScriptAttributes(root, hostingIssues, "ok");
+        Assertions.assertEquals(0, hostingIssues.size());
+    }
+
+    private Element loadJelly(String file) {
+        String fullPath = "src/test/resources/" + file + ".jelly";
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        try {
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(new FileInputStream(fullPath));
+            return doc.getDocumentElement();
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/resources/inlineScript.jelly
+++ b/src/test/resources/inlineScript.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+      <script>
+        console.log("Hello Worls")
+      </script>
+</j:jelly>

--- a/src/test/resources/inlineScriptAttribute.jelly
+++ b/src/test/resources/inlineScriptAttribute.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:radio onclick="doSomething()"/>
+  <button type="button" onclick="doSomething()"/>
+  <input type="text" onchange="doSomething()" checkUrl="myurl"/>
+</j:jelly>

--- a/src/test/resources/inlineScriptJson.jelly
+++ b/src/test/resources/inlineScriptJson.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <script id="theme-manager-theme" type="application/json">{ "id": "myid" }</script>
+</j:jelly>

--- a/src/test/resources/inlineStyle.jelly
+++ b/src/test/resources/inlineStyle.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+      <style>
+        p {
+          color: black;
+        }
+      </style>
+</j:jelly>

--- a/src/test/resources/ok.jelly
+++ b/src/test/resources/ok.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <script id="theme-manager-theme" type="application/json">{ "id": "myid" }</script>
+  <f:radio field="radio"/>
+  <button type="button"/>
+  <input type="text" checkUrl="myurl" checkDependsOn=""/>
+</j:jelly>


### PR DESCRIPTION
The JellyVerifier checks for several kinds of inline javascript and style usages which are not CSP compliant.
Following checks are implement
- inline style tags
- script tags without `src` attribute that are not of type `application/json`
- `onclick` attribute in namespaced element (this is an indicator that the deprecated onclick attribute is used that a few jellies in core support, e.g. f:radio), logged as warning
- all attributes starting with `on` in tags without a namespace (Those are typically html elements), logged as warning
- usage of `checkUrl` without `checkDependsOn`

Potentially some check might produce false positives.

Tested against issue 3310 which currently uses inline script and style.
Tested against 4024 it found usages of `onclick` attributes

Added unit tests that verifies all checks.

fixes #3770
