### PR TITLE
Leaving `maven-plugin`

### DIFF
--- a/permissions/plugin-maven-plugin.yml
+++ b/permissions/plugin-maven-plugin.yml
@@ -8,7 +8,6 @@ paths:
   - "org/jvnet/hudson/main/maven-plugin"
 developers:
   - "integer"
-  - "jglick"
   - "kohsuke"
   - "olamy"
   - "olivergondza"


### PR DESCRIPTION
# Link to GitHub repository

I have already left https://github.com/orgs/jenkinsci/teams/maven-plugin-developers as I have no interest in maintaining this plugin and do not care to see notifications.

# When modifying release permission

CC @olamy I guess?

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
