### PR TITLE
Remove mramonleon as a maintainer

### DIFF
--- a/permissions/component-async-http-client.yml
+++ b/permissions/component-async-http-client.yml
@@ -8,7 +8,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/component-lib-durable-task.yml
+++ b/permissions/component-lib-durable-task.yml
@@ -11,6 +11,5 @@ developers:
   - "teilo"
   - "batmat"
   - "olamy"
-  - "mramonleon"
 cd:
   enabled: true

--- a/permissions/plugin-ace-editor.yml
+++ b/permissions/plugin-ace-editor.yml
@@ -9,7 +9,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-active-directory.yml
+++ b/permissions/plugin-active-directory.yml
@@ -11,7 +11,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
   - "carroll"
   - "teilo"

--- a/permissions/plugin-antisamy-markup-formatter.yml
+++ b/permissions/plugin-antisamy-markup-formatter.yml
@@ -11,7 +11,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-apache-httpcomponents-client-4-api.yml
+++ b/permissions/plugin-apache-httpcomponents-client-4-api.yml
@@ -10,7 +10,6 @@ cd:
 developers:
   - "oleg_nenashev"
   - "dnusbaum"
-  - "mramonleon"
   - "carroll"
   - "teilo"
   - "rsandell"

--- a/permissions/plugin-async-http-client.yml
+++ b/permissions/plugin-async-http-client.yml
@@ -10,7 +10,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-authentication-tokens.yml
+++ b/permissions/plugin-authentication-tokens.yml
@@ -12,7 +12,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
   - "jglick"
   - "teilo"

--- a/permissions/plugin-bootstrap.yml
+++ b/permissions/plugin-bootstrap.yml
@@ -9,7 +9,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-caffeine-api.yml
+++ b/permissions/plugin-caffeine-api.yml
@@ -8,7 +8,6 @@ developers:
   - "rsandell"
   - "carroll"
   - "olamy"
-  - "mramonleon"
   - "alecharp"
   - "bitwiseman"
 issues:

--- a/permissions/plugin-cloudbees-folder.yml
+++ b/permissions/plugin-cloudbees-folder.yml
@@ -19,7 +19,6 @@ developers:
   - "batmat"
   - "bitwiseman"
   - "carroll"
-  - "mramonleon"
   - "olamy"
   - "teilo"
 security:

--- a/permissions/plugin-cloverphp.yml
+++ b/permissions/plugin-cloverphp.yml
@@ -10,7 +10,6 @@ developers:
   - "batmat"
   - "bitwiseman"
   - "carroll"
-  - "mramonleon"
   - "olamy"
   - "rsandell"
   - "teilo"

--- a/permissions/plugin-command-launcher.yml
+++ b/permissions/plugin-command-launcher.yml
@@ -10,7 +10,6 @@ cd:
 developers:
   - "jglick"
   - "oleg_nenashev"
-  - "mramonleon"
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-config-file-provider.yml
+++ b/permissions/plugin-config-file-provider.yml
@@ -12,7 +12,6 @@ developers:
   - "egutierrez"
   - "alecharp"
   - "batmat"
-  - "mramonleon"
   - "rsandell"
   - "jm_meessen"
 security:

--- a/permissions/plugin-deployer-framework.yml
+++ b/permissions/plugin-deployer-framework.yml
@@ -10,7 +10,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
   - "carroll"
   - "olamy"

--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -18,7 +18,6 @@ developers:
   - "teilo"
   - "batmat"
   - "olamy"
-  - "mramonleon"
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-ec2.yml
+++ b/permissions/plugin-ec2.yml
@@ -10,7 +10,6 @@ developers:
   - "julienduchesne"
   - "fcojfernandez"
   - "raihaan"
-  - "mramonleon"
   - "froblesmartin"
 security:
   contacts:

--- a/permissions/plugin-emma.yml
+++ b/permissions/plugin-emma.yml
@@ -10,7 +10,6 @@ developers:
   - "batmat"
   - "bitwiseman"
   - "carroll"
-  - "mramonleon"
   - "olamy"
   - "rsandell"
   - "teilo"

--- a/permissions/plugin-external-monitor-job.yml
+++ b/permissions/plugin-external-monitor-job.yml
@@ -13,7 +13,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-git-server.yml
+++ b/permissions/plugin-git-server.yml
@@ -13,7 +13,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-handlebars.yml
+++ b/permissions/plugin-handlebars.yml
@@ -9,7 +9,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-jackson2-api.yml
+++ b/permissions/plugin-jackson2-api.yml
@@ -15,7 +15,6 @@ developers:
   - "rsandell"
   - "carroll"
   - "olamy"
-  - "mramonleon"
   - "bitwiseman"
 security:
   contacts:

--- a/permissions/plugin-jdk-tool.yml
+++ b/permissions/plugin-jdk-tool.yml
@@ -12,7 +12,6 @@ developers:
   - "jglick"
   - "oleg_nenashev"
   - "aheritier"
-  - "mramonleon"
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-jquery-detached.yml
+++ b/permissions/plugin-jquery-detached.yml
@@ -9,7 +9,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-junit.yml
+++ b/permissions/plugin-junit.yml
@@ -16,7 +16,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
   - "timja"
 security:

--- a/permissions/plugin-matrix-project.yml
+++ b/permissions/plugin-matrix-project.yml
@@ -12,7 +12,6 @@ developers:
   - "oleg_nenashev"
   - "olivergondza"
   - "batmat"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -13,7 +13,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
   - "dnusbaum"
   - "markewaite"

--- a/permissions/plugin-momentjs.yml
+++ b/permissions/plugin-momentjs.yml
@@ -9,7 +9,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-msbuild.yml
+++ b/permissions/plugin-msbuild.yml
@@ -8,7 +8,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/msbuild"
 developers:
-  - "mramonleon"
   - "batmat"
   - "rsandell"
   - "bitwiseman"

--- a/permissions/plugin-node-iterator-api.yml
+++ b/permissions/plugin-node-iterator-api.yml
@@ -9,7 +9,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
   - "teilo"
 security:

--- a/permissions/plugin-numeraljs.yml
+++ b/permissions/plugin-numeraljs.yml
@@ -9,7 +9,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-s3.yml
+++ b/permissions/plugin-s3.yml
@@ -16,7 +16,6 @@ developers:
   - "fcojfernandez"
   - "alecharp"
   - "batmat"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-ssh-agent.yml
+++ b/permissions/plugin-ssh-agent.yml
@@ -14,7 +14,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -14,7 +14,6 @@ developers:
   - "escoem"
   - "dnusbaum"
   - "egutierrez"
-  - "mramonleon"
   - "allan_burdajewicz"
 security:
   contacts:

--- a/permissions/plugin-suppress-stack-trace.yml
+++ b/permissions/plugin-suppress-stack-trace.yml
@@ -11,7 +11,6 @@ developers:
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:

--- a/permissions/plugin-windows-slaves.yml
+++ b/permissions/plugin-windows-slaves.yml
@@ -14,7 +14,6 @@ developers:
   - "carroll"
   - "bitwiseman"
   - "olamy"
-  - "mramonleon"
   - "poddingue"
 security:
   contacts:

--- a/permissions/pom-js-module-base.yml
+++ b/permissions/pom-js-module-base.yml
@@ -5,7 +5,6 @@ paths:
   - "org/jenkins-ci/ui/jenkins-js-libs"
 developers:
   - "batmat"
-  - "mramonleon"
   - "rsandell"
 security:
   contacts:


### PR DESCRIPTION
# Remove mramonleon as a maintainer

I asked Manuel Ramón León Jiménez if he was willing to be removed as a plugin maintainer since he has not been active in the Jenkins project for several years.  He replied:

> Hi Mark, good to hear from you. Be free to remove me from them all.

This pull request removes mramonleon from all Jenkins plugins.

# Link to GitHub repository

* component-async-http-client
* component-lib-durable-task
* plugin-ace-editor
* plugin-active-directory
* plugin-antisamy-markup-formatter
* plugin-apache-httpcomponents-client-4-api
* plugin-async-http-client
* plugin-authentication-tokens
* plugin-bootstrap
* plugin-caffeine-api
* plugin-cloudbees-folder
* plugin-cloverphp
* plugin-command-launcher
* plugin-config-file-provider
* plugin-deployer-framework
* plugin-durable-task
* plugin-ec2
* plugin-emma
* plugin-external-monitor-job
* plugin-git-server
* plugin-handlebars
* plugin-jackson2-api
* plugin-jdk-tool
* plugin-jquery-detached
* plugin-junit
* plugin-matrix-project
* plugin-mercurial
* plugin-momentjs
* plugin-msbuild
* plugin-node-iterator-api
* plugin-numeraljs
* plugin-s3
* plugin-ssh-agent
* plugin-support-core
* plugin-suppress-stack-trace
* plugin-windows-slaves
* pom-js-module-base

# When modifying release permission

See the lists inside the individual files.

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
