### PR TITLE
Additional maintainer for plugin-configuration-as-code-groovy.yml

### DIFF
--- a/permissions/plugin-configuration-as-code-groovy.yml
+++ b/permissions/plugin-configuration-as-code-groovy.yml
@@ -8,3 +8,4 @@ paths:
 developers:
   - "szandala"
   - "jetersen"
+  - "pascalhofmann"


### PR DESCRIPTION
@jetersen @szandala 

# Link to GitHub repository

[<!-- Provide a link to the plugin or component repository you want to modify -->](https://github.com/jenkinsci/configuration-as-code-groovy-plugin)

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@pascal-hofmann`


This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
