### PR TITLE
Fix YAML reference syntax

### DIFF
--- a/permissions/plugin-database.yml
+++ b/permissions/plugin-database.yml
@@ -1,6 +1,6 @@
 ---
 name: "database"
-&GH github: "jenkinsci/database-plugin"
+github: &GH "jenkinsci/database-plugin"
 issues:
   - github: *GH
 paths:


### PR DESCRIPTION
Fixes a typo that results in a console warning:

> Unexpected GitHub repo for issue tracker, skipping: null

CC @timja @davidvanlaatum 