### PR TITLE
Add all artifacts to maintainers and issue lists when wildcard is used

### DIFF
--- a/permissions/plugin-aws-java-sdk.yml
+++ b/permissions/plugin-aws-java-sdk.yml
@@ -6,6 +6,29 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/aws-java-sdk"
   - "org/jenkins-ci/plugins/aws-java-sdk/aws-java-sdk-*"
+extraNames:
+  - aws-java-sdk-api-gateway
+  - aws-java-sdk-autoscaling
+  - aws-java-sdk-cloudformation
+  - aws-java-sdk-cloudfront
+  - aws-java-sdk-codebuild
+  - aws-java-sdk-codedeploy
+  - aws-java-sdk-ec2
+  - aws-java-sdk-ecr
+  - aws-java-sdk-ecs
+  - aws-java-sdk-efs
+  - aws-java-sdk-elasticbeanstalk
+  - aws-java-sdk-elasticloadbalancingv2
+  - aws-java-sdk-iam
+  - aws-java-sdk-kinesis
+  - aws-java-sdk-lambda
+  - aws-java-sdk-logs
+  - aws-java-sdk-minimal
+  - aws-java-sdk-organizations
+  - aws-java-sdk-secretsmanager
+  - aws-java-sdk-sns
+  - aws-java-sdk-sqs
+  - aws-java-sdk-ssm
 cd:
   enabled: true
 developers:

--- a/permissions/plugin-gcp-java-sdk.yml
+++ b/permissions/plugin-gcp-java-sdk.yml
@@ -4,6 +4,9 @@ github: &GH "jenkinsci/gcp-java-sdk-plugin"
 paths:
 - "io/jenkins/plugins/gcp-java-sdk"
 - "io/jenkins/plugins/gcp-java-sdk-*"
+extraNames:
+- gcp-java-sdk-auth
+- gcp-java-sdk-storage
 developers:
 - "aneveux"
 - "@cloudbees-developers"

--- a/permissions/plugin-mina-sshd-api.yml
+++ b/permissions/plugin-mina-sshd-api.yml
@@ -3,6 +3,11 @@ name: "mina-sshd-api"
 github: &GH "jenkinsci/mina-sshd-api-plugin"
 paths:
   - "io/jenkins/plugins/mina-sshd-api/mina-sshd-api-*"
+extraNames:
+  - "mina-sshd-api-common"
+  - "mina-sshd-api-core"
+  - "mina-sshd-api-scp"
+  - "mina-sshd-api-sftp"
 cd:
   enabled: true
 developers:

--- a/permissions/plugin-remoting-opentelemetry.yml
+++ b/permissions/plugin-remoting-opentelemetry.yml
@@ -2,7 +2,8 @@
 name: "remoting-opentelemetry"
 github: &GH "jenkinsci/remoting-opentelemetry-plugin"
 paths:
-  - "io/jenkins/plugins/remoting-opentelemetry*"
+  - "io/jenkins/plugins/remoting-opentelemetry"
+  - "io/jenkins/plugins/remoting-opentelemetry-*"
 developers:
   - "aki7m"
   - "oleg_nenashev"

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -123,6 +123,7 @@ public class Definition {
     private String[] paths = new String[0];
     private String[] developers = new String[0];
     private IssueTracker[] issues = new IssueTracker[0];
+    private String[] extraNames = new String[0];
 
     private String github;
 
@@ -151,6 +152,14 @@ public class Definition {
 
     public void setPaths(String[] paths) {
         this.paths = paths.clone();
+    }
+
+    public void setExtraNames(String[] extraNames) {
+        this.extraNames = extraNames.clone();
+    }
+
+    public String[] getExtraNames() {
+        return extraNames.clone();
     }
 
     public IssueTracker[] getIssues() {


### PR DESCRIPTION
Fixes #2911 

Allows each component to define extra artifact names, those then inherit the same maintainers and issue tracker(s) as the parent component.

A more straightforward approach might be to just define `paths` explicitly for each component without using *, but since the last element of path sometimes doesn't match the component name and the component name takes precedence, I decided to add a new field to Definition for defining the extra components.