### PR TITLE
Enable CD on plugin-flaky-test-handler.yml

### DIFF
--- a/permissions/plugin-flaky-test-handler.yml
+++ b/permissions/plugin-flaky-test-handler.yml
@@ -8,3 +8,5 @@ paths:
 developers:
   - "svenjost"
   - "vtintillier"
+cd:
+  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/flaky-test-handler-plugin/

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

I unfortunately merged the PR for enabling already because in section https://www.jenkins.io/doc/developer/publishing/releasing-cd/#update-maven-pom-and-config it says "Merge this PR activating CD".

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/flaky-test-handler-plugin/pull/31

```[tasklist]
### CD checklist (for submitters)
- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
