### PR TITLE
Add `basil` to `maven-plugin`

### DIFF
--- a/permissions/plugin-maven-plugin.yml
+++ b/permissions/plugin-maven-plugin.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/main/maven-plugin"
   - "org/jvnet/hudson/main/maven-plugin"
 developers:
+  - "basil"
   - "integer"
   - "kohsuke"
   - "olamy"


### PR DESCRIPTION
@olamy I would like to ensure that https://github.com/jenkinsci/maven-plugin/pull/345 is released. If you are interested in performing a release, then I do not need release permissions and this PR can simply be closed. If you are not interested in performing a release, then I would like to be added to the Artifactory permissions list so that I can perform a release.

# Link to GitHub repository

https://github.com/jenkinsci/maven-plugin

# When modifying release permission

- @basil

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
