### PR TITLE
Update release permissions for `stapler-maven-plugin`

### DIFF
--- a/permissions/component-stapler-maven-plugin.yml
+++ b/permissions/component-stapler-maven-plugin.yml
@@ -4,6 +4,7 @@ github: &GH "jenkinsci/stapler-maven-plugin"
 issues:
   - github: *GH
 paths:
+  - "io/jenkins/tools/maven"
   - "io/jenkins/tools/maven/stapler-maven-plugin"
 cd:
   enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/stapler-maven-plugin

# When modifying release permission

https://github.com/jenkinsci/stapler-maven-plugin/actions/runs/11355448581/job/31584797141 failed with a 403 error. Checking the permissions file, it was missing a path. Compare to e.g. `license-maven-plugin` and `jellydoc-maven-plugin`.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
