### PR TITLE
Add markewaite as ignore-commit-strategy maintainer

### DIFF
--- a/permissions/plugin-ignore-committer-strategy.yml
+++ b/permissions/plugin-ignore-committer-strategy.yml
@@ -7,3 +7,4 @@ paths:
   - "au/com/versent/jenkins/plugins/ignore-committer-strategy"
 developers:
   - "bb3rn4rd"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as ignore-commit-strategy maintainer

[PR-10](https://github.com/jenkinsci/ignore-committer-strategy-plugin/pull/10) is a pull request to update the plugin to build with Java 11, 17, and 21.  The update adapts the plugin to changes in the branch API that happened in 2019.

The pull request includes a few other pull requests:

* https://github.com/jenkinsci/ignore-committer-strategy-plugin/pull/3
* https://github.com/jenkinsci/ignore-committer-strategy-plugin/pull/5
* https://github.com/jenkinsci/ignore-committer-strategy-plugin/pull/7

I don't expect to make significant additional changes, but since I use the plugin and it currently has an implied dependency on a plugin that I would like to remove, I'm willing to adopt it.

@b-b3rn4rd is the current maintainer but has not made any change to the repository in over six years.  @b-b3rn4rd it would be easiest if you approve my adopting the plugin.  Reply with a comment if you approve that I adopt the plugin.

If there is no response to that mention, then the regular adoption process will allow me to adopt it in two weeks.

# Link to GitHub repository

https://github.com/jenkinsci/ignore-committer-strategy-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@MarkEWaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
