### PR TITLE
Change Defensics groupId path to io.jenkins.plugins

### DIFF
--- a/permissions/plugin-defensics.yml
+++ b/permissions/plugin-defensics.yml
@@ -4,7 +4,7 @@ github: "jenkinsci/defensics-plugin"
 issues:
   - jira: '27252'  # defensics-plugin
 paths:
-  - "com/synopsys/defensics"
+  - "io/jenkins/plugins/defensics"
 developers:
   - "defensics_oss"
   - "synhal"


### PR DESCRIPTION
The former Synopsys Software Integrity Group is [now its own company](https://www.blackduck.com/blog/our-new-beginning-as-black-duck.html), Black Duck Software, Inc. so the groupId path part needs to change for the next plugin release. 

Based on [Jenkins style guide](https://www.jenkins.io/doc/developer/publishing/style-guides/#group-id)  the recommended groupId is now `io.jenkins.plugins`.

# Link to GitHub repository

https://github.com/jenkinsci/defensics-plugin


# When modifying release permission

**Note:** User list is not changed in this PR. Only change is that some Github usernames have been changed to have bd- (Black Duck) prefix.

List the GitHub usernames of the users who should have commit permissions below:
- @bd-halkoaho
- @bd-mtv
- @defensics-oss

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
