### PR TITLE
fix(component-plugin-modernizer-tool) update GitHub URL following organization migration

### DIFF
--- a/permissions/component-plugin-modernizer-tool.yml
+++ b/permissions/component-plugin-modernizer-tool.yml
@@ -1,6 +1,6 @@
 ---
 name: "plugin-modernizer-tool"
-github: &GH "jenkinsci/plugin-modernizer-tool"
+github: &GH "jenkins-infra/plugin-modernizer-tool"
 issues:
   - github: *GH
 paths:

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -168,7 +168,7 @@ class ArtifactoryPermissionsUpdater {
                 }
             } else {
                 if (definition.cd && definition.getCd().enabled) {
-                    throw new Exception("Cannot have CD ('cd') enabled without specifying GitHub repository ('github')")
+                    throw new Exception("Cannot have CD ('cd') enabled without specifying GitHub repository ('github'), for component: " + definition.name)
                 }
             }
 

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -168,6 +168,7 @@ class ArtifactoryPermissionsUpdater {
                 }
             } else {
                 if (definition.cd && definition.getCd().enabled) {
+                    LOGGER.severe(definition.toString())
                     throw new Exception("Cannot have CD ('cd') enabled without specifying GitHub repository ('github'), for component: " + definition.name)
                 }
             }

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -151,7 +151,7 @@ class ArtifactoryPermissionsUpdater {
                     paths.addAll(definition.paths)
                 }
                 if (definition.cd && definition.getCd().enabled) {
-                    if (!definition.github.matches('(jenkinsci)/.+')) {
+                    if (!definition.github.matches('(jenkinsci|jenkins-infra)/.+')) {
                         throw new Exception("CD is only supported when the GitHub repository is in @jenkinsci")
                     }
                     if (definition.developers.length > 0) {

--- a/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
+++ b/src/main/groovy/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.groovy
@@ -168,7 +168,6 @@ class ArtifactoryPermissionsUpdater {
                 }
             } else {
                 if (definition.cd && definition.getCd().enabled) {
-                    LOGGER.severe(definition.toString())
                     throw new Exception("Cannot have CD ('cd') enabled without specifying GitHub repository ('github'), for component: " + definition.name)
                 }
             }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -16,36 +16,14 @@ public class Definition {
     public static class CD {
         public boolean enabled;
         public boolean exclusive = true;
-
-        @Override
-        public String toString() {
-            return "CD{" +
-                    "enabled=" + enabled +
-                    ", exclusive=" + exclusive +
-                    '}';
-        }
     }
 
     public static class Security {
         public SecurityContacts contacts;
-
-        @Override
-        public String toString() {
-            return "Security{" +
-                    "contacts=" + contacts +
-                    '}';
-        }
     }
 
     public static class SecurityContacts {
         public String jira;
-
-        @Override
-        public String toString() {
-            return "SecurityContacts{" +
-                    "jira='" + jira + '\'' +
-                    '}';
-        }
     }
 
     /**
@@ -79,7 +57,7 @@ public class Definition {
             if (github == null) {
                 return false;
             }
-            if (!github.startsWith("jenkinsci/")) {
+            if (!(github.startsWith("jenkinsci/") || github.startsWith("jenkins-infra/"))) {
                 LOGGER.log(Level.INFO, "Unexpected GitHub repo for issue tracker, skipping: " + jira);
                 return false;
             }
@@ -140,15 +118,6 @@ public class Definition {
                 return "github";
             }
             throw new IllegalStateException("Invalid issue tracker: " + github + " / " + jira);
-        }
-
-        @Override
-        public String toString() {
-            return "IssueTracker{" +
-                    "jira='" + jira + '\'' +
-                    ", github='" + github + '\'' +
-                    ", report=" + report +
-                    '}';
         }
     }
 
@@ -229,16 +198,9 @@ public class Definition {
     }
 
     public String getGithub() {
-        if (github != null && github.startsWith("jenkinsci/")) {
+        if (github != null && (github.startsWith("jenkinsci/") || github.startsWith("jenkins-infra/"))) {
             return github;
         }
         return null;
-    }
-
-    @Override
-    public String toString() {
-        return MessageFormat
-                .format("Definition'{'name=''{0}'', paths={1}, developers={2}, issues={3}, extraNames={4}, releaseBlocked={5}, github=''{6}'', cd={7}, security={8}'}'",
-                        name, Arrays.toString(paths), Arrays.toString(developers), Arrays.toString(issues), Arrays.toString(extraNames), releaseBlocked, github, cd, security);
     }
 }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -16,14 +16,36 @@ public class Definition {
     public static class CD {
         public boolean enabled;
         public boolean exclusive = true;
+
+        @Override
+        public String toString() {
+            return "CD{" +
+                    "enabled=" + enabled +
+                    ", exclusive=" + exclusive +
+                    '}';
+        }
     }
 
     public static class Security {
         public SecurityContacts contacts;
+
+        @Override
+        public String toString() {
+            return "Security{" +
+                    "contacts=" + contacts +
+                    '}';
+        }
     }
 
     public static class SecurityContacts {
         public String jira;
+
+        @Override
+        public String toString() {
+            return "SecurityContacts{" +
+                    "jira='" + jira + '\'' +
+                    '}';
+        }
     }
 
     /**
@@ -118,6 +140,15 @@ public class Definition {
                 return "github";
             }
             throw new IllegalStateException("Invalid issue tracker: " + github + " / " + jira);
+        }
+
+        @Override
+        public String toString() {
+            return "IssueTracker{" +
+                    "jira='" + jira + '\'' +
+                    ", github='" + github + '\'' +
+                    ", report=" + report +
+                    '}';
         }
     }
 

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -2,6 +2,8 @@ package io.jenkins.infra.repository_permissions_updater;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -200,5 +202,12 @@ public class Definition {
             return github;
         }
         return null;
+    }
+
+    @Override
+    public String toString() {
+        return MessageFormat
+                .format("Definition'{'name=''{0}'', paths={1}, developers={2}, issues={3}, extraNames={4}, releaseBlocked={5}, github=''{6}'', cd={7}, security={8}'}'",
+                        name, Arrays.toString(paths), Arrays.toString(developers), Arrays.toString(issues), Arrays.toString(extraNames), releaseBlocked, github, cd, security);
     }
 }


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkins-infra/plugin-modernizer-tool


This PR updates the GitHub URL of the repository which has been migrated from `jenkinsci` to `jenkins-infra` GitHub organization as part of https://github.com/jenkins-infra/helpdesk/issues/4262

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
