### PR TITLE
Enable CD for Leastload plugin

### DIFF
--- a/permissions/plugin-leastload.yml
+++ b/permissions/plugin-leastload.yml
@@ -8,3 +8,5 @@ paths:
 developers:
   - "bstick12"
   - "hashar"
+cd:
+  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/leastload-plugin/

### Link to the PR enabling CD in your plugin

The required changes in the plugin repository are proposed in https://github.com/jenkinsci/leastload-plugin/pull/19

### CD checklist (for submitters)
- [X] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 


### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.


