### PR TITLE
Add markewaite as a last-changes plugin maintainer

### DIFF
--- a/permissions/plugin-last-changes.yml
+++ b/permissions/plugin-last-changes.yml
@@ -8,3 +8,4 @@ paths:
   - "org/jenkins-ci/plugins/last-changes"
 developers:
   - "rmpestano"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as a last-changes plugin maintainer

[PR-97](https://github.com/jenkinsci/last-changes-plugin/pull/97) needs to be merged and released so that users of the last-changes plugin are not disrupted when they upgrade to git client 5.0.0 or git client plugin 6.0.0.

The pull request was submitted in September.  There has been no response from @rmpestano to [my question](https://github.com/jenkinsci/last-changes-plugin/pull/97#issuecomment-2440212352).  I assume that @rmpestano is inactive as a maintainer.

That [pull request](https://github.com/jenkinsci/last-changes-plugin/pull/97) is a minimal change that adapts to git client plugin 5.0.0 and later without unnecessary changes.  Other changes to modernize the plugin can be considered once the immediate issue with newer versions of git client plugin has been resolved.

A [modernization pull request](https://github.com/jenkinsci/last-changes-plugin/pull/98) has been submitted that includes several steps to modernize the plugin, though it has not been tested yet.

I don't mind waiting the usual two weeks to adopt the plugin, but it would be nice if @rmpestano could approve this pull request so that I can be added as a maintainer.

# Link to GitHub repository

* https://github.com/jenkinsci/last-changes-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@MarkEWaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
