### PR TITLE
Getting added to the developers plugin-crowdstrike-security

### DIFF
--- a/permissions/plugin-crowdstrike-security.yml
+++ b/permissions/plugin-crowdstrike-security.yml
@@ -7,5 +7,6 @@ developers:
 - "crwd_etatarevic"
 - "crwdsmullz"
 - "crwdlemos"
+- "crwdharshitac"
 issues:
   - github: *GH


### PR DESCRIPTION
List the GitHub usernames of the users who should have commit permissions below:

@crwdharshitac

Existing team members of the plugin to approve this request:
@crwd-etatarevic 
@crwdlemos
This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:
```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

