### PR TITLE
adding crwdasarja as developer to crowdstrike-security plugin

### DIFF
--- a/permissions/plugin-crowdstrike-security.yml
+++ b/permissions/plugin-crowdstrike-security.yml
@@ -5,8 +5,8 @@ paths:
 - "io/jenkins/plugins/crowdstrike-security"
 developers:
 - "crwd_etatarevic"
-- "crwdsmullz"
 - "crwdlemos"
 - "crwdharshitac"
+- "crwdasarja"
 issues:
   - github: *GH


### PR DESCRIPTION
# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->
https://github.com/jenkinsci/crowdstrike-security-plugin

Adding @asarja-crwd as developer to crowdstrike-security plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@crwd-etatarevic` 

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```