### PR TITLE
Revert "Bump org.jenkins-ci:jenkins from 1.123 to 1.126"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.126</version>
+        <version>1.123</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#4192

Breaks the hosting validator, we need to update the maven version on any of the GitHub action workflows, cc @MarkEWaite 