### PR TITLE
Add additional paths to `aws-java-sdk2`

### DIFF
--- a/permissions/plugin-aws-java-sdk2.yml
+++ b/permissions/plugin-aws-java-sdk2.yml
@@ -2,7 +2,35 @@
 name: "aws-java-sdk2"
 github: &GH "jenkinsci/aws-java-sdk2-plugin"
 paths:
-- "io/jenkins/plugins/aws-java-sdk2/aws-java-sdk2-parent"
+  - "io/jenkins/plugins/aws-java-sdk2"
+  - "io/jenkins/plugins/aws-java-sdk2/aws-java-sdk2-*"
+extraNames:
+  - aws-java-sdk2-apigateway
+  - aws-java-sdk2-autoscaling
+  - aws-java-sdk2-cloudformation
+  - aws-java-sdk2-cloudfront
+  - aws-java-sdk2-cloudwatchlogs
+  - aws-java-sdk2-codebuild
+  - aws-java-sdk2-codedeploy
+  - aws-java-sdk2-core
+  - aws-java-sdk2-ec2
+  - aws-java-sdk2-ecr
+  - aws-java-sdk2-ecs
+  - aws-java-sdk2-efs
+  - aws-java-sdk2-elasticbeanstalk
+  - aws-java-sdk2-elasticloadbalancingv2
+  - aws-java-sdk2-iam
+  - aws-java-sdk2-kinesis
+  - aws-java-sdk2-lambda
+  - aws-java-sdk2-organizations
+  - aws-java-sdk2-s3
+  - aws-java-sdk2-secretsmanager
+  - aws-java-sdk2-sns
+  - aws-java-sdk2-sqs
+  - aws-java-sdk2-ssm
+  - aws-java-sdk2-sts
+cd:
+  enabled: true
 developers: []
 issues:
   - jira: 29620


### PR DESCRIPTION
Attempting to model this off the file for `permissions/plugin-aws-java-sdk.yml`:

- Add additional paths
- Add extra names
- Enable CD

# Link to GitHub repository

https://github.com/jenkinsci/aws-java-sdk2-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@username1`
- `@username2`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
