### PR TITLE
Mark cloudbees-bitbucket-branch-source plugin to not use anymore GitHub as issue tracker

### DIFF
--- a/permissions/plugin-cloudbees-bitbucket-branch-source.yml
+++ b/permissions/plugin-cloudbees-bitbucket-branch-source.yml
@@ -4,6 +4,7 @@ github: &gh "jenkinsci/bitbucket-branch-source-plugin"
 issues:
   - jira: '21428'  # bitbucket-branch-source-plugin
   - github: *gh
+    report: false
 paths:
   - "org/jenkins-ci/plugins/cloudbees-bitbucket-branch-source"
 developers:


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/bitbucket-branch-source-plugin

# Reason of changes
Disable Github as issue tracker (at least discourage the use) as discussed in the Jenkins Developer Google Group at https://groups.google.com/g/jenkinsci-dev/c/nE_sQ5CjRxc
