### PR TITLE
Change issue tracker from GitHub to Jira

### DIFF
--- a/permissions/plugin-pull-request-monitoring.yml
+++ b/permissions/plugin-pull-request-monitoring.yml
@@ -8,6 +8,6 @@ developers:
   - "mPokornyETM"
   - "drulli"
 issues:
-  - github: *GH
+  - jira: '29720' # pull-request-monitoring-plugin
 cd:
   enabled: true


### PR DESCRIPTION
Followup to #4223.

I want to change the issue tracker from GitHub to Jira: 
https://github.com/jenkinsci/pull-request-monitoring-plugin

New component: https://issues.jenkins.io/rest/api/2/component/29720

All my other plugins are tracked in Jira as well.

