### PR TITLE
Disable automatic release for bitbucket-branch-source-plugin

### DIFF
--- a/permissions/plugin-cloudbees-bitbucket-branch-source.yml
+++ b/permissions/plugin-cloudbees-bitbucket-branch-source.yml
@@ -20,5 +20,3 @@ developers:
 security:
   contacts:
     jira: "cloudbees_security_members"
-cd:
-  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/bitbucket-branch-source-plugin

I need to disable automatic release becuase:
* I need to test master code in our environment and only after this period that I want to release (actually I  have to create  PR with an interesting tag);
* release will happens because of tag in PRs. But those tag when set by the PR author trigger a release when merge. It has already  happened to me that I didn't remember to check tags at the merge time and a release came out even if I didn't want to;
* in Github commit page I'm not able to understand if a specific commit in which release has been released. I have to choose tag filter than select next or previous tag to see when the commit appear in the list. Manual release using maven plugin add specific commits. Otherwise I have to be behind a PC with a local git client, often I see and respond to the PR or issue using phone.
* actually master is waiting the git-plugin to be released, but I would release an hot fix. Using manual release I can do in a separate branch (support branch for example) using semantic versioning

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
