### PR TITLE
Let markewaite adopt the docker-java-api plugin

### DIFF
--- a/permissions/plugin-docker-java-api.yml
+++ b/permissions/plugin-docker-java-api.yml
@@ -8,5 +8,6 @@ paths:
 developers:
   - "ydubreuil"
   - "ericcitaire"
+  - "markewaite"
 cd:
   enabled: true


### PR DESCRIPTION
## Let markewaite adopt the docker-java-api plugin

The [Docker API plugin](https://plugins.jenkins.io/docker-java-api/) is up for adoption and is a dependency of the [Docker plugin](https://plugins.jenkins.io/docker-plugin/) that I maintain and use.

I'd like to adopt the plugin so that it remains current.

I was involved in the testing of pull request:

* https://github.com/jenkinsci/docker-java-api-plugin/pull/110

Pull requests I've submitted include:

* https://github.com/jenkinsci/docker-java-api-plugin/pull/112
* https://github.com/jenkinsci/docker-java-api-plugin/pull/113
* https://github.com/jenkinsci/docker-java-api-plugin/pull/114

Pull request that will be closed:

* https://github.com/jenkinsci/docker-java-api-plugin/pull/109

# Link to GitHub repository

* https://github.com/jenkinsci/docker-java-api-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- `@markewaite`

Existing team member permission should not be required, since the plugin is up for adoption, but the team members are:

- @ericcitaire
- @ydubreuil

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request. (**N/A because plugin is up for adoption**)
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
