### PR TITLE
Add 'janfaracik' as a maintainer of the 'Build monitor view' plugin

### DIFF
--- a/permissions/plugin-build-monitor-plugin.yml
+++ b/permissions/plugin-build-monitor-plugin.yml
@@ -9,5 +9,6 @@ paths:
 developers:
   - "janmolak"
   - "dcendents"
+  - "janfaracik"
 cd:
   enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/build-monitor-plugin

I've been a long time user of this plugin and myself and my team have found it really helpful for visualising our instance of Jenkins. I'd like to adopt it to ensure that it's maintained/updated for the future. I've been a long time contributor to Jenkins now focusing on UI/UX, and currently own the [Design Library plugin](https://github.com/jenkinsci/design-library-plugin/).

@jan-molak 

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@janfaracik`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
