### PR TITLE
chore(ci): enable permissions for CD workflow

### DIFF
--- a/permissions/plugin-indusface-was.yml
+++ b/permissions/plugin-indusface-was.yml
@@ -7,3 +7,5 @@ developers:
 - "indusface_jenkins_plugin"
 issues:
   - jira: 29722
+cd:
+  enabled: true


### PR DESCRIPTION
### What
This PR updates the configuration to explicitly enable Continuous Deployment (CD) by setting `cd.enabled` to `true`.

### Why
Enabling CD ensures that deployment workflows are active and properly configured for automation, aligning with the project's CI/CD strategy.

### How
- Modified the relevant configuration file to include:
  permissions/plugin-indusface-was.yml
  cd:
    enabled: true
