### PR TITLE
dependency-track-plugin: No longer use Jira as an issue tracker

### DIFF
--- a/permissions/plugin-dependency-track.yml
+++ b/permissions/plugin-dependency-track.yml
@@ -3,6 +3,7 @@ name: "dependency-track"
 github: &gh "jenkinsci/dependency-track-plugin"
 issues:
   - jira: '24428'  # dependency-track-plugin
+    report: false
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/dependency-track"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/dependency-track-plugin

# Changes

Disabled Jira as issue tracker in order to have only one issue tracker. GH issues are preferred because pull requests, issues and code can be easier linked and tracked. In the last four years, [most of the issues where created on GitHub](https://github.com/jenkinsci/dependency-track-plugin/issues?q=is%3Aissue%20-author%3Asephiroth-j), but [only five on Jira](https://issues.jenkins.io/browse/JENKINS-74822?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20dependency-track-plugin%20and%20id%20%3E%20%20JENKINS-64102%20ORDER%20BY%20id%20DESC).