### PR TITLE
Adopt ansible-tower-plugin

### DIFF
--- a/permissions/plugin-ansible-tower.yml
+++ b/permissions/plugin-ansible-tower.yml
@@ -7,4 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/ansible-tower"
 developers:
   - "johnwestcottiv"
-  - "micr0zz" 
+  - "micr0zz"

--- a/permissions/plugin-ansible-tower.yml
+++ b/permissions/plugin-ansible-tower.yml
@@ -7,4 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/ansible-tower"
 developers:
   - "johnwestcottiv"
-  - "micr0zz"
+  - "micr0zz" 

--- a/permissions/plugin-ansible-tower.yml
+++ b/permissions/plugin-ansible-tower.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/ansible-tower"
 developers:
   - "johnwestcottiv"
+  - "micr0zz"

--- a/permissions/plugin-ansible-tower.yml
+++ b/permissions/plugin-ansible-tower.yml
@@ -7,4 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/ansible-tower"
 developers:
   - "johnwestcottiv"
-  - "micr0zz"
+  - "nupinto"


### PR DESCRIPTION
# Link to GitHub repository

Plugin is not up for adoption, but looks very abandoned (no release since 2020, no answer on PR from maintainer, build broken etc...) I would like to refresh it. I have interest to keep maintaining it since I have interest to use it on a daily basis

If I can access to will modernize it further to support Java 17 and 21

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@micr0zz`

FYI @john-westcott-iv 

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

```[tasklist]
### Release permission checklist (for submitters)
- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [X] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [X] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.  
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

```[tasklist]
### CD checklist (for submitters)
- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation. 
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
