### PR TITLE
Remove sag47 from ghprb plugin

### DIFF
--- a/permissions/plugin-ghprb.yml
+++ b/permissions/plugin-ghprb.yml
@@ -10,6 +10,5 @@ developers:
   - "bpatterson"
   - "jpwku"
   - "papajulio"
-  - "sag47"
   - "olivergondza"
   - "krisstern"


### PR DESCRIPTION
## Remove sag47 from ghprb plugin

Jenkins user `sag47` is @samrocketman on GitHub.

https://github.com/jenkins-infra/repository-permissions-updater/pull/4294#issuecomment-2652293145 gives Sam's approval to remove him from this plugin.

# Link to GitHub repository

https://github.com/jenkinsci/ghprb-plugin

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```
There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
