### PR TITLE
Revert "Enable automated plugin release of `pubsub-light`"

### DIFF
--- a/permissions/plugin-pubsub-light.yml
+++ b/permissions/plugin-pubsub-light.yml
@@ -5,8 +5,6 @@ issues:
   - jira: '23040'  # pubsub-light-plugin
 paths:
   - "org/jenkins-ci/plugins/pubsub-light"
-cd:
-  enabled: true
 developers:
   - "michaelneale"
   - "vivek"


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#4319.

Initial pull request was merge without proper acceptance from the plugin maintainers.