### PR TITLE
Revert "Enable automated plugin release of `blueocean-display-url`"

### DIFF
--- a/permissions/plugin-blueocean-display-url.yml
+++ b/permissions/plugin-blueocean-display-url.yml
@@ -5,8 +5,6 @@ issues:
   - jira: '21827'  # blueocean-display-url-plugin
 paths:
   - "org/jenkins-ci/plugins/blueocean-display-url"
-cd:
-  enabled: true
 developers:
   - "michaelneale"
   - "vivek"


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#4321.

Initial pull request was merge without proper acceptance from the plugin maintainers.