### PR TITLE
Revert "Enable automated plugin release of `htmlpublisher`"

### DIFF
--- a/permissions/plugin-htmlpublisher.yml
+++ b/permissions/plugin-htmlpublisher.yml
@@ -6,8 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/htmlpublisher"
   - "org/jvnet/hudson/plugins/htmlpublisher"
-cd:
-  enabled: true
 developers:
   - "mcrooney"
   - "r2b2_nz"


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#4306.

The initial pull request was not approved by any of the maintainers.