### PR TITLE
Enable automated plugin release of `declarative-pipeline-migration-assistant`

### DIFF
--- a/permissions/plugin-declarative-pipeline-migration-assistant-api.yml
+++ b/permissions/plugin-declarative-pipeline-migration-assistant-api.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '27120'  # declarative-pipeline-migration-assistant-plugin
 paths:
   - "org/jenkins-ci/plugins/to-declarative/declarative-pipeline-migration-assistant-api"
+cd:
+  enabled: true
 developers:
   - "abayer"
   - "dnusbaum"

--- a/permissions/plugin-declarative-pipeline-migration-assistant.yml
+++ b/permissions/plugin-declarative-pipeline-migration-assistant.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '27120'  # declarative-pipeline-migration-assistant-plugin
 paths:
   - "org/jenkins-ci/plugins/to-declarative/declarative-pipeline-migration-assistant"
+cd:
+  enabled: true
 developers:
   - "abayer"
   - "dnusbaum"

--- a/permissions/pom-declarative-pipeline-migration-assistant-parent.yml
+++ b/permissions/pom-declarative-pipeline-migration-assistant-parent.yml
@@ -3,6 +3,8 @@ name: "declarative-pipeline-migration-assistant-parent"
 github: "jenkinsci/declarative-pipeline-migration-assistant-plugin"
 paths:
   - "org/jenkins-ci/plugins/to-declarative/declarative-pipeline-migration-assistant-parent"
+cd:
+  enabled: true
 developers:
   - "abayer"
   - "dnusbaum"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@username1`
- `@username2`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin/pull/286

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
