### PR TITLE
 Enable automated plugin release of nested-data-reporting-plugin

### DIFF
--- a/permissions/plugin-nested-data-reporting.yml
+++ b/permissions/plugin-nested-data-reporting.yml
@@ -3,7 +3,10 @@ name: "nested-data-reporting"
 github: &GH "jenkinsci/nested-data-reporting-plugin"
 paths:
   - "io/jenkins/plugins/nested-data-reporting"
+cd:
+  enabled: true
 developers:
   - "simonsymhoven"
+  - "totocaca123"
 issues:
   - github: *GH


### PR DESCRIPTION
I've been the only active maintainer for quite a while and CD based delivery will be easier for me and for others to help maintain the plugin.

# Link to GitHub repository

https://github.com/jenkinsci/nested-data-reporting-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- @totocaca123

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin
CD enabling was directy done on master branch (see related commit) and is currenty active) 1 another commit done later to improve and clean cd file
https://github.com/jenkinsci/nested-data-reporting-plugin/commit/a25b6c188cfba7d852f4504aee5d3d240ab99273

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
