### PR TITLE
Update plugin-vmanager-plugin.yml

### DIFF
--- a/permissions/plugin-vmanager-plugin.yml
+++ b/permissions/plugin-vmanager-plugin.yml
@@ -5,5 +5,7 @@ issues:
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/vmanager-plugin"
+cd:
+  enabled: true
 developers:
   - "tyanai"


### PR DESCRIPTION
Enabling CD only.

# Link to GitHub repository for the master plugin:
https://github.com/jenkinsci/vmanager-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@tyanai`

(No change here)

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/vmanager-plugin/tree/Working-Branch

### CD checklist (for submitters)

- [Yes] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
