### PR TITLE
add new checks to the Hosting Checker

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/ConditionChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/ConditionChecker.java
@@ -12,24 +12,6 @@ public abstract class ConditionChecker {
     public abstract boolean checkCondition(HostingRequest issue) throws IOException;
 
     protected boolean fileExistsInForkFrom(HostingRequest issue, String fileName) throws IOException {
-        boolean res = false;
-        GitHub github = GitHub.connect();
-        String forkFrom = issue.getRepositoryUrl();
-
-        if (StringUtils.isNotBlank(forkFrom)) {
-            Matcher m = Pattern.compile("(?:https://github\\.com/)?(\\S+)/(\\S+)", Pattern.CASE_INSENSITIVE).matcher(forkFrom);
-            if (m.matches()) {
-                String owner = m.group(1);
-                String repoName = m.group(2);
-
-                GHRepository repo = github.getRepository(owner + "/" + repoName);
-                try {
-                    GHContent file = repo.getFileContent(fileName);
-                    res = file != null && file.isFile();
-                } catch (IOException ignored) {
-                }
-            }
-        }
-        return res;
+        return HostingChecker.fileExistsInRepo(issue, fileName);
     }
 }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GitHubVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GitHubVerifier.java
@@ -7,15 +7,20 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHLicense;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.PagedIterator;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class GitHubVerifier implements Verifier {
+
+    private static final String UNWANTED_FILES = "It was detected that you have files in the `%s` folder or that you had in the past files in that folder. " +
+            "Please remove the `target` folder and also rewrite the git history to never have contained any files in the `%s` folder.";
     @Override
     public void verify(HostingRequest request, HashSet<VerificationMessage> hostingIssues) throws IOException {
         GitHub github = GitHub.connect();
@@ -66,53 +71,95 @@ public class GitHubVerifier implements Verifier {
                 }
 
                 if (repo != null) {
-                    try {
-                        GHContent readme = repo.getReadme();
-                        if(readme == null) {
-                            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a readme file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
-                        }
-                    } catch (IOException e) {
-                        hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a readme file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
-                    }
-
-                    try {
-                        GHLicense license = repo.getLicense();
-                        if(license == null) {
-                            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a license file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
-                        }
-                    } catch(IOException e) {
-                        hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a license file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
-                    }
-
-                    // check if the repo was originally forked from jenkinsci
-                    try {
-                        GHRepository parent = repo.getParent();
-                        if (parent != null && parent.getFullName().startsWith("jenkinsci")) {
-                            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Repository '%s' is currently showing as forked from a jenkinsci org repository, this relationship needs to be broken", forkFrom));
-                        }
-                    } catch (IOException e) {
-
-                    }
-
-                    // now need to check if there are any forks INTO jenkinsci already from this repo
-                    try {
-                        List<String> badForks = new ArrayList<>();
-                        for (GHRepository fork : repo.listForks()) {
-                            if (fork.getFullName().startsWith("jenkinsci")) {
-                                badForks.add(fork.getFullName());
-                            }
-                        }
-
-                        if (badForks.size() > 0) {
-                            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Repository '%s' already has the following forks in the jenkinsci org: %s", forkFrom, String.join(", ", badForks)));
-                        }
-                    } catch (Exception e) {
-                        // need to try this out to see what type of exceptions might occur
-                    }
+                    checkReadme(repo, hostingIssues);
+                    checkLicense(repo, hostingIssues);
+                    checkForkedFromJenkinsCi(repo, hostingIssues, forkFrom);
+                    checkForkedIntoJenkinsCi(repo, hostingIssues, forkFrom);
+                    checkUnwantedFiles(repo, hostingIssues);
                 }
             } else {
                 hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, HostingChecker.INVALID_FORK_FROM, forkFrom));
             }
+        }
+    }
+
+
+    private void checkForkedIntoJenkinsCi(GHRepository repo, HashSet<VerificationMessage> hostingIssues, String forkFrom) {
+        // now need to check if there are any forks INTO jenkinsci already from this repo
+        try {
+            List<String> badForks = new ArrayList<>();
+            for (GHRepository fork : repo.listForks()) {
+                if (fork.getFullName().startsWith("jenkinsci")) {
+                    badForks.add(fork.getFullName());
+                }
+            }
+
+            if (badForks.size() > 0) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Repository '%s' already has the following forks in the jenkinsci org: %s", forkFrom, String.join(", ", badForks)));
+            }
+        } catch (Exception e) {
+            // need to try this out to see what type of exceptions might occur
+        }
+    }
+
+    private void checkForkedFromJenkinsCi(GHRepository repo, HashSet<VerificationMessage> hostingIssues, String forkFrom) {
+        // check if the repo was originally forked from jenkinsci
+        try {
+            GHRepository parent = repo.getParent();
+            if (parent != null && parent.getFullName().startsWith("jenkinsci")) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Repository '%s' is currently showing as forked from a jenkinsci org repository, this relationship needs to be broken", forkFrom));
+            }
+        } catch (IOException e) {
+
+        }
+    }
+
+    private void checkLicense(GHRepository repo, HashSet<VerificationMessage> hostingIssues) {
+        try {
+            GHLicense license = repo.getLicense();
+            if(license == null) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a license file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
+            }
+        } catch(IOException e) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a license file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
+        }
+    }
+
+    private void checkReadme(GHRepository repo, HashSet<VerificationMessage> hostingIssues) {
+        try {
+            GHContent readme = repo.getReadme();
+            if(readme == null) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a readme file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
+            }
+        } catch (IOException e) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please add a readme file to your repo, GitHub provides an easy mechanism to do this from their user interface."));
+        }
+    }
+
+    private void checkUnwantedFiles(GHRepository repo, HashSet<VerificationMessage> hostingIssues) {
+        boolean foundTargetFolder = false;
+        boolean foundWorkFolder = false;
+        for (GHCommit commit : repo.listCommits()) {
+            try {
+                List<GHCommit.File> files = commit.listFiles().toList();
+                if (files.stream().anyMatch(file -> file.getFileName().startsWith("target/"))) {
+                    foundTargetFolder = true;
+                }
+                if (files.stream().anyMatch(file -> file.getFileName().startsWith("work/"))) {
+                    foundWorkFolder = true;
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            if (foundTargetFolder && foundWorkFolder) {
+                break;
+            }
+        }
+        if (foundTargetFolder) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, UNWANTED_FILES, "target", "target"));
+        }
+        if (foundWorkFolder) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, UNWANTED_FILES, "work", "work"));
         }
     }
 }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -27,7 +27,7 @@ public class HostingChecker {
 
     public static final String INVALID_FORK_FROM = "Repository URL '%s' is not a valid GitHub repository (check that you do not have .git at the end, GitHub API doesn't support this).";
 
-    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 452, 4);
+    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 479, 3);
 
     public static void main(String[] args) throws IOException {
         new HostingChecker().checkRequest(Integer.parseInt(args[0]));

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -27,7 +27,7 @@ public class HostingChecker {
 
     public static final String INVALID_FORK_FROM = "Repository URL '%s' is not a valid GitHub repository (check that you do not have .git at the end, GitHub API doesn't support this).";
 
-    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 440, 3);
+    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 452, 4);
 
     public static void main(String[] args) throws IOException {
         new HostingChecker().checkRequest(Integer.parseInt(args[0]));
@@ -45,6 +45,7 @@ public class HostingChecker {
         verifications.add(Triplet.with("Maven", new MavenVerifier(), new FileExistsConditionChecker("pom.xml")));
         verifications.add(Triplet.with("JenkinsProjectUsers", new JenkinsProjectUserVerifier(), null));
         verifications.add(Triplet.with("Jelly", new JellyVerifier(), null));
+        verifications.add(Triplet.with("RequiredFiles", new RequiredFilesVerifier(), null));
 
         final HostingRequest hostingRequest = HostingRequestParser.retrieveAndParse(issueID);
 

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
@@ -347,9 +347,6 @@ public class MavenVerifier implements BuildSystemVerifier {
             if (!expected.equals(artifactId)) {
                 hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The artifactId `%s` of the bom is not in sync with the jenkins baseline version `%s`", artifactId, jenkinsVersion.baseline()));
             }
-            if (!model.getProperties().containsKey("jenkins.baseline")) {
-                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "When using the bom, make sure to also set the property `jenkins.baseline` and use this property in `jenkins.version` and the artifactId of the bom."));
-            }
         }
     }
 
@@ -361,6 +358,9 @@ public class MavenVerifier implements BuildSystemVerifier {
                 hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please remove the property `%s` from the pom.xml. It is already defined via the parent pom.", p));
             }
         });
+        if (!props.containsKey("jenkins.baseline")) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Please define the property `jenkins.baseline` and use this property in `<jenkins.version>${jenkins.baseline}.3</jenkins.version>` and the artifactId of the bom."));
+        }
     }
 
     private void checkDependencies(Model model, HashSet<VerificationMessage> hostingIssues) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
@@ -1,0 +1,86 @@
+package io.jenkins.infra.repository_permissions_updater.hosting;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHFileNotFoundException;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
+public class RequiredFilesVerifier implements Verifier {
+
+    @Override
+    public void verify(HostingRequest request, HashSet<VerificationMessage> hostingIssues) throws IOException {
+
+        GitHub github = GitHub.connect();
+        String forkFrom = request.getRepositoryUrl();
+        String forkTo = request.getNewRepoName();
+
+        if (StringUtils.isNotBlank(forkFrom)) {
+            Matcher m = Pattern.compile("(?:https://github\\.com/)?(\\S+)/(\\S+)", CASE_INSENSITIVE).matcher(forkFrom);
+            if(m.matches()) {
+                String owner = m.group(1);
+                String repoName = m.group(2);
+
+                GHRepository repo = github.getRepository(owner + "/" + repoName);
+                checkJenkinsfile(repo, hostingIssues);
+                checkSecurityScan(repo, hostingIssues);
+                checkCodeOwners(repo, hostingIssues, forkTo);
+            }
+        }
+    }
+
+    private void checkCodeOwners(GHRepository repo, HashSet<VerificationMessage> hostingIssues, String forkTo) throws IOException {
+        String expected = "* @jenkinsci/" + forkTo + "-developers";
+        GHContent file = null;
+        try {
+            file = repo.getFileContent(".github/CODEOWNERS");
+        } catch (GHFileNotFoundException e) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Missing file `.github/CODEOWNERS`. Please add this file containing the line: `" + expected + "`"));
+            return;
+        }
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(file.read()));
+        if (bufferedReader.lines().noneMatch(line -> line.equals(expected))) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The file `.github/CODEOWNERS` doesn't contain the expected line `" + expected + "`"));
+        }
+    }
+
+    private void checkJenkinsfile(GHRepository repo, HashSet<VerificationMessage> hostingIssues) throws IOException {
+        GHContent file = null;
+        try {
+            file = repo.getFileContent("Jenkinsfile");
+        } catch (GHFileNotFoundException e) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Missing `Jenkinsfile`. Please add a Jenkinsfile to your repo so it can be built on ci.jenkins.io. A suitable version can downloaded [here](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile)"));
+            return;
+        }
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(file.read()));
+        if (bufferedReader.lines().noneMatch(line -> line.startsWith("buildPlugin("))) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It seems your `Jenkinsfile` is not calling `buildPlugin`. "));
+        }
+    }
+
+
+    private void checkSecurityScan(GHRepository repo, HashSet<VerificationMessage> hostingIssues) throws IOException {
+        if (fileNotExistsInRepo(repo, ".github/workflows/jenkins-security-scan.yml") &&
+                fileNotExistsInRepo(repo, ".github/workflows/jenkins-security-scan.yaml")) {
+            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Missing file `.github/workflows/jenkins-security-scan.yml`. This file helps to keep your plugin conform to security standards defined by the Jenkins project." +
+                    " You can download it from [here](https://github.com/jenkinsci/archetypes/blob/master/common-files/.github/workflows/jenkins-security-scan.yml)"));
+        }
+    }
+
+    private boolean fileNotExistsInRepo(GHRepository repo, String fileName) throws IOException {
+        try {
+            GHContent file = repo.getFileContent(fileName);
+            return file == null || !file.isFile();
+        } catch (GHFileNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
@@ -3,6 +3,7 @@ package io.jenkins.infra.repository_permissions_updater.hosting;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,9 +47,10 @@ public class RequiredFilesVerifier implements Verifier {
             hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Missing file `.github/CODEOWNERS`. Please add this file containing the line: `" + expected + "`"));
             return;
         }
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(file.read()));
-        if (bufferedReader.lines().noneMatch(line -> line.equals(expected))) {
-            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The file `.github/CODEOWNERS` doesn't contain the expected line `" + expected + "`"));
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(file.read(), StandardCharsets.UTF_8))) {
+            if (bufferedReader.lines().noneMatch(line -> line.equals(expected))) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "The file `.github/CODEOWNERS` doesn't contain the expected line `" + expected + "`"));
+            }
         }
     }
 
@@ -60,9 +62,10 @@ public class RequiredFilesVerifier implements Verifier {
             hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Missing `Jenkinsfile`. Please add a Jenkinsfile to your repo so it can be built on ci.jenkins.io. A suitable version can downloaded [here](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile)"));
             return;
         }
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(file.read()));
-        if (bufferedReader.lines().noneMatch(line -> line.startsWith("buildPlugin("))) {
-            hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It seems your `Jenkinsfile` is not calling `buildPlugin`. "));
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(file.read(), StandardCharsets.UTF_8))) {
+            if (bufferedReader.lines().noneMatch(line -> line.startsWith("buildPlugin("))) {
+                hostingIssues.add(new VerificationMessage(VerificationMessage.Severity.REQUIRED, "It seems your `Jenkinsfile` is not calling `buildPlugin`. "));
+            }
         }
     }
 


### PR DESCRIPTION
Addressing some of points mentioned in #4133 and some other improvements

- fix bug with the new jenkins.baseline property. The maven Model is not replacing properties, so the jenkins.version would contain `${jenkins.baseline}` and the version check is skipped.
- checks that there is no developers section in the pom
- checks that when plugins are imported that a dependencyManagement section is defined, logged as warning
- checks that when a dependencyManagement section is defined, plugin imports don't have a version (might not be 100% accurate if a plugin import is not in the bom, so only logged as info)
- when a dependencyManagement is present and contains a bom check that the version in the artifactId is in sync with the jenkins.version and that the jenkins.baseline property is used.
- checks for the existence of `Jenkinsfile` in the repo and that it contains a line that starts with `buildPlugin(`
- checks for the existence of a jenkins-security-scan yaml file in .github/workflows
- checks for the existence of a CODEOWNERS file and that it contains the expected line
- checks for the existence of `.gitignore`  and that it excludes `target` and `work`
- checks that `target` and `work` have never been checked in to the repo
- Increase minimum Jenkins version to 2.452.4
- Increase minimum parent pom to 4.88

tested against some open hosting requests and verified that the checks work as expected

fixes #2310 
fixes #2311


