### PR TITLE
Enable test-results-analyzer plugin continuous delivery

### DIFF
--- a/permissions/plugin-test-results-analyzer.yml
+++ b/permissions/plugin-test-results-analyzer.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '19327'  # test-results-analyzer-plugin
 paths:
   - "org/jenkins-ci/plugins/test-results-analyzer"
+cd:
+  enabled: true
 developers:
   - "menonvarun"
   - "poddingue"


### PR DESCRIPTION
## Enable test-results-analyzer plugin continuous delivery

Need to release a version that uses Jakarta EE 9 and requires Jenkins 2.479.3 or newer.

# Link to GitHub repository

* https://github.com/jenkinsci/test-results-analyzer-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- N/A

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)

- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

* https://github.com/jenkinsci/test-results-analyzer-plugin/pull/136

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
