### PR TITLE
Add permission file for playwright-e2e-test plugin

### DIFF
--- a/permissions/plugin-playwright-e2e-test.yaml
+++ b/permissions/plugin-playwright-e2e-test.yaml
@@ -1,0 +1,10 @@
+---
+name: "playwright-e2e-test"
+github: "jenkinsci/playwright-e2e-test-plugin"
+developers:
+  - KWY97
+  - Shbak111
+  - Airdexx
+  - 3957ki
+  - dmswjdsz
+  - 98silverline


### PR DESCRIPTION
# Link to GitHub repository  
https://github.com/KWY97/playwright-e2e-test-plugin

# Developers with release permissions  
- @KWY97  
- @Shbak111  
- @Airdexx  
- @3957ki  
- @dmswjdsz  
- @98silverline  

We are requesting hosting and release permissions for the `playwright-e2e-test` plugin.  
All listed users are part of the development team and have write access to the GitHub repository.
