### PR TITLE
Update guidance on leaving the fork network

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -140,7 +140,7 @@ public class Hoster {
                     + issueTrackerText
                     + prDescription
                     + "\n\nPlease [delete your original repository](" + forkFrom + "/settings?confirm_delete=yes) (if there are no other forks), under 'Danger Zone', so that the jenkinsci organization repository "
-                    + "is the definitive source for the code. If there are other forks, please contact GitHub support to make the jenkinsci repo the root of the fork network (mention that Jenkins approval was given in support request 569994). "
+                    + "is the definitive source for the code. If there are other forks, then use the 'Leave fork network' action in the 'Danger Zone' on the settings page of your new jenkinsci repository. "
                     + "Also, please make sure you properly follow the [documentation on documenting your plugin](https://jenkins.io/doc/developer/publishing/documentation/) "
                     + "so that your plugin is correctly documented. \n\n"
                     + "You will also need to do the following in order to push changes and release your plugin: \n\n"


### PR DESCRIPTION
You can now do the leave fork network in the UI.

I think still worth deleting original repository so that you can re-fork easily.