### PR TITLE
Remove ikedam from plugins

### DIFF
--- a/permissions/plugin-authorize-project.yml
+++ b/permissions/plugin-authorize-project.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '18155'  # authorize-project-plugin
 paths:
   - "org/jenkins-ci/plugins/authorize-project"
-developers:
-  - "ikedam"
+developers: []

--- a/permissions/plugin-build-timeout.yml
+++ b/permissions/plugin-build-timeout.yml
@@ -7,7 +7,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/build-timeout"
 developers:
-  - "ikedam"
   - "oleg_nenashev"
   - "krisstern"
 security:

--- a/permissions/plugin-copyartifact.yml
+++ b/permissions/plugin-copyartifact.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/copyartifact"
   - "org/jvnet/hudson/plugins/copyartifact"
 developers:
-  - "ikedam"
   - "wolfs"
   - "markewaite"
   - "allancth"

--- a/permissions/plugin-doclinks.yml
+++ b/permissions/plugin-doclinks.yml
@@ -7,5 +7,4 @@ issues:
 paths:
   - "org/jenkinsci/plugins/doclinks"
   - "org/jvnet/hudson/plugins/doclinks"
-developers:
-  - "ikedam"
+developers: []

--- a/permissions/plugin-editable-choice.yml
+++ b/permissions/plugin-editable-choice.yml
@@ -3,8 +3,7 @@ name: "editable-choice"
 github: &GH "jenkinsci/editable-choice-plugin"
 paths:
   - "io/jenkins/plugins/editable-choice"
-developers:
-  - "ikedam"
+developers: []
 issues:
   - jira: 28633
 cd:

--- a/permissions/plugin-extensible-choice-parameter.yml
+++ b/permissions/plugin-extensible-choice-parameter.yml
@@ -7,5 +7,4 @@ paths:
   - "jp/ikedam/jenkins/plugins/extensible-choice-parameter"
 cd:
   enabled: true
-developers:
-  - "ikedam"
+developers: []

--- a/permissions/plugin-flexible-publish.yml
+++ b/permissions/plugin-flexible-publish.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '16130'  # flexible-publish-plugin
 paths:
   - "org/jenkins-ci/plugins/flexible-publish"
-developers:
-  - "ikedam"
+developers: []

--- a/permissions/plugin-groovy-label-assignment.yml
+++ b/permissions/plugin-groovy-label-assignment.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '17655'  # groovy-label-assignment-plugin
 paths:
   - "jp/ikedam/jenkins/plugins/groovy-label-assignment"
-developers:
-  - "ikedam"
+developers: []

--- a/permissions/plugin-groovy-postbuild.yml
+++ b/permissions/plugin-groovy-postbuild.yml
@@ -8,5 +8,4 @@ issues:
 paths:
   - "org/jvnet/hudson/plugins/groovy-postbuild"
 developers:
-  - "ikedam"
   - "markewaite"

--- a/permissions/plugin-jobcopy-builder.yml
+++ b/permissions/plugin-jobcopy-builder.yml
@@ -5,5 +5,4 @@ issues:
   - jira: '17506'  # jobcopy-builder-plugin
 paths:
   - "jp/ikedam/jenkins/plugins/jobcopy-builder"
-developers:
-  - "ikedam"
+developers: []

--- a/permissions/plugin-matrix-combinations-parameter.yml
+++ b/permissions/plugin-matrix-combinations-parameter.yml
@@ -6,5 +6,4 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/matrix-combinations-parameter"
 developers:
-  - "ikedam"
   - "omer727"

--- a/permissions/plugin-naginator.yml
+++ b/permissions/plugin-naginator.yml
@@ -9,6 +9,5 @@ paths:
   - "org/jenkins-ci/plugins/naginator"
 developers:
   - "galunto"
-  - "ikedam"
   - "integer"
   - "sghill"

--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/parameterized-trigger"
 developers:
-  - "ikedam"
   - "kwhetstone"
   - "oleg_nenashev"
   - "wolfs"

--- a/permissions/plugin-update-sites-manager.yml
+++ b/permissions/plugin-update-sites-manager.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "jp/ikedam/jenkins/plugins/update-sites-manager"
 developers:
-  - "ikedam"
   - "slide_o_mix"
 cd:
   enabled: true


### PR DESCRIPTION
I no longer contribute to Jenkins plugins for years, and I plan to leave from Github teams in Jenkins organization to stop notifications from plugin repositories.

This request removes @ikedam from plugins.

# Link to GitHub repository

* https://github.com/jenkinsci/authorize-project-plugin
* https://github.com/jenkinsci/build-timeout-plugin
* https://github.com/jenkinsci/copyartifact-plugin
* https://github.com/jenkinsci/doclinks-plugin
* https://github.com/jenkinsci/editable-choice-plugin
* https://github.com/jenkinsci/extensible-choice-parameter-plugin
* https://github.com/jenkinsci/flexible-publish-plugin
* https://github.com/jenkinsci/groovy-label-assignment-plugin
* https://github.com/jenkinsci/groovy-postbuild-plugin
* https://github.com/jenkinsci/jobcopy-builder-plugin
* https://github.com/jenkinsci/matrix-combinations-plugin
* https://github.com/jenkinsci/naginator-plugin
* https://github.com/jenkinsci/parameterized-trigger-plugin
* https://github.com/jenkinsci/update-sites-manager-plugin

# When modifying release permission

(This request contains only user removals, and I believe this can be skipped)

List the GitHub usernames of the users who should have commit permissions below:
- `@username1`
- `@username2`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

(This request contains only user removals, and I believe this can be skipped)

- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
