### PR TITLE
Remove lucamilanesio from the statistics-gatherer plugin

### DIFF
--- a/permissions/plugin-statistics-gatherer.yml
+++ b/permissions/plugin-statistics-gatherer.yml
@@ -8,4 +8,3 @@ paths:
   - "org/jenkins/plugins/statistics/gatherer/statistics-gatherer"
 developers:
   - "macha762"
-  - "lucamilanesio"


### PR DESCRIPTION
# Link to GitHub repository

[statistics-gatherer](https://plugins.jenkins.io/statistics-gatherer/)

# When modifying release permission

List the GitHub usernames of the users who should be removed from the commit permissions below:
- `@lucamilanesio`

This is needed in order to maintain a healthy list of really active developers.