### PR TITLE
Broken manual releases of nested view plugin

### DIFF
--- a/permissions/plugin-nested-view.yml
+++ b/permissions/plugin-nested-view.yml
@@ -8,5 +8,3 @@ paths:
 developers:
   - "lvotypkova"
   - "judovana"
-cd:
-  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/nested-view-plugin/

Hello! The manual releases of nested view plugin are broken.
```
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.3:deploy (default-deploy) on project nested-view: Failed to deploy artifacts: Could not transfer artifact org.jenkins-ci.plugins:nested-view:pom:2.0 from/to maven.jenkins-ci.org (https://repo.jenkins-ci.org/releases/): status code: 403, reason phrase:  (403) -> [Help 1]
```

The only change in meantime (on permissions scope) is the 
```
+cd:
+  enabled: true
```
from https://github.com/jenkins-infra/repository-permissions-updater/pull/4449

Not sure how it is affecting the releases, but as CD is broken for some time, I would liek to remove it, and get back to manual releases which seems to work more stable.  TY!