### PR TITLE
Adopt android-signing plugin to speedup review and merging

### DIFF
--- a/permissions/plugin-android-signing.yml
+++ b/permissions/plugin-android-signing.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/android-signing"
 developers:
   - "restjohn"
+  - "panicking"


### PR DESCRIPTION
Plugin seems not updated since years. Adopt it to move a bit forward

# Link to GitHub repository

https://github.com/jenkinsci/android-signing-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `panicking`

Pull request

https://github.com/jenkinsci/android-signing-plugin/pull/5
