### PR TITLE
Block further releases of gatling-plugin

### DIFF
--- a/permissions/plugin-gatling.yml
+++ b/permissions/plugin-gatling.yml
@@ -8,6 +8,8 @@ paths:
 developers:
   - "slandelle"
   - "vedanthvasudev"
+# SECURITY-3588
+releaseBlocked: true
 cd:
   enabled: true
   exclusive: false


### PR DESCRIPTION
https://www.jenkins.io/security/advisory/2025-06-06/

# Link to GitHub repository

https://github.com/jenkinsci/gatling-plugin

