### PR TITLE
Enable CD for digitalocean-plugin and move issues to github

### DIFF
--- a/permissions/plugin-digitalocean-plugin.yml
+++ b/permissions/plugin-digitalocean-plugin.yml
@@ -2,7 +2,11 @@
 name: "digitalocean-plugin"
 github: "jenkinsci/digitalocean-plugin"
 issues:
+  - github: 'jenkinsci/digitalocean-plugin' # The preferred issue tracker
   - jira: '18831'  # digitalocean-plugin
+    report: false # No new issues should be reported here
+cd:
+  enabled: true
 paths:
   - "com/dubture/jenkins/digitalocean-plugin"
 developers:


### PR DESCRIPTION
# Link to GitHub repository

github.com/jenkinsci/digitalocean-plugin/

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/digitalocean-plugin/pull/77

### CD checklist (for submitters)

- [X] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.

cc @khayyamsaleem @speedythesnail 