### PR TITLE
cleanup(plugin-jenkinswalldisplay) only retain 1 issue tracker

### DIFF
--- a/permissions/plugin-jenkinswalldisplay.yml
+++ b/permissions/plugin-jenkinswalldisplay.yml
@@ -2,10 +2,7 @@
 name: "jenkinswalldisplay"
 github: "jenkinsci/walldisplay-plugin"
 issues:
-  # This should probably be cleaned up:
   - jira: '16045'  # jenkinswalldisplay-plugin
-  - jira: '15880'  # walldisplay-plugin
-  - jira: '17579'  # jenkinswalldisplay-pom
 paths:
   - "org/jenkins-ci/plugins/jenkinswalldisplay"
 developers:


### PR DESCRIPTION
# Link to GitHub repository

Ref. https://github.com/jenkins-infra/helpdesk/issues/2508#issuecomment-2989895628
