### PR TITLE
[OpenTelemetry] Add CloudBees team to help with security issues

### DIFF
--- a/permissions/plugin-opentelemetry-api.yml
+++ b/permissions/plugin-opentelemetry-api.yml
@@ -10,3 +10,6 @@ cd:
   enabled: true
 issues:
   - github: *GH
+security:
+  contacts:
+    jira: "cloudbees_security_members"

--- a/permissions/plugin-opentelemetry.yml
+++ b/permissions/plugin-opentelemetry.yml
@@ -11,3 +11,6 @@ issues:
   - github: *GH
 cd:
   enabled: true
+security:
+  contacts:
+    jira: "cloudbees_security_members"


### PR DESCRIPTION
At CloudBees, we are adding these two plugins to our [CloudBees Assurance Program](https://docs.cloudbees.com/docs/cloudbees-ci/latest/assurance-program/). Hence, we would like to offer our help in case a security issue arises.
As usual, we'll always abide by the approach the maintainers want to follow. But for example, if a maintainer is lacking time to handle a given security issue, we'll be willing and happy to handle it.

Thank you.

# Link to GitHub repository
* https://github.com/jenkinsci/opentelemetry-plugin
* https://github.com/jenkinsci/opentelemetry-api-plugin

## Pinging relevant folks

### Known maintainers
* @kuisathaverat 
* @cyrille-leclerc 

### Security Officer

@Wadeck FYI

# When modifying release permission

N/A

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

N/A

## When enabling automated releases (cd: true)
N/A

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

N/A

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [x] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
