### PR TITLE
Create autolinks for Jira

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -320,6 +320,11 @@ public class Hoster {
         r.enableIssueTracker(useGHIssues);
         r.enableWiki(false);
         r.setHomepage("https://plugins.jenkins.io/" + r.getName().replace("-plugin", "") + "/");
+        r.createAutolink()
+                .withKeyPrefix("JENKINS-")
+                .withUrlTemplate("https://issues.jenkins.io/browse/JENKINS-<num>")
+                .withIsAlphanumeric(false)
+                .create();
     }
 
     /**


### PR DESCRIPTION
Given we're on a sponsored GH OSS plan, we can make use of various Enterprise features.
This specific feature is already used in various plugins - and core itself - to reference an issue from Jenkins' Jira in a commit:

![Screenshot 2025-06-29 at 15 01 46](https://github.com/user-attachments/assets/adb36803-f271-4970-926d-3f90121747db)

Clicking on "JENKINS-75683" jumps directly to the issue on Jira: https://issues.jenkins.io/browse/JENKINS-75683

The change proposed enables this as default for all new plugins, allowing contributors to reference a clickable Jira issue in a commit.