### PR TITLE
`log-cli` uses GH issues

### DIFF
--- a/permissions/plugin-log-cli.yml
+++ b/permissions/plugin-log-cli.yml
@@ -1,10 +1,10 @@
 ---
 name: "log-cli"
-github: "jenkinsci/log-cli-plugin"
+github: &GH "jenkinsci/log-cli-plugin"
 cd:
   enabled: true
 issues:
-  - jira: '23228' # log-cli-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/log-cli"
 developers:


### PR DESCRIPTION
https://github.com/jenkinsci/log-cli-plugin/issues hope I am interpreting https://github.com/jenkins-infra/repository-permissions-updater/tree/master?tab=readme-ov-file#declaring-issue-trackers correctly.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
