### PR TITLE
Fix linking of Jira component

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -139,9 +139,9 @@ public class Hoster {
             String issueTrackerText;
             if (issueTrackerChoice == IssueTracker.JIRA) {
                 issueTrackerText = "\n\nA Jira component named [" + forkTo
-                        + "](https://issues.jenkins.io/issues/?jql=project+%3D+JENKINS+AND+component+%3D+ " + forkTo
-                        + ")" + "has also been created with " + defaultAssignee
-                        + " as the default assignee for issues.";
+                        + "](https://issues.jenkins.io/issues/?jql=project+%3D+JENKINS+AND+component+%3D+" + forkTo
+                        + ")" + " has also been created with `" + defaultAssignee
+                        + "` as the default assignee for issues.";
             } else {
                 issueTrackerText =
                         "\n\nGitHub issues has been selected for issue tracking and was enabled for the forked repo.";


### PR DESCRIPTION
Noticed in https://github.com/jenkins-infra/repository-permissions-updater/issues/4552#issuecomment-3128864481

Additionally, escaping the member by adding backslashes.