### PR TITLE
Exclude git & git client from community plugin maintainers initiative

### DIFF
--- a/permissions/plugin-git-client.yml
+++ b/permissions/plugin-git-client.yml
@@ -6,6 +6,7 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/git-client"
   - "org/jenkinsci/plugins/git-client"
+community-plugin-maintainers: false
 developers:
   - "markewaite"
   - "olamy"

--- a/permissions/plugin-git-client.yml
+++ b/permissions/plugin-git-client.yml
@@ -6,7 +6,7 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/git-client"
   - "org/jenkinsci/plugins/git-client"
-community-plugin-maintainers: false
+communityPluginMaintainers: false
 developers:
   - "markewaite"
   - "olamy"

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -7,6 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/git"
   - "org/jenkinsci/plugins/git"
   - "org/jvnet/hudson/plugins/git"
+community-plugin-maintainers: false
 developers:
   - "markewaite"
   - "olamy"

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -7,7 +7,7 @@ paths:
   - "org/jenkins-ci/plugins/git"
   - "org/jenkinsci/plugins/git"
   - "org/jvnet/hudson/plugins/git"
-community-plugin-maintainers: false
+communityPluginMaintainers: false
 developers:
   - "markewaite"
   - "olamy"

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -123,6 +123,7 @@ public class Definition {
     private IssueTracker[] issues = new IssueTracker[0];
     private String[] extraNames = new String[0];
     private boolean releaseBlocked;
+    private boolean communityPluginMaintainers;
 
     private String github;
 
@@ -191,6 +192,14 @@ public class Definition {
 
     public void setReleaseBlocked(boolean releaseBlocked) {
         this.releaseBlocked = releaseBlocked;
+    }
+
+    public boolean isCommunityPluginMaintainers() {
+        return communityPluginMaintainers;
+    }
+
+    public void setCommunityPluginMaintainers(boolean communityPluginMaintainers) {
+        this.communityPluginMaintainers = communityPluginMaintainers;
     }
 
     public String getGithub() {


### PR DESCRIPTION
## Exclude git & git client from community plugin maintainers initiative

A [Google Doc](https://docs.google.com/document/d/1GEI7tQp3UxGCbQQyF1JdujgwkoWcMluvUMFanV2nDGo/edit?usp=sharing) describes the Community Plugin Maintainers Initiative in more detail.

Maintainers of the git plugin and the git client plugin will assure that pull requests from the community plugin maintainers initiative are reviewed and merged promptly so that community plugin maintainers do not need to enable automated software releases with JEP-229.

Plugin version numbers are manually maintained for these two plugins.

# Link to GitHub repository

N/A

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

N/A

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)

- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

N/A

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
