### PR TITLE
Opt out of the "community plugin maintainers" initiative

### DIFF
--- a/permissions/plugin-better-pipeline-flowgraph-table.yml
+++ b/permissions/plugin-better-pipeline-flowgraph-table.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-csp.yml
+++ b/permissions/plugin-csp.yml
@@ -7,3 +7,4 @@ developers:
   - "@security"
 issues:
   - github: *GH
+communityPluginMaintainers: false

--- a/permissions/plugin-disable-job-button.yml
+++ b/permissions/plugin-disable-job-button.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-environment-filter-utils.yml
+++ b/permissions/plugin-environment-filter-utils.yml
@@ -9,3 +9,4 @@ developers:
   - "@security"
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-generic-environment-filters.yml
+++ b/permissions/plugin-generic-environment-filters.yml
@@ -9,3 +9,4 @@ developers:
   - "@security"
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-generic-tool.yml
+++ b/permissions/plugin-generic-tool.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-inline-pipeline.yml
+++ b/permissions/plugin-inline-pipeline.yml
@@ -11,3 +11,4 @@ developers:
   - "@security"
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-localization-support.yml
+++ b/permissions/plugin-localization-support.yml
@@ -7,3 +7,4 @@ paths:
   - "io/jenkins/plugins/localization-support"
 developers:
   - "danielbeck"
+communityPluginMaintainers: false

--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/matrix-auth"
 developers:
   - "danielbeck"
+communityPluginMaintainers: false

--- a/permissions/plugin-people-view.yml
+++ b/permissions/plugin-people-view.yml
@@ -7,3 +7,4 @@ developers:
 - "danielbeck"
 issues:
   - jira: '29420' # people-view-plugin
+communityPluginMaintainers: false

--- a/permissions/plugin-pipeline-keepenv-step.yml
+++ b/permissions/plugin-pipeline-keepenv-step.yml
@@ -9,3 +9,4 @@ developers:
   - "@security"
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-remoting-security-workaround.yml
+++ b/permissions/plugin-remoting-security-workaround.yml
@@ -7,3 +7,4 @@ paths:
   - "io/jenkins/plugins/remoting-security-workaround"
 developers:
   - "@security"
+communityPluginMaintainers: false

--- a/permissions/plugin-safe-batch-environment-filter.yml
+++ b/permissions/plugin-safe-batch-environment-filter.yml
@@ -9,3 +9,4 @@ issues:
   - github: *GH
 cd:
   enabled: true
+communityPluginMaintainers: false

--- a/permissions/plugin-strict-crumb-issuer.yml
+++ b/permissions/plugin-strict-crumb-issuer.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/strict-crumb-issuer"
 developers:
   - "@security"
+communityPluginMaintainers: false


### PR DESCRIPTION
My feedback to the original proposal was never addressed, so this PR opts out all "my" plugins (maintained only by me or `@security`) from this initiative.