### PR TITLE
Enable CD for my multi-module plugins

### DIFF
--- a/permissions/plugin-coverage.yml
+++ b/permissions/plugin-coverage.yml
@@ -7,3 +7,5 @@ paths:
   - "io/jenkins/plugins/coverage"
 developers:
   - "drulli"
+cd:
+  enabled: true

--- a/permissions/plugin-git-forensics.yml
+++ b/permissions/plugin-git-forensics.yml
@@ -7,3 +7,5 @@ paths:
   - "io/jenkins/plugins/git-forensics"
 developers:
   - "drulli"
+cd:
+  enabled: true

--- a/permissions/plugin-warnings-ng.yml
+++ b/permissions/plugin-warnings-ng.yml
@@ -10,3 +10,5 @@ developers:
 security:
   contacts:
     jira: "cloudbees_security_members"
+cd:
+  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->
- https://github.com/jenkinsci/warnings-ng-plugin
- https://github.com/jenkinsci/git-forensics-plugin
- https://github.com/jenkinsci/coverage-plugin

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

- https://github.com/jenkinsci/warnings-ng-plugin/pull/2084
- https://github.com/jenkinsci/git-forensics-plugin/pull/1027
- https://github.com/jenkinsci/coverage-plugin/pull/473

### CD checklist (for submitters)

- [X] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
