### PR TITLE
Create repo file for #4608 manually

### DIFF
--- a/permissions/component-gradle-convention-plugin.yml
+++ b/permissions/component-gradle-convention-plugin.yml
@@ -1,0 +1,9 @@
+---
+name: "jenkins-gradle-convention"
+github: &gh "jenkinsci/gradle-convention-plugin"
+issues:
+  - github: *gh
+paths:
+  - "io/jenkins/plugins/gradle-convention-plugin"
+developers:
+  - "aaravmahajanofficial"


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/repository-permissions-updater/issues/4608; there's something wrong in the underlying logic for non-maven distributions, but that shouldn't stop the hosting process and needs to be looked into at another point.