### PR TITLE
Enable CD for vulnerability-vines-ai plugin

### DIFF
--- a/permissions/plugin-vulnerability-vines-ai.yml
+++ b/permissions/plugin-vulnerability-vines-ai.yml
@@ -6,4 +6,6 @@ paths:
 developers:
 - "rocheston"
 issues:
-  - github: *GH
+- github: *GH
+cd:
+  enabled: true


### PR DESCRIPTION
This PR enables JEP-229 Continuous Delivery for the vulnerability-vines-ai plugin.

Plugin repo PR: https://github.com/jenkinsci/vulnerability-vines-ai-plugin/pull/<PR-number>
