### PR TITLE
Remove jglick from `reverse-proxy-auth-plugin`

### DIFF
--- a/permissions/plugin-reverse-proxy-auth-plugin.yml
+++ b/permissions/plugin-reverse-proxy-auth-plugin.yml
@@ -10,6 +10,5 @@ cd:
 developers:
   - "wilder_rodrigues"
   - "oleg_nenashev"
-  - "jglick"
   - "sboardwell"
   - "rdalton"


### PR DESCRIPTION
Reverting #1745 since that was a one-time update for a long-since-closed JEP, and I have no intention of working on this plugin. I am also leaving the GH team since I am tired of getting notifications from Renovate and other PRs.