### PR TITLE
Enable CD for `lib-support-log-formatter`

### DIFF
--- a/permissions/component-support-log-formatter.yml
+++ b/permissions/component-support-log-formatter.yml
@@ -3,5 +3,7 @@ name: "support-log-formatter"
 github: "jenkinsci/lib-support-log-formatter"
 paths:
   - "io/jenkins/lib/support-log-formatter"
+cd:
+  enabled: true
 developers:
   - "@core"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/lib-support-log-formatter/pull/98 e.g. for https://github.com/jenkinsci/lib-support-log-formatter/pull/97

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
