### PR TITLE
Removing myself from `mercurial`

### DIFF
--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -9,7 +9,6 @@ paths:
 cd:
   enabled: true
 developers:
-  - "jglick"
   - "batmat"
   - "egutierrez"
   - "fcojfernandez"


### PR DESCRIPTION
I was the (an?) original author but no longer maintain it and do not wish to even receive notifications like in https://github.com/jenkinsci/mercurial-plugin/pull/308.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
