### PR TITLE
Add autolink builder for security issues

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -325,6 +325,11 @@ public class Hoster {
                 .withUrlTemplate("https://issues.jenkins.io/browse/JENKINS-<num>")
                 .withIsAlphanumeric(false)
                 .create();
+        r.createAutolink()
+                .withKeyPrefix("SECURITY-")
+                .withUrlTemplate("https://jenkins.io/security/issue/SECURITY-<num>")
+                .withIsAlphanumeric(false)
+                .create();
     }
 
     /**


### PR DESCRIPTION
The change proposed adds an autolink builder - similiar to the one already in place - which adds autolinks to security issues, if the cert team pushes commits matching the pattern `SECURITY-`.

Given Jira issues are private, the link resolves to the advisories, e.g. `SECURITY-3618` would link to https://www.jenkins.io/security/issue/SECURITY-3618.