### PR TITLE
Add @alleyj to developers with commit permission to Helix ALM Test Management

### DIFF
--- a/permissions/plugin-helix-alm-test-management.yml
+++ b/permissions/plugin-helix-alm-test-management.yml
@@ -6,6 +6,6 @@ paths:
 developers:
 - "vincentp"
 - "perforce_pjackson"
-- "alleyj"
+- "jonathan_alley"
 issues:
   - github: *GH


### PR DESCRIPTION
# Link to GitHub repository

Fixes https://github.com/jenkins-infra/repository-permissions-updater/issues/4670

https://github.com/jenkinsci/helix-alm-test-management-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- @alleyj
- @vincentp
- @petejax

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [X] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [X] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
