### PR TITLE
Enable CD for sonargraph-integration-plugin

### DIFF
--- a/permissions/plugin-sonargraph-integration.yml
+++ b/permissions/plugin-sonargraph-integration.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '21430'  # sonargraph-integration-plugin
 paths:
   - "org/jenkins-ci/plugins/sonargraph-integration"
+cd:
+  enabled: true
 developers:
   - "andreashoyerh2m"
   - "builderh2m"


### PR DESCRIPTION
# Link to GitHub repository

[sonargraph-integration-plugin](https://github.com/jenkinsci/sonargraph-integration-plugin)



## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

I added it to cd.yml on the master branch, but it currently fails with status 401

### CD checklist (for submitters)

- [ X] I already did the changes by committing to master and want to enable cd

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
