### PR TITLE
Remove CloudBees permissions from matrix-project plugin

### DIFF
--- a/permissions/plugin-matrix-project.yml
+++ b/permissions/plugin-matrix-project.yml
@@ -12,6 +12,3 @@ developers:
   - "oleg_nenashev"
   - "batmat"
   - "rsandell"
-security:
-  contacts:
-    jira: []


### PR DESCRIPTION
Hello,

Simply removing CloudBees from contacts on `matrix-project`.

Ping @Wadeck as security contact is changing.

# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->
https://github.com/jenkinsci/matrix-project-plugin


### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
