### PR TITLE
Removing myself from `view-job-filters`

### DIFF
--- a/permissions/plugin-view-job-filters.yml
+++ b/permissions/plugin-view-job-filters.yml
@@ -10,7 +10,6 @@ cd:
   enabled: true
 developers:
   - "svenschoenung"
-  - "jglick"
   - "@cloudbees-developers"
 security:
   contacts:


### PR DESCRIPTION
I did not want notifications like https://github.com/jenkinsci/view-job-filters-plugin/pull/114 as I am not involved with this plugin at all.