### PR TITLE
Add markewaite as a maintainer of build-with-parameters plugin

### DIFF
--- a/permissions/plugin-build-with-parameters.yml
+++ b/permissions/plugin-build-with-parameters.yml
@@ -7,5 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/build-with-parameters"
 developers:
   - "sugonyak_ivan"
+  - "markewaite"
 cd:
   enabled: true


### PR DESCRIPTION
## Add markewaite as a maintainer of build-with-parameters plugin

Plugin seems to be abandoned since there has not been a merge of the EE 8 to EE 9 migration pull request:

* https://github.com/jenkinsci/build-with-parameters-plugin/pull/30

I will merge that and also merge my pull request for Java 25:

* https://github.com/jenkinsci/build-with-parameters-plugin/pull/32

Once those two pull requests are merged, I'll release a new version so that the EE 8 to EE 9 migration changes are available for users.

@sugonyak is the current maintainer.  Would be nice if he can approve me being added as a maintainer so that we don't need to wait the two weeks for the timeout.

# Link to GitHub repository

* https://github.com/jenkinsci/build-with-parameters-plugin/

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@MarkEWaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
