### PR TITLE
Enable CD for remoting test client

### DIFF
--- a/permissions/component-remoting-test-client.yml
+++ b/permissions/component-remoting-test-client.yml
@@ -3,5 +3,7 @@ name: "remoting-test-client"
 github: "jenkinsci/remoting-test-client"
 paths:
   - "org/jenkins-ci/remoting-test-client"
+cd:
+  enabled: true
 developers:
   - "@core"


### PR DESCRIPTION
Enables CD for https://github.com/jenkinsci/remoting-test-client, to release https://github.com/jenkinsci/remoting-test-client/pull/51; unblocking https://github.com/jenkinsci/remoting/pull/834