### PR TITLE
Enhanced Jenkinsfile validation

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
@@ -1,6 +1,6 @@
 package io.jenkins.infra.repository_permissions_updater.hosting;
 
-import static io.jenkins.infra.repository_permissions_updater.hosting.HostingChecker.LOWEST_JENKINS_VERSION;
+import static io.jenkins.infra.repository_permissions_updater.hosting.Requirements.LOWEST_JENKINS_VERSION;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import java.io.IOException;

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -28,8 +28,6 @@ public class HostingChecker {
     public static final String INVALID_FORK_FROM =
             "Repository URL '%s' is not a valid GitHub repository (check that you do not have .git at the end, GitHub API doesn't support this).";
 
-    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 492, 3);
-
     public static void main(String[] args) throws IOException {
         new HostingChecker().checkRequest(Integer.parseInt(args[0]));
     }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
@@ -1,6 +1,8 @@
 package io.jenkins.infra.repository_permissions_updater.hosting;
 
-import static io.jenkins.infra.repository_permissions_updater.hosting.HostingChecker.LOWEST_JENKINS_VERSION;
+import static io.jenkins.infra.repository_permissions_updater.hosting.Requirements.LOWEST_JENKINS_VERSION;
+import static io.jenkins.infra.repository_permissions_updater.hosting.Requirements.LOWEST_PARENT_POM_VERSION;
+import static io.jenkins.infra.repository_permissions_updater.hosting.Requirements.PARENT_POM_WITH_JENKINS_VERSION;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -51,9 +53,6 @@ public class MavenVerifier implements BuildSystemVerifier {
     private static final int MAX_LENGTH_OF_GROUP_ID_PLUS_ARTIFACT_ID = 100;
     private static final int MAX_LENGTH_OF_ARTIFACT_ID = 37;
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenVerifier.class);
-
-    public static final Version LOWEST_PARENT_POM_VERSION = new Version(5, 28);
-    public static final Version PARENT_POM_WITH_JENKINS_VERSION = new Version(2);
 
     public static final String INVALID_POM = "The pom.xml file in the root of the origin repository is not valid";
     public static final String SPECIFY_LICENSE =

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
@@ -1,5 +1,6 @@
 package io.jenkins.infra.repository_permissions_updater.hosting;
 
+import static io.jenkins.infra.repository_permissions_updater.hosting.Requirements.ALLOWED_JDK_VERSIONS;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import groovy.lang.GroovyClassLoader;
@@ -41,8 +42,6 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
 public class RequiredFilesVerifier implements Verifier {
-
-    private static final List<Integer> ALLOWED_JDK_VERSIONS = List.of(21, 25);
 
     @Override
     public void verify(HostingRequest request, HashSet<VerificationMessage> hostingIssues) throws IOException {
@@ -372,7 +371,7 @@ public class RequiredFilesVerifier implements Verifier {
                 }
             }
 
-        } catch (Exception e) {
+        } catch (IOException e) {
             hostingIssues.add(
                     new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Could not parse Jenkinsfile."));
         }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Requirements.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Requirements.java
@@ -1,0 +1,13 @@
+package io.jenkins.infra.repository_permissions_updater.hosting;
+
+import java.util.List;
+
+/**
+ * Requirements for hosting Jenkins plugins repositories.
+ */
+public class Requirements {
+    public static final Version LOWEST_PARENT_POM_VERSION = new Version(5, 28);
+    public static final Version PARENT_POM_WITH_JENKINS_VERSION = new Version(2);
+    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 492, 3);
+    public static final List<Integer> ALLOWED_JDK_VERSIONS = List.of(21, 25);
+}


### PR DESCRIPTION
To reduce manual efforts the Jenkinsfile it is now parsed with groovy.
Typically the Jenkinsfile should be simple and not do anything else than calling `buildPlugin` with parameters.

Following checks are performed:
- Call to `buildPlugin` is the only method call in the file.
- buildPlugin has a `configurations` parameter
- configurations is a list
- configurations contain `platform` and `jdk`
- jdk has allowed value (currently 21 and 25)

Tested with various open hosting requests. They all complain about using java 17
Also tested with manually provided Jenkinsfile with some simple variable declarations upfront:
 ```
    def jdkVersion = 17
    def config = [[platform: 'linux', jdk: jdkVersion]]
    buildPlugin(configurations: config)
```