### PR TITLE
Migrate Kubernetes plugin issues to GitHub

### DIFF
--- a/permissions/plugin-kubernetes.yml
+++ b/permissions/plugin-kubernetes.yml
@@ -1,8 +1,8 @@
 ---
 name: "kubernetes"
-github: "jenkinsci/kubernetes-plugin"
+github: &gh "jenkinsci/kubernetes-plugin"
 issues:
-  - jira: '20639'  # kubernetes-plugin
+  - github: *gh
 paths:
   - "org/csanchez/jenkins/plugins/kubernetes"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@Vlatombe / @jglick for approval

Let me know if any objections or questions