### PR TITLE
Migrate Blueocean plugin issues to GitHub

### DIFF
--- a/permissions/plugin-blueocean-bitbucket-pipeline.yml
+++ b/permissions/plugin-blueocean-bitbucket-pipeline.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-bitbucket-pipeline"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-bitbucket-pipeline"
 developers:

--- a/permissions/plugin-blueocean-commons.yml
+++ b/permissions/plugin-blueocean-commons.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-commons"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-commons"
 developers:

--- a/permissions/plugin-blueocean-config.yml
+++ b/permissions/plugin-blueocean-config.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-config"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-config"
 developers:

--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-core-js"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-core-js"
 developers:

--- a/permissions/plugin-blueocean-dashboard.yml
+++ b/permissions/plugin-blueocean-dashboard.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-dashboard"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-dashboard"
 developers:

--- a/permissions/plugin-blueocean-events.yml
+++ b/permissions/plugin-blueocean-events.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-events"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-events"
 developers:

--- a/permissions/plugin-blueocean-git-pipeline.yml
+++ b/permissions/plugin-blueocean-git-pipeline.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-git-pipeline"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-git-pipeline"
 developers:

--- a/permissions/plugin-blueocean-github-pipeline.yml
+++ b/permissions/plugin-blueocean-github-pipeline.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-github-pipeline"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-github-pipeline"
 developers:

--- a/permissions/plugin-blueocean-i18n.yml
+++ b/permissions/plugin-blueocean-i18n.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-i18n"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-i18n"
 developers:

--- a/permissions/plugin-blueocean-jira.yml
+++ b/permissions/plugin-blueocean-jira.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-jira"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-jira"
 developers:

--- a/permissions/plugin-blueocean-jwt.yml
+++ b/permissions/plugin-blueocean-jwt.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-jwt"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-jwt"
 developers:

--- a/permissions/plugin-blueocean-personalization.yml
+++ b/permissions/plugin-blueocean-personalization.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-personalization"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-personalization"
 developers:

--- a/permissions/plugin-blueocean-pipeline-api-impl.yml
+++ b/permissions/plugin-blueocean-pipeline-api-impl.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-pipeline-api-impl"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-pipeline-api-impl"
 developers:

--- a/permissions/plugin-blueocean-pipeline-scm-api.yml
+++ b/permissions/plugin-blueocean-pipeline-scm-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-pipeline-scm-api"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-pipeline-scm-api"
 developers:

--- a/permissions/plugin-blueocean-rest-impl.yml
+++ b/permissions/plugin-blueocean-rest-impl.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-rest-impl"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-rest-impl"
 developers:

--- a/permissions/plugin-blueocean-rest.yml
+++ b/permissions/plugin-blueocean-rest.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-rest"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-rest"
 developers:

--- a/permissions/plugin-blueocean-web.yml
+++ b/permissions/plugin-blueocean-web.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean-web"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean-web"
 developers:

--- a/permissions/plugin-blueocean.yml
+++ b/permissions/plugin-blueocean.yml
@@ -1,8 +1,8 @@
 ---
 name: "blueocean"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/blueocean"
 developers:

--- a/permissions/plugin-jenkins-design-language.yml
+++ b/permissions/plugin-jenkins-design-language.yml
@@ -1,8 +1,8 @@
 ---
 name: "jenkins-design-language"
-github: "jenkinsci/blueocean-plugin"
+github: &gh "jenkinsci/blueocean-plugin"
 issues:
-  - jira: '21481'  # blueocean-plugin
+  - github: *gh
 paths:
   - "io/jenkins/blueocean/jenkins-design-language"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@dwnusbaum / @olamy / @joseblas for approval

Let me know if any objections or questions

-----

For blueocean this has the advantage that we can pin an issue asking people to only raise compatibility issues and no new development is happening, as there's nothing discouraging bugs being raised in Jira for it.