### PR TITLE
Migrate git and git-client plugin issues to GitHub

### DIFF
--- a/permissions/plugin-git-client.yml
+++ b/permissions/plugin-git-client.yml
@@ -1,8 +1,8 @@
 ---
 name: "git-client"
-github: "jenkinsci/git-client-plugin"
+github: &gh "jenkinsci/git-client-plugin"
 issues:
-  - jira: '17423'  # git-client-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/git-client"
   - "org/jenkinsci/plugins/git-client"

--- a/permissions/plugin-git.yml
+++ b/permissions/plugin-git.yml
@@ -1,8 +1,8 @@
 ---
 name: "git"
-github: "jenkinsci/git-plugin"
+github: &gh "jenkinsci/git-plugin"
 issues:
-  - jira: '15543'  # git-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/git"
   - "org/jenkinsci/plugins/git"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@MarkEWaite  for approval

Let me know if any objections or questions