### PR TITLE
Migrate ec2 plugin issues to GitHub

### DIFF
--- a/permissions/plugin-ec2.yml
+++ b/permissions/plugin-ec2.yml
@@ -1,8 +1,8 @@
 ---
 name: "ec2"
-github: "jenkinsci/ec2-plugin"
+github: &gh "jenkinsci/ec2-plugin"
 issues:
-  - jira: '15625'  # ec2-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/ec2"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@res0nance for approval

Let me know if any objections or questions