### PR TITLE
Migrate job-dsl plugin issues to GitHub

### DIFF
--- a/permissions/plugin-job-dsl.yml
+++ b/permissions/plugin-job-dsl.yml
@@ -1,8 +1,8 @@
 ---
 name: "job-dsl"
-github: "jenkinsci/job-dsl-plugin"
+github: &gh "jenkinsci/job-dsl-plugin"
 issues:
-  - jira: '16720'  # job-dsl-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/job-dsl"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@MarkEWaite  for approval

Let me know if any objections or questions

----

For job-dsl this has the benefit that for whomever adopts this plugin it will be easier to tell what issues are open and need working on.