### PR TITLE
Clean up CloudBees permissions for jenkinsci/ant-plugin CAP removal

### DIFF
--- a/permissions/plugin-ant.yml
+++ b/permissions/plugin-ant.yml
@@ -12,6 +12,3 @@ developers:
   - "jglick"
   - "fcojfernandez"
   - "markewaite"
-security:
-  contacts:
-    jira: []


### PR DESCRIPTION
This PR cleans up CloudBees-specific permissions for **jenkinsci/ant-plugin** following its removal from the CloudBees Assurance Program (CAP).