### PR TITLE
Unify CLI entry points into a single main with subcommands

### DIFF
--- a/.github/workflows/hosting-comment-checker.yml
+++ b/.github/workflows/hosting-comment-checker.yml
@@ -32,6 +32,6 @@ jobs:
         run: mvn -B package -Dspotbugs.skip
       - name: Run hosting checker
         run: |
-          java -cp target/repository-permissions-updater-1.0-SNAPSHOT-bin/repository-permissions-updater-1.0-SNAPSHOT.jar io.jenkins.infra.repository_permissions_updater.hosting.HostingChecker ${{ github.event.issue.number }}
+          java -jar target/repository-permissions-updater-1.0-SNAPSHOT-bin/repository-permissions-updater-1.0-SNAPSHOT.jar check-hosting ${{ github.event.issue.number }}
         env:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hosting-comment-hoster.yml
+++ b/.github/workflows/hosting-comment-hoster.yml
@@ -45,7 +45,7 @@ jobs:
         run: mvn -B package -Dspotbugs.skip
       - name: Run hoster
         run: |
-          java -cp target/repository-permissions-updater-1.0-SNAPSHOT-bin/repository-permissions-updater-1.0-SNAPSHOT.jar io.jenkins.infra.repository_permissions_updater.hosting.Hoster ${{ github.event.issue.number }}
+          java -jar target/repository-permissions-updater-1.0-SNAPSHOT-bin/repository-permissions-updater-1.0-SNAPSHOT.jar host ${{ github.event.issue.number }}
         env:
           GITHUB_OAUTH: ${{ secrets.HOSTING_PAT }}
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}

--- a/.github/workflows/hosting-issue-checker.yml
+++ b/.github/workflows/hosting-issue-checker.yml
@@ -21,6 +21,6 @@ jobs:
         run: mvn -B package -Dspotbugs.skip
       - name: Run hosting checker
         run: |
-          java -cp target/repository-permissions-updater-1.0-SNAPSHOT-bin/repository-permissions-updater-1.0-SNAPSHOT.jar io.jenkins.infra.repository_permissions_updater.hosting.HostingChecker ${{ github.event.issue.number }}
+          java -jar target/repository-permissions-updater-1.0-SNAPSHOT-bin/repository-permissions-updater-1.0-SNAPSHOT.jar check-hosting ${{ github.event.issue.number }}
         env:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,8 @@ node('maven-21 || (java&&linux)') {
                             ' -DartifactoryApiTempDir=$PWD/json' +
                             ' -DartifactoryUserNamesJsonListUrl=https://reports.jenkins.io/artifactory-ldap-users-report.json' +
                             ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
-                            ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar'
+                            ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar' +
+                            ' sync'
 
 
                 if (dryRun) {

--- a/README.md
+++ b/README.md
@@ -212,9 +212,20 @@ Further issue trackers are mostly provided as a reference, e.g. when listing exi
 Usage
 -----
 
-To see how to run this tool to synchronize Artifactory permission targets with the definitions in this repository, see `Jenkinsfile`.
+This tool provides a unified CLI with subcommands. See `Jenkinsfile` for the `sync` command and GitHub Actions workflows for hosting commands.
 
-The following Java system properties can be used to customize the tool's behavior:
+Available commands:
+```bash
+RPU_CLI="java -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar"
+
+$RPU_CLI sync
+$RPU_CLI check-hosting <issue-id>
+$RPU_CLI host <issue-id>
+```
+
+### Configuration
+
+The following Java system properties can be used to customize the behavior of the `sync` command:
 
 * `dryRun` - Set to `true` to generate the API payloads without submitting them. No modifications will be executed.
 * `development` - Set to `true` during tool development to ensure production data is not overridden. This will have the following effects:
@@ -233,7 +244,13 @@ The following Java system properties can be used to customize the tool's behavio
 * `jiraUserNamesJsonListUrl` - URL to a list containing known Jira user names of (potential) maintainers.
   This is essentially a workaround to reduce the number of individual user lookups via Jira API.
 
-It expected the following environment variables to be set:
+The following Java system properties can be used for the `check-hosting` command:
+
+* `debugHosting` - Set to `true` to enable debug mode.
+
+### Environment Variables
+
+The following environment variables are expected to be set:
 
 - `ARTIFACTORY_USERNAME` - Admin user name for Artifactory
 - `ARTIFACTORY_PASSWORD` - Corresponding admin password (or API key) for Artifactory admin user

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </scm>
 
   <properties>
-    <main.class>io.jenkins.infra.repository_permissions_updater.ArtifactoryPermissionsUpdater</main.class>
+    <main.class>io.jenkins.infra.repository_permissions_updater.cli.RepositoryPermissionsUpdaterCLI</main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
     <maven.version>3.9.11</maven.version>
@@ -104,6 +104,11 @@
       <groupId>eu.neilalexander</groupId>
       <artifactId>jnacl</artifactId>
       <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>4.7.6</version>
     </dependency>
     <dependency>
       <groupId>io.atlassian.fugue</groupId>

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
@@ -588,7 +588,7 @@ public final class ArtifactoryPermissionsUpdater {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void syncPermissions() throws IOException {
         for (Handler h : Logger.getLogger("").getHandlers()) {
             if (h instanceof ConsoleHandler) {
                 ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/RepositoryPermissionsUpdaterCLI.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/RepositoryPermissionsUpdaterCLI.java
@@ -1,0 +1,31 @@
+package io.jenkins.infra.repository_permissions_updater.cli;
+
+import io.jenkins.infra.repository_permissions_updater.cli.commands.CheckHostingCommand;
+import io.jenkins.infra.repository_permissions_updater.cli.commands.HostCommand;
+import io.jenkins.infra.repository_permissions_updater.cli.commands.SyncCommand;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/**
+ * Main entry point for the Repository Permissions Updater CLI.
+ * Provides unified access to all repository permissions operations.
+ */
+@Command(
+        name = "rpu-cli",
+        description = "Repository Permissions Updater - Manage Jenkins plugin permissions",
+        mixinStandardHelpOptions = true,
+        version = "1.0-SNAPSHOT",
+        subcommands = {SyncCommand.class, CheckHostingCommand.class, HostCommand.class})
+public class RepositoryPermissionsUpdaterCLI implements Runnable {
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new RepositoryPermissionsUpdaterCLI()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public void run() {
+        // When no subcommand is specified, show usage
+        CommandLine.usage(this, System.out);
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/CheckHostingCommand.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/CheckHostingCommand.java
@@ -1,0 +1,26 @@
+package io.jenkins.infra.repository_permissions_updater.cli.commands;
+
+import io.jenkins.infra.repository_permissions_updater.hosting.HostingChecker;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Command to check a hosting request.
+ * Configuration is via system properties if needed.
+ */
+@Command(
+        name = "check-hosting",
+        description = "Check a plugin hosting request for compliance",
+        mixinStandardHelpOptions = true)
+public class CheckHostingCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "GitHub issue number of the hosting request")
+    private int issueNumber;
+
+    @Override
+    public Integer call() throws Exception {
+        new HostingChecker().checkRequest(issueNumber);
+        return 0;
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/HostCommand.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/HostCommand.java
@@ -1,0 +1,23 @@
+package io.jenkins.infra.repository_permissions_updater.cli.commands;
+
+import io.jenkins.infra.repository_permissions_updater.hosting.Hoster;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Command to process an approved hosting request.
+ * Wraps the functionality of {@link Hoster}.
+ */
+@Command(name = "host", description = "Process an approved plugin hosting request", mixinStandardHelpOptions = true)
+public class HostCommand implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "GitHub issue number of the hosting request to process")
+    private int issueNumber;
+
+    @Override
+    public Integer call() throws Exception {
+        new Hoster().run(issueNumber);
+        return 0;
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/SyncCommand.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/SyncCommand.java
@@ -1,0 +1,22 @@
+package io.jenkins.infra.repository_permissions_updater.cli.commands;
+
+import io.jenkins.infra.repository_permissions_updater.ArtifactoryPermissionsUpdater;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+/**
+ * Command to sync permissions to Artifactory.
+ * Configuration is via system properties (see Jenkinsfile for examples).
+ */
+@Command(
+        name = "sync",
+        description = "Sync permissions to Artifactory based on YAML definitions",
+        mixinStandardHelpOptions = true)
+public class SyncCommand implements Callable<Integer> {
+
+    @Override
+    public Integer call() throws Exception {
+        ArtifactoryPermissionsUpdater.syncPermissions();
+        return 0;
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -49,11 +49,7 @@ public class Hoster {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Hoster.class);
 
-    public static void main(String[] args) {
-        new Hoster().run(Integer.parseInt(args[0]));
-    }
-
-    private void run(int issueID) {
+    public void run(int issueID) {
         LOGGER.info("Approving hosting request {}", issueID);
 
         JiraRestClient client = null;

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -28,10 +28,6 @@ public class HostingChecker {
     public static final String INVALID_FORK_FROM =
             "Repository URL '%s' is not a valid GitHub repository (check that you do not have .git at the end, GitHub API doesn't support this).";
 
-    public static void main(String[] args) throws IOException {
-        new HostingChecker().checkRequest(Integer.parseInt(args[0]));
-    }
-
     public void checkRequest(int issueID) throws IOException {
         boolean hasBuildSystem = false;
         HashSet<VerificationMessage> hostingIssues = new HashSet<>();


### PR DESCRIPTION
Introduces a unified CLI using picocli with three subcommands:
- sync: Sync permissions to Artifactory (previously ArtifactoryPermissionsUpdater.main)
- check-hosting: Check hosting requests (previously HostingChecker.main)
- host: Process approved hosting requests (previously Hoster.main)

Changes:
- Add picocli dependency and update Main-Class in pom.xml
- Create RepositoryPermissionsUpdaterCLI as the single entry point
- Refactor main() methods to be callable from commands
- Update Jenkinsfile & GHA to use the new subcommands
- Keep all system property configuration unchanged for backward compatibility

I tried to keep the change as minimal as possible to kinda "prove" the approach.
Related to #4755

# Link to GitHub repository

N/A

Removed the usual template, as this change is about RPU's code itself, not the permissions. 

Disclaimer: I did use AI to assist me on this, but I did review every single line of change, as it should be :).
