### PR TITLE
Add markewaite as a trilead maintainer

### DIFF
--- a/permissions/component-trilead-ssh2.yml
+++ b/permissions/component-trilead-ssh2.yml
@@ -8,5 +8,6 @@ developers:
   - "kohsuke"
   - "mc1arke"
   - "ifernandezcalvo"
+  - "markewaite"
 cd:
   enabled: true

--- a/permissions/plugin-trilead-api.yml
+++ b/permissions/plugin-trilead-api.yml
@@ -8,6 +8,7 @@ paths:
 developers:
   - "mc1arke"
   - "ifernandezcalvo"
+  - "markewaite"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
## Add markewaite as a trilead maintainer

The trilead-ssh2 fork that is maintained by the Jenkins project has a bug.  That bug caused the regression documented in issue:

* https://github.com/jenkinsci/jenkins/issues/11312

The issue is fixed by a pull request to the trilead-ssh2 forked repository:

* https://github.com/jenkinsci/trilead-ssh2/pull/273

I need maintainer access to merge that pull request so that a new release of the library can be created.  I've tested the following additonal pull requests that should be merged as well:

* https://github.com/jenkinsci/trilead-ssh2/pull/268
* https://github.com/jenkinsci/trilead-ssh2/pull/269
* https://github.com/jenkinsci/trilead-ssh2/pull/270
* https://github.com/jenkinsci/trilead-ssh2/pull/271
* https://github.com/jenkinsci/trilead-ssh2/pull/272

Once the library is released, then I need permission to update the trilead-api plugin to use the new library.  The repository for the trilead-api plugin is:

* https://github.com/jenkinsci/trilead-api-plugin

Current committers to both repositories include:

* @kuisathaverat
* @mc1arke

# Link to GitHub repository

* https://github.com/jenkinsci/trilead-ssh2
* https://github.com/jenkinsci/trilead-api-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@MarkEWaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
