### PR TITLE
remove ifernandezcalvo permissions from trilead-ssh2, trilead-api, amazon-ecr, sshd, and aws-global-configuration

### DIFF
--- a/permissions/component-trilead-ssh2.yml
+++ b/permissions/component-trilead-ssh2.yml
@@ -7,7 +7,6 @@ paths:
 developers:
   - "kohsuke"
   - "mc1arke"
-  - "ifernandezcalvo"
   - "markewaite"
 cd:
   enabled: true

--- a/permissions/plugin-amazon-ecr.yml
+++ b/permissions/plugin-amazon-ecr.yml
@@ -7,7 +7,6 @@ paths:
   - "com/cloudbees/jenkins/plugins/amazon-ecr"
 developers:
   - "aheritier"
-  - "ifernandezcalvo"
   - "tgr"
 cd:
   enabled: true

--- a/permissions/plugin-aws-global-configuration.yml
+++ b/permissions/plugin-aws-global-configuration.yml
@@ -11,7 +11,6 @@ developers:
   - "jglick"
   - "csanchez"
   - "oleg_nenashev"
-  - "ifernandezcalvo"
   - "@cloudbees-developers"
 security:
   contacts:

--- a/permissions/plugin-sshd.yml
+++ b/permissions/plugin-sshd.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/modules/sshd"
 developers:
-  - "ifernandezcalvo"
   - "jvz"
   - "oleg_nenashev"
   - "timja"

--- a/permissions/plugin-trilead-api.yml
+++ b/permissions/plugin-trilead-api.yml
@@ -7,7 +7,6 @@ paths:
   - "org/jenkins-ci/plugins/trilead-api"
 developers:
   - "mc1arke"
-  - "ifernandezcalvo"
   - "markewaite"
 security:
   contacts:


### PR DESCRIPTION
# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->
* https://github.com/jenkinsci/trilead-api-plugin
* https://github.com/jenkinsci/trilead-ssh2
* https://github.com/jenkinsci/amazon-ecr-plugin
* https://github.com/jenkinsci/sshd-plugin
* https://github.com/jenkinsci/aws-global-configuration-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

The rest of the people that was there

This is needed in order to cut releases of the plugin or component.

no

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
