### PR TITLE
Add @jglick to `lib-durable-task` permissions

### DIFF
--- a/permissions/component-lib-durable-task.yml
+++ b/permissions/component-lib-durable-task.yml
@@ -11,5 +11,6 @@ developers:
   - "teilo"
   - "batmat"
   - "olamy"
+  - "jglick"
 cd:
   enabled: true


### PR DESCRIPTION
I have permissions on the plugins using this library https://github.com/jenkins-infra/repository-permissions-updater/blob/2be1115a66072d5c981770e5c68cc35f2e14c730/permissions/plugin-durable-task.yml#L9 https://github.com/jenkins-infra/repository-permissions-updater/blob/2be1115a66072d5c981770e5c68cc35f2e14c730/permissions/plugin-workflow-durable-task-step.yml#L9C1-L10C1 but not the library itself, blocking me from merging things like https://github.com/jenkinsci/lib-durable-task/pull/128.

As usual, this file itself has no actual effect; what I need is the GitHub write permission.

CC @car-roll @dwnusbaum @jtnord @batmat @olamy 

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
