### PR TITLE
Migrate maven plugin issues to GitHub

### DIFF
--- a/permissions/plugin-maven-plugin.yml
+++ b/permissions/plugin-maven-plugin.yml
@@ -1,8 +1,8 @@
 ---
 name: "maven-plugin"
-github: "jenkinsci/maven-plugin"
+github: &gh "jenkinsci/maven-plugin"
 issues:
-  - jira: '16033'  # maven-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/main/maven-plugin"
   - "org/jvnet/hudson/main/maven-plugin"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@olamy for approval

Let me know if any objections or questions