### PR TITLE
Migrate gerrit trigger plugin issues to GitHub

### DIFF
--- a/permissions/plugin-gerrit-trigger.yml
+++ b/permissions/plugin-gerrit-trigger.yml
@@ -1,8 +1,8 @@
 ---
 name: "gerrit-trigger"
-github: "jenkinsci/gerrit-trigger-plugin"
+github: &gh "jenkinsci/gerrit-trigger-plugin"
 issues:
-  - jira: '15731'  # gerrit-trigger-plugin
+  - github: *gh
 paths:
   - "com/sonyericsson/hudson/plugins/gerrit/gerrit-trigger"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@rsandell for approval

Let me know if any objections or questions