### PR TITLE
Migrate matrix-project plugin issues to GitHub

### DIFF
--- a/permissions/plugin-matrix-project.yml
+++ b/permissions/plugin-matrix-project.yml
@@ -1,8 +1,8 @@
 ---
 name: "matrix-project"
-github: "jenkinsci/matrix-project-plugin"
+github: &gh "jenkinsci/matrix-project-plugin"
 issues:
-  - jira: '18765'  # matrix-project-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/matrix-project"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@oleg-nenashev / @amuniz / @batmat / @rsandell for approval

Let me know if any objections or questions