### PR TITLE
Migrate docker-workflow plugin issues to GitHub

### DIFF
--- a/permissions/plugin-docker-workflow.yml
+++ b/permissions/plugin-docker-workflow.yml
@@ -1,8 +1,8 @@
 ---
 name: "docker-workflow"
-github: "jenkinsci/docker-workflow-plugin"
+github: &gh "jenkinsci/docker-workflow-plugin"
 issues:
-  - jira: '20625'  # docker-workflow-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/docker-workflow"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick / @dwnusbaum / @oleg-nenashev  for approval

Let me know if any objections or questions