### PR TITLE
Migrate active directory plugin issues to GitHub

### DIFF
--- a/permissions/plugin-active-directory.yml
+++ b/permissions/plugin-active-directory.yml
@@ -1,8 +1,8 @@
 ---
 name: "active-directory"
-github: "jenkinsci/active-directory-plugin"
+github: &gh "jenkinsci/active-directory-plugin"
 issues:
-  - jira: '15526'  # active-directory-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/active-directory"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@batmat / @jtnord / @rsandell  for approval

Let me know if any objections or questions