### PR TITLE
Migrate parameterized-trigger plugin issues to GitHub

### DIFF
--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -1,8 +1,8 @@
 ---
 name: "parameterized-trigger"
-github: "jenkinsci/parameterized-trigger-plugin"
+github: &gh "jenkinsci/parameterized-trigger-plugin"
 issues:
-  - jira: '15592'  # parameterized-trigger-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/parameterized-trigger"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@MarkEWaite  for approval

Let me know if any objections or questions