### PR TITLE
Migrate promoted builds plugin issues to GitHub

### DIFF
--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -1,8 +1,8 @@
 ---
 name: "promoted-builds"
-github: "jenkinsci/promoted-builds-plugin"
+github: &gh "jenkinsci/promoted-builds-plugin"
 issues:
-  - jira: '15567'  # promoted-builds-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/promoted-builds"
   - "org/jvnet/hudson/plugins/promoted-builds"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@oleg-nenashev / @jtnord / @MarkEWaite  for approval

Let me know if any objections or questions