### PR TITLE
Migrate build-failure-analyzer plugin issues to GitHub

### DIFF
--- a/permissions/plugin-build-failure-analyzer.yml
+++ b/permissions/plugin-build-failure-analyzer.yml
@@ -1,8 +1,8 @@
 ---
 name: "build-failure-analyzer"
-github: "jenkinsci/build-failure-analyzer-plugin"
+github: &gh "jenkinsci/build-failure-analyzer-plugin"
 issues:
-  - jira: '17224'  # build-failure-analyzer-plugin
+  - github: *gh
 paths:
   - "com/sonyericsson/jenkins/plugins/bfa/build-failure-analyzer"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@rsandell  / @TWestling for approval

Let me know if any objections or questions