### PR TITLE
Migrate envinject plugin issues to GitHub

### DIFF
--- a/permissions/plugin-envinject.yml
+++ b/permissions/plugin-envinject.yml
@@ -1,8 +1,8 @@
 ---
 name: "envinject"
-github: "jenkinsci/envinject-plugin"
+github: &gh "jenkinsci/envinject-plugin"
 issues:
-  - jira: '15893'  # envinject-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/envinject"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@NotMyFault  for approval

Let me know if any objections or questions