### PR TITLE
Migrate workflow-cps plugin issues to GitHub

### DIFF
--- a/permissions/plugin-workflow-cps.yml
+++ b/permissions/plugin-workflow-cps.yml
@@ -1,6 +1,6 @@
 ---
 name: "workflow-cps"
-github: "jenkinsci/workflow-cps-plugin"
+github: &gh "jenkinsci/workflow-cps-plugin"
 issues:
   - github: *gh
 paths:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick  for approval

Let me know if any objections or questions