### PR TITLE
Migrate pipeline-model-definition plugin issues to GitHub

### DIFF
--- a/permissions/plugin-pipeline-model-definition.yml
+++ b/permissions/plugin-pipeline-model-definition.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-model-definition"
-github: "jenkinsci/pipeline-model-definition-plugin"
+github: &gh "jenkinsci/pipeline-model-definition-plugin"
 issues:
-  - jira: '21706'  # pipeline-model-definition-plugin
+  - github: *gh
 paths:
   - "org/jenkinsci/plugins/pipeline-model-definition"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@rsandell  / @jtnord / @batmat  for approval

Let me know if any objections or questions