### PR TITLE
Migrate p4 plugin issues to GitHub

### DIFF
--- a/permissions/plugin-p4.yml
+++ b/permissions/plugin-p4.yml
@@ -1,8 +1,8 @@
 ---
 name: "p4"
-github: "jenkinsci/p4-plugin"
+github: &gh "jenkinsci/p4-plugin"
 issues:
-  - jira: '19224'  # p4-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/p4"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components and many plugins are migrated to GitHub from Jira, I'd like to request to migrate this plugins issues to GitHub. See https://jenkins.io/jep/238 for more details. 

@ajindal-mdx / @msmeeth56 / @p4charu / @p4paul / @skumar7322 for approval

Let me know if any objections or questions