### PR TITLE
Migrate subversion plugin issues to GitHub

### DIFF
--- a/permissions/plugin-subversion.yml
+++ b/permissions/plugin-subversion.yml
@@ -1,8 +1,8 @@
 ---
 name: "subversion"
-github: "jenkinsci/subversion-plugin"
+github: &gh "jenkinsci/subversion-plugin"
 issues:
-  - jira: '15485'  # subversion-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/subversion"
   - "org/jvnet/hudson/plugins/subversion"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@didiez for approval

Let me know if any objections or questions