### PR TITLE
Migrate ldap plugin issues to GitHub

### DIFF
--- a/permissions/plugin-ldap.yml
+++ b/permissions/plugin-ldap.yml
@@ -1,8 +1,8 @@
 ---
 name: "ldap"
-github: "jenkinsci/ldap-plugin"
+github: &gh "jenkinsci/ldap-plugin"
 issues:
-  - jira: '17122'  # ldap-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/ldap"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@rsandell for approval

Let me know if any objections or questions