### PR TITLE
Migrate github plugin issues to GitHub

### DIFF
--- a/permissions/plugin-github.yml
+++ b/permissions/plugin-github.yml
@@ -1,8 +1,8 @@
 ---
 name: "github"
-github: "jenkinsci/github-plugin"
+github: &gh "jenkinsci/github-plugin"
 issues:
-  - jira: '15896'  # github-plugin
+  - github: *gh
 paths:
   - "com/coravy/hudson/plugins/github/github"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@KostyaSha for approval

Let me know if any objections or questions