### PR TITLE
Migrate hp-application-automation-tools-plugin plugin issues to GitHub

### DIFF
--- a/permissions/plugin-hp-application-automation-tools-plugin.yml
+++ b/permissions/plugin-hp-application-automation-tools-plugin.yml
@@ -1,8 +1,8 @@
 ---
 name: "hp-application-automation-tools-plugin"
-github: "jenkinsci/hpe-application-automation-tools-plugin"
+github: &gh "jenkinsci/hpe-application-automation-tools-plugin"
 issues:
-  - jira: '17322'  # hp-application-automation-tools-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/hp-application-automation-tools-plugin"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@LauraBuzas / @andreibangau99 for approval

Let me know if any objections or questions