### PR TITLE
Migrate Active Choices plugin issues to GitHub

### DIFF
--- a/permissions/plugin-uno-choice.yml
+++ b/permissions/plugin-uno-choice.yml
@@ -1,8 +1,8 @@
 ---
 name: "uno-choice"
-github: "jenkinsci/active-choices-plugin"
+github: &gh "jenkinsci/active-choices-plugin"
 issues:
-  - jira: '20520'  # active-choices-plugin
+  - github: *gh
 paths:
   - "org/biouno/uno-choice"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@kinow  for approval

Let me know if any objections or questions