### PR TITLE
Migrate xcode-plugin plugin issues to GitHub

### DIFF
--- a/permissions/plugin-xcode-plugin.yml
+++ b/permissions/plugin-xcode-plugin.yml
@@ -1,8 +1,8 @@
 ---
 name: "xcode-plugin"
-github: "jenkinsci/xcode-plugin"
+github: &gh "jenkinsci/xcode-plugin"
 issues:
-  - jira: '16124'  # xcode-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/xcode-plugin"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@kazuhidet for approval

Let me know if any objections or questions