### PR TITLE
Migrate build-pipeline-plugin plugin issues to GitHub

### DIFF
--- a/permissions/plugin-build-pipeline-plugin.yml
+++ b/permissions/plugin-build-pipeline-plugin.yml
@@ -1,8 +1,8 @@
 ---
 name: "build-pipeline-plugin"
-github: "jenkinsci/build-pipeline-plugin"
+github: &gh "jenkinsci/build-pipeline-plugin"
 issues:
-  - jira: '15962'  # build-pipeline-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/build-pipeline-plugin"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@recena / @geoffbullen / @dalvizu  for approval

Let me know if any objections or questions