### PR TITLE
Migrate clearcase plugin issues to GitHub

### DIFF
--- a/permissions/plugin-clearcase.yml
+++ b/permissions/plugin-clearcase.yml
@@ -1,8 +1,8 @@
 ---
 name: "clearcase"
-github: "jenkinsci/clearcase-plugin"
+github: &gh "jenkinsci/clearcase-plugin"
 issues:
-  - jira: '15503'  # clearcase-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/clearcase"
   - "org/jvnet/hudson/plugins/clearcase"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@Vlatombe / @MadsNielsen  for approval

Let me know if any objections or questions