### PR TITLE
Migrate credentials plugin issues to GitHub

### DIFF
--- a/permissions/plugin-credentials.yml
+++ b/permissions/plugin-credentials.yml
@@ -1,8 +1,8 @@
 ---
 name: "credentials"
-github: "jenkinsci/credentials-plugin"
+github: &gh "jenkinsci/credentials-plugin"
 issues:
-  - jira: '16523'  # credentials-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/credentials"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions