### PR TITLE
Migrate durable-task plugin issues to GitHub

### DIFF
--- a/permissions/plugin-durable-task.yml
+++ b/permissions/plugin-durable-task.yml
@@ -1,8 +1,8 @@
 ---
 name: "durable-task"
-github: "jenkinsci/durable-task-plugin"
+github: &gh "jenkinsci/durable-task-plugin"
 issues:
-  - jira: '18622'  # durable-task-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/durable-task"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions