### PR TITLE
Migrate script-security plugin issues to GitHub

### DIFF
--- a/permissions/plugin-script-security.yml
+++ b/permissions/plugin-script-security.yml
@@ -1,8 +1,8 @@
 ---
 name: "script-security"
-github: "jenkinsci/script-security-plugin"
+github: &gh "jenkinsci/script-security-plugin"
 issues:
-  - jira: '18520'  # script-security-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/script-security"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions