### PR TITLE
remove ifernandez from ssh-build-agents and saml plugin

### DIFF
--- a/permissions/plugin-saml.yml
+++ b/permissions/plugin-saml.yml
@@ -8,7 +8,6 @@ paths:
 developers:
   - "0xcfff"
   - "chengas123"
-  - "ifernandezcalvo"
   - "mdonohue"
   - "sbower"
 security:

--- a/permissions/plugin-ssh-slaves.yml
+++ b/permissions/plugin-ssh-slaves.yml
@@ -10,7 +10,6 @@ developers:
   - "jglick"
   - "kohsuke"
   - "oleg_nenashev"
-  - "ifernandezcalvo"
   - "olamy"
 security:
   contacts:


### PR DESCRIPTION
# Link to GitHub repository

* https://github.com/jenkinsci/ssh-agents-plugin
* https://github.com/jenkinsci/saml-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- the same minus ifernandezcalvo

This is needed in order to cut releases of the plugin or component.

no

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
