### PR TITLE
Migrate email-ext plugin issues to GitHub

### DIFF
--- a/permissions/plugin-email-ext.yml
+++ b/permissions/plugin-email-ext.yml
@@ -1,8 +1,8 @@
 ---
 name: "email-ext"
-github: "jenkinsci/email-ext-plugin"
+github: &gh "jenkinsci/email-ext-plugin"
 issues:
-  - jira: '15538'  # email-ext-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/email-ext"
   - "org/jvnet/hudson/plugins/email-ext"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@slide for approval

Let me know if any objections or questions