### PR TITLE
Migrate warnings-ng plugin issues to GitHub

### DIFF
--- a/permissions/plugin-warnings-ng.yml
+++ b/permissions/plugin-warnings-ng.yml
@@ -1,8 +1,8 @@
 ---
 name: "warnings-ng"
-github: "jenkinsci/warnings-ng-plugin"
+github: &gh "jenkinsci/warnings-ng-plugin"
 issues:
-  - jira: '24526'  # warnings-ng-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/warnings-ng"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@uhafner for approval

Let me know if any objections or questions