### PR TITLE
Migrate warnings plugin issues to GitHub

### DIFF
--- a/permissions/plugin-warnings.yml
+++ b/permissions/plugin-warnings.yml
@@ -1,8 +1,8 @@
 ---
 name: "warnings"
-github: "jenkinsci/warnings-plugin"
+github: &gh "jenkinsci/warnings-plugin"
 issues:
-  - jira: '15513'  # warnings-plugin
+  - github: *gh
 paths:
   - "org/jvnet/hudson/plugins/warnings"
 developers: []


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@uhafner what do you think? I was thinking of unarchiving, migrating and rearchiving the repo, just so all the issue are on GitHub?