### PR TITLE
Migrate pipeline-maven plugin issues to GitHub

### DIFF
--- a/permissions/plugin-pipeline-maven.yml
+++ b/permissions/plugin-pipeline-maven.yml
@@ -1,10 +1,10 @@
 ---
 name: "pipeline-maven"
-github: "jenkinsci/pipeline-maven-plugin"
+github: &gh "jenkinsci/pipeline-maven-plugin"
 cd:
   enabled: true
 issues:
-  - jira: '21669'  # pipeline-maven-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/pipeline-maven"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@bguerin for approval

Let me know if any objections or questions