### PR TITLE
Migrate ssh-slaves plugin issues to GitHub

### DIFF
--- a/permissions/plugin-ssh-slaves.yml
+++ b/permissions/plugin-ssh-slaves.yml
@@ -1,8 +1,8 @@
 ---
 name: "ssh-slaves"
-github: "jenkinsci/ssh-agents-plugin"
+github: &gh "jenkinsci/ssh-agents-plugin"
 issues:
-  - jira: '15578'  # ssh-slaves-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/ssh-slaves"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick / @olamy for approval

Let me know if any objections or questions