### PR TITLE
Migrate xunit plugin issues to GitHub

### DIFF
--- a/permissions/plugin-xunit.yml
+++ b/permissions/plugin-xunit.yml
@@ -1,8 +1,8 @@
 ---
 name: "xunit"
-github: "jenkinsci/xunit-plugin"
+github: &gh "jenkinsci/xunit-plugin"
 issues:
-  - jira: '15636'  # xunit-plugin
+  - github: *gh
 paths:
   - "com/thalesgroup/jenkins-ci/plugins/xunit"
   - "org/jenkins-ci/plugins/xunit"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira. The majority of the top plugins are all using GitHub, I'd like to request to move this plugin too.

@nfalco79  for approval

Let me know if any objections or questions