### PR TITLE
Migrate role-strategy plugin issues to GitHub

### DIFF
--- a/permissions/plugin-role-strategy.yml
+++ b/permissions/plugin-role-strategy.yml
@@ -1,8 +1,8 @@
 ---
 name: "role-strategy"
-github: "jenkinsci/role-strategy-plugin"
+github: &gh "jenkinsci/role-strategy-plugin"
 issues:
-  - jira: '15758'  # role-strategy-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/role-strategy"
   - "org/jvnet/hudson/plugins/role-strategy"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@mawinter69  for approval

Let me know if any objections or questions