### PR TITLE
Migrate branch-api plugin issues to GitHub

### DIFF
--- a/permissions/plugin-branch-api.yml
+++ b/permissions/plugin-branch-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "branch-api"
-github: "jenkinsci/branch-api-plugin"
+github: &gh "jenkinsci/branch-api-plugin"
 issues:
-  - jira: '18621'  # branch-api-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/branch-api"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions