### PR TITLE
Migrate support-core plugin issues to GitHub

### DIFF
--- a/permissions/plugin-support-core.yml
+++ b/permissions/plugin-support-core.yml
@@ -1,8 +1,8 @@
 ---
 name: "support-core"
-github: "jenkinsci/support-core-plugin"
+github: &gh "jenkinsci/support-core-plugin"
 issues:
-  - jira: '18146'  # support-core-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/support-core"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions