### PR TITLE
Migrate mailer plugin issues to GitHub

### DIFF
--- a/permissions/plugin-mailer.yml
+++ b/permissions/plugin-mailer.yml
@@ -1,8 +1,8 @@
 ---
 name: "mailer"
-github: "jenkinsci/mailer-plugin"
+github: &gh "jenkinsci/mailer-plugin"
 issues:
-  - jira: '17522'  # mailer-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/mailer"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@alecharp / @jglick for approval

Let me know if any objections or questions