### PR TITLE
Migrate jobConfigHistory plugin issues to GitHub

### DIFF
--- a/permissions/plugin-jobConfigHistory.yml
+++ b/permissions/plugin-jobConfigHistory.yml
@@ -1,8 +1,8 @@
 ---
 name: "jobConfigHistory"
-github: "jenkinsci/job-config-history-plugin"
+github: &gh "jenkinsci/job-config-history-plugin"
 issues:
-  - jira: '15683'  # jobconfighistory-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/jobConfigHistory"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@StefanSpieker  for approval

Let me know if any objections or questions