### PR TITLE
Migrate htmlpublisher plugin issues to GitHub

### DIFF
--- a/permissions/plugin-htmlpublisher.yml
+++ b/permissions/plugin-htmlpublisher.yml
@@ -1,8 +1,8 @@
 ---
 name: "htmlpublisher"
-github: "jenkinsci/htmlpublisher-plugin"
+github: &gh "jenkinsci/htmlpublisher-plugin"
 issues:
-  - jira: '15681'  # htmlpublisher-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/htmlpublisher"
   - "org/jvnet/hudson/plugins/htmlpublisher"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@rsandell  for approval

Let me know if any objections or questions