### PR TITLE
Migrate saml plugin issues to GitHub

### DIFF
--- a/permissions/plugin-saml.yml
+++ b/permissions/plugin-saml.yml
@@ -1,8 +1,8 @@
 ---
 name: "saml"
-github: "jenkinsci/saml-plugin"
+github: &gh "jenkinsci/saml-plugin"
 issues:
-  - jira: '20321'  # saml-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/saml"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@mdonohue for approval

Let me know if any objections or questions