### PR TITLE
Migrate cloudbees-folder plugin issues to GitHub

### DIFF
--- a/permissions/plugin-cloudbees-folder.yml
+++ b/permissions/plugin-cloudbees-folder.yml
@@ -1,8 +1,8 @@
 ---
 name: "cloudbees-folder"
-github: "jenkinsci/cloudbees-folder-plugin"
+github: &gh "jenkinsci/cloudbees-folder-plugin"
 issues:
-  - jira: '18137'  # cloudbees-folder-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/cloudbees-folder"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions