### PR TITLE
Migrate matrix-auth plugin issues to GitHub

### DIFF
--- a/permissions/plugin-matrix-auth.yml
+++ b/permissions/plugin-matrix-auth.yml
@@ -1,8 +1,8 @@
 ---
 name: "matrix-auth"
-github: "jenkinsci/matrix-auth-plugin"
+github: &gh "jenkinsci/matrix-auth-plugin"
 issues:
-  - jira: '18131'  # matrix-auth-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/matrix-auth"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@daniel-beck for approval

Let me know if any objections or questions