### PR TITLE
Migrate workflow-multibranch plugin issues to GitHub

### DIFF
--- a/permissions/plugin-workflow-multibranch.yml
+++ b/permissions/plugin-workflow-multibranch.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-multibranch"
-github: "jenkinsci/workflow-multibranch-plugin"
+github: &gh "jenkinsci/workflow-multibranch-plugin"
 issues:
-  - jira: '21465'  # workflow-multibranch-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-multibranch"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions