### PR TITLE
Migrate workflow-job plugin issues to GitHub

### DIFF
--- a/permissions/plugin-workflow-job.yml
+++ b/permissions/plugin-workflow-job.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-job"
-github: "jenkinsci/workflow-job-plugin"
+github: &gh "jenkinsci/workflow-job-plugin"
 issues:
-  - jira: '21716'  # workflow-job-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-job"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions