### PR TITLE
Migrate workflow-cps-global-lib plugin issues to GitHub

### DIFF
--- a/permissions/plugin-workflow-cps-global-lib.yml
+++ b/permissions/plugin-workflow-cps-global-lib.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-cps-global-lib"
-github: "jenkinsci/workflow-cps-global-lib-plugin"
+github: &gh "jenkinsci/workflow-cps-global-lib-plugin"
 issues:
-  - jira: '21714'  # workflow-cps-global-lib-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-cps-global-lib"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions