### PR TITLE
Migrate workflow-durable-task-step plugin issues to GitHub

### DIFF
--- a/permissions/plugin-workflow-durable-task-step.yml
+++ b/permissions/plugin-workflow-durable-task-step.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-durable-task-step"
-github: "jenkinsci/workflow-durable-task-step-plugin"
+github: &gh "jenkinsci/workflow-durable-task-step-plugin"
 issues:
-  - jira: '21715'  # workflow-durable-task-step-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-durable-task-step"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions