### PR TITLE
Migrate credentials-binding plugin issues to GitHub

### DIFF
--- a/permissions/plugin-credentials-binding.yml
+++ b/permissions/plugin-credentials-binding.yml
@@ -1,8 +1,8 @@
 ---
 name: "credentials-binding"
-github: "jenkinsci/credentials-binding-plugin"
+github: &gh "jenkinsci/credentials-binding-plugin"
 issues:
-  - jira: '18129'  # credentials-binding-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/credentials-binding"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions