### PR TITLE
Migrate pipeline-utility-steps plugin issues to GitHub

### DIFF
--- a/permissions/plugin-pipeline-utility-steps.yml
+++ b/permissions/plugin-pipeline-utility-steps.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-utility-steps"
-github: "jenkinsci/pipeline-utility-steps-plugin"
+github: &gh "jenkinsci/pipeline-utility-steps-plugin"
 issues:
-  - jira: '21135'  # pipeline-utility-steps-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/pipeline-utility-steps"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@rsandell  for approval

Let me know if any objections or questions