### PR TITLE
Migrate timestamper plugin issues to GitHub

### DIFF
--- a/permissions/plugin-timestamper.yml
+++ b/permissions/plugin-timestamper.yml
@@ -1,8 +1,8 @@
 ---
 name: "timestamper"
-github: "jenkinsci/timestamper-plugin"
+github: &gh "jenkinsci/timestamper-plugin"
 issues:
-  - jira: '15749'  # timestamper-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/timestamper"
   - "org/jvnet/hudson/plugins/timestamper"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@basil for approval

Let me know if any objections or questions