### PR TITLE
Migrate analysis-model-api plugin issues to GitHub

### DIFF
--- a/permissions/plugin-analysis-model-api.yml
+++ b/permissions/plugin-analysis-model-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "analysis-model-api"
-github: "jenkinsci/analysis-model-api-plugin"
+github: &gh "jenkinsci/analysis-model-api-plugin"
 issues:
-  - jira: '24221'  # analysis-model-api-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/analysis-model-api"
   - "io/jenkins/plugins/analysis-model-api"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Approved in https://github.com/jenkins-infra/repository-permissions-updater/pull/4794#issuecomment-3636462631
FYI @uhafner 

Let me know if any objections or questions