### PR TITLE
Migrate 4 (timja owned) plugins issues to GitHub

### DIFF
--- a/permissions/plugin-beer.yml
+++ b/permissions/plugin-beer.yml
@@ -1,8 +1,8 @@
 ---
 name: "beer"
-github: "jenkinsci/beer-plugin"
+github: &gh "jenkinsci/beer-plugin"
 issues:
-  - jira: '17586'  # beer-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/beer"
 developers:

--- a/permissions/plugin-junit-sql-storage.yml
+++ b/permissions/plugin-junit-sql-storage.yml
@@ -3,7 +3,6 @@ name: "junit-sql-storage"
 github: &gh "jenkinsci/junit-sql-storage-plugin"
 issues:
   - github: *gh
-  - jira: '28020'  # junit-sql-storage-plugin
 paths:
   - "io/jenkins/plugins/junit-sql-storage"
 developers:

--- a/permissions/plugin-slack.yml
+++ b/permissions/plugin-slack.yml
@@ -3,7 +3,6 @@ name: "slack"
 github: &gh "jenkinsci/slack-plugin"
 issues:
   - github: *gh
-  - jira: '18321'  # slack-plugin
 paths:
   - "org/jenkins-ci/plugins/slack"
 cd:

--- a/permissions/plugin-theme-manager.yml
+++ b/permissions/plugin-theme-manager.yml
@@ -3,8 +3,6 @@ name: "theme-manager"
 github: &gh "jenkinsci/theme-manager-plugin"
 issues:
   - github: *gh
-  - jira: '27322'  # theme-manager-plugin
-    report: false
 paths:
   - "io/jenkins/plugins/theme-manager"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

- beer
- junit-sql-storage
- slack
- theme-manager