### PR TITLE
Migrate gradle plugin issues to GitHub

### DIFF
--- a/permissions/plugin-gradle.yml
+++ b/permissions/plugin-gradle.yml
@@ -1,8 +1,8 @@
 ---
 name: "gradle"
-github: "jenkinsci/gradle-plugin"
+github: &gh "jenkinsci/gradle-plugin"
 issues:
-  - jira: '15547'  # gradle-plugin
+  - github: *gh
 paths:
   - "com/zenika/jenkins-ci/plugins/gradle"
   - "org/jenkins-ci/plugins/gradle"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. Most of the top plugins are all on GitHub issues now

@alextu for approval

Let me know if any objections or questions