### PR TITLE
Migrate workflow-basic-steps plugin issues to GitHub

### DIFF
--- a/permissions/plugin-workflow-basic-steps.yml
+++ b/permissions/plugin-workflow-basic-steps.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-basic-steps"
-github: "jenkinsci/workflow-basic-steps-plugin"
+github: &gh "jenkinsci/workflow-basic-steps-plugin"
 issues:
-  - jira: '21712'  # workflow-basic-steps-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-basic-steps"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

@jglick for approval

Let me know if any objections or questions