### PR TITLE
Migrate 3 plugins issues to GitHub

### DIFF
--- a/permissions/plugin-additional-identities-plugin.yml
+++ b/permissions/plugin-additional-identities-plugin.yml
@@ -1,8 +1,7 @@
 ---
 name: "additional-identities-plugin"
-github: &gh "&GH jenkinsci/additional-identities-plugin"
+github: &gh "jenkinsci/additional-identities-plugin"
 issues:
-  - github: *GH
   - github: *gh
 paths:
   - "com/cloudbees/jenkins/plugins/additional-identities-plugin"

--- a/permissions/plugin-gravatar.yml
+++ b/permissions/plugin-gravatar.yml
@@ -1,8 +1,7 @@
 ---
 name: "gravatar"
-github: &gh "&GH jenkinsci/gravatar-plugin"
+github: &gh "jenkinsci/gravatar-plugin"
 issues:
-  - github: *GH
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/gravatar"

--- a/permissions/plugin-scoring-load-balancer.yml
+++ b/permissions/plugin-scoring-load-balancer.yml
@@ -1,8 +1,7 @@
 ---
 name: "scoring-load-balancer"
-github: &gh "&GH jenkinsci/scoring-load-balancer-plugin"
+github: &gh "jenkinsci/scoring-load-balancer-plugin"
 issues:
-  - github: *GH
   - github: *gh
 paths:
   - "jp/ikedam/jenkins/plugins/scoring-load-balancer"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- gravatar
- additional-identities-plugin
- scoring-load-balancer

Fixes https://github.com/jenkinsci/gravatar-plugin/issues/38
Fixes https://github.com/jenkinsci/additional-identities-plugin/issues/44
Fixes https://github.com/jenkinsci/scoring-load-balancer-plugin/issues/49

FYI @viceice

Given the open issues taking those as pre-approval and I've migrated the existing issues over.


<!--
Jira to GitHub mapping:

-->