### PR TITLE
Migrate 3 plugins issues to GitHub

### DIFF
--- a/permissions/plugin-text-finder.yml
+++ b/permissions/plugin-text-finder.yml
@@ -1,8 +1,8 @@
 ---
 name: "text-finder"
-github: "jenkinsci/text-finder-plugin"
+github: &gh "jenkinsci/text-finder-plugin"
 issues:
-  - jira: '15583'  # text-finder-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/text-finder"
   - "org/jvnet/hudson/plugins/text-finder"

--- a/permissions/plugin-throttle-concurrents.yml
+++ b/permissions/plugin-throttle-concurrents.yml
@@ -1,8 +1,8 @@
 ---
 name: "throttle-concurrents"
-github: "jenkinsci/throttle-concurrent-builds-plugin"
+github: &gh "jenkinsci/throttle-concurrent-builds-plugin"
 issues:
-  - jira: '15745'  # throttle-concurrent-builds-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/throttle-concurrents"
   - "org/jvnet/hudson/plugins/throttle-concurrents"

--- a/permissions/plugin-timestamper.yml
+++ b/permissions/plugin-timestamper.yml
@@ -1,8 +1,8 @@
 ---
 name: "timestamper"
-github: "jenkinsci/timestamper-plugin"
+github: &gh "jenkinsci/timestamper-plugin"
 issues:
-  - jira: '15749'  # timestamper-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/timestamper"
   - "org/jvnet/hudson/plugins/timestamper"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- text-finder
- throttle-concurrents
- timestamper

@MarkEWaite for approval

Let me know if any objections or questions

<!--
Jira to GitHub mapping:
text-finder-plugin:text-finder-plugin
throttle-concurrent-builds-plugin:throttle-concurrent-builds-plugin
timestamper-plugin:timestamper-plugin

-->