### PR TITLE
Migrate gitee plugin issues to GitHub

### DIFF
--- a/permissions/plugin-gitee.yml
+++ b/permissions/plugin-gitee.yml
@@ -1,8 +1,8 @@
 ---
 name: "gitee"
-github: "jenkinsci/gitee-plugin"
+github: &gh "jenkinsci/gitee-plugin"
 issues:
-  - jira: '23941'  # gitee-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/gitee"
 cd:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- gitee

Approved by @Puffy1215 in https://github.com/jenkins-infra/repository-permissions-updater/pull/4837#issuecomment-3665756331

Let me know if any objections or questions

<!--
Jira to GitHub mapping:
gitee-plugin:gitee-plugin

-->