### PR TITLE
Migrate git-forensics plugin issues to GitHub

### DIFF
--- a/permissions/plugin-git-forensics.yml
+++ b/permissions/plugin-git-forensics.yml
@@ -1,8 +1,8 @@
 ---
 name: "git-forensics"
-github: "jenkinsci/git-forensics-plugin"
+github: &gh "jenkinsci/git-forensics-plugin"
 issues:
-  - jira: '25321'  # git-forensics-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/git-forensics"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- git-forensics

@uhafner  for approval

Let me know if any objections or questions

(noticed https://github.com/jenkinsci/jenkins/issues/25948 and went to transfer it but this one isn't migrated yet)

<!--
Jira to GitHub mapping:
git-forensics-plugin:git-forensics-plugin

-->