### PR TITLE
Migrate 18 (uhafner) plugins issues to GitHub

### DIFF
--- a/permissions/plugin-autograding.yml
+++ b/permissions/plugin-autograding.yml
@@ -1,8 +1,8 @@
 ---
 name: "autograding"
-github: "jenkinsci/autograding-plugin"
+github: &gh "jenkinsci/autograding-plugin"
 issues:
-  - jira: '27127'  # autograding-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/autograding"
 developers:

--- a/permissions/plugin-bootstrap4-api.yml
+++ b/permissions/plugin-bootstrap4-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "bootstrap4-api"
-github: "jenkinsci/bootstrap4-api-plugin"
+github: &gh "jenkinsci/bootstrap4-api-plugin"
 issues:
-  - jira: '26330'  # bootstrap4-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/bootstrap4-api"
 developers:

--- a/permissions/plugin-bootstrap5-api.yml
+++ b/permissions/plugin-bootstrap5-api.yml
@@ -1,12 +1,12 @@
 ---
 name: "bootstrap5-api"
-github: "jenkinsci/bootstrap5-api-plugin"
+github: &gh "jenkinsci/bootstrap5-api-plugin"
 paths:
   - "io/jenkins/plugins/bootstrap5-api"
 developers:
   - "drulli"
 issues:
-  - jira: 28620
+  - github: *gh
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-checks-api.yml
+++ b/permissions/plugin-checks-api.yml
@@ -3,7 +3,6 @@ name: "checks-api"
 github: &gh "jenkinsci/checks-api-plugin"
 issues:
   - github: *gh
-  - jira: '27529'  # checks-api-plugin
 paths:
   - "io/jenkins/plugins/checks-api"
 developers:

--- a/permissions/plugin-cobertura.yml
+++ b/permissions/plugin-cobertura.yml
@@ -2,7 +2,6 @@
 name: "cobertura"
 github: &gh "jenkinsci/cobertura-plugin"
 issues:
-  - jira: '15500'  # cobertura-plugin
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/cobertura"

--- a/permissions/plugin-code-coverage-api.yml
+++ b/permissions/plugin-code-coverage-api.yml
@@ -3,7 +3,6 @@ name: "code-coverage-api"
 github: &gh "jenkinsci/code-coverage-api-plugin"
 issues:
   - github: *gh
-  - jira: '23723'  # code-coverage-api-plugin
 paths:
   - "io/jenkins/plugins/code-coverage-api"
 developers:

--- a/permissions/plugin-coverage.yml
+++ b/permissions/plugin-coverage.yml
@@ -1,8 +1,8 @@
 ---
 name: "coverage"
-github: "jenkinsci/coverage-plugin"
+github: &gh "jenkinsci/coverage-plugin"
 issues:
-  - jira: '29223'  # coverage-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/coverage"
 developers:

--- a/permissions/plugin-data-tables-api.yml
+++ b/permissions/plugin-data-tables-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "data-tables-api"
-github: "jenkinsci/data-tables-api-plugin"
+github: &gh "jenkinsci/data-tables-api-plugin"
 issues:
-  - jira: '26333'  # data-tables-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/data-tables-api"
 developers:

--- a/permissions/plugin-echarts-api.yml
+++ b/permissions/plugin-echarts-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "echarts-api"
-github: "jenkinsci/echarts-api-plugin"
+github: &gh "jenkinsci/echarts-api-plugin"
 issues:
-  - jira: '26331'  # echarts-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/echarts-api"
 developers:

--- a/permissions/plugin-font-awesome-api.yml
+++ b/permissions/plugin-font-awesome-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "font-awesome-api"
-github: "jenkinsci/font-awesome-api-plugin"
+github: &gh "jenkinsci/font-awesome-api-plugin"
 issues:
-  - jira: '26326'  # font-awesome-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/font-awesome-api"
 developers:

--- a/permissions/plugin-forensics-api.yml
+++ b/permissions/plugin-forensics-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "forensics-api"
-github: "jenkinsci/forensics-api-plugin"
+github: &gh "jenkinsci/forensics-api-plugin"
 issues:
-  - jira: '25439'  # forensics-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/forensics-api"
 developers:

--- a/permissions/plugin-github-checks.yml
+++ b/permissions/plugin-github-checks.yml
@@ -3,7 +3,6 @@ name: "github-checks"
 github: &gh "jenkinsci/github-checks-plugin"
 issues:
   - github: *gh
-  - jira: '27523'  # github-checks-plugin
 paths:
   - "io/jenkins/plugins/github-checks"
 developers:

--- a/permissions/plugin-jquery3-api.yml
+++ b/permissions/plugin-jquery3-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "jquery3-api"
-github: "jenkinsci/jquery3-api-plugin"
+github: &gh "jenkinsci/jquery3-api-plugin"
 issues:
-  - jira: '26329'  # jquery3-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/jquery3-api"
 developers:

--- a/permissions/plugin-metrics-aggregation.yml
+++ b/permissions/plugin-metrics-aggregation.yml
@@ -1,8 +1,8 @@
 ---
 name: "metrics-aggregation"
-github: "jenkinsci/metrics-aggregation-plugin"
+github: &gh "jenkinsci/metrics-aggregation-plugin"
 issues:
-  - jira: '26720'  # metrics-aggregation-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/metrics-aggregation"
 developers:

--- a/permissions/plugin-plugin-util-api.yml
+++ b/permissions/plugin-plugin-util-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "plugin-util-api"
-github: "jenkinsci/plugin-util-api-plugin"
+github: &gh "jenkinsci/plugin-util-api-plugin"
 issues:
-  - jira: '26521'  # plugin-util-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/plugin-util-api"
 developers:

--- a/permissions/plugin-popper-api.yml
+++ b/permissions/plugin-popper-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "popper-api"
-github: "jenkinsci/popper-api-plugin"
+github: &gh "jenkinsci/popper-api-plugin"
 issues:
-  - jira: '26328'  # popper-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/popper-api"
 developers:

--- a/permissions/plugin-popper2-api.yml
+++ b/permissions/plugin-popper2-api.yml
@@ -6,4 +6,4 @@ paths:
 developers:
   - "drulli"
 issues:
-  - jira: 28621
+  - github: *GH

--- a/permissions/plugin-prism-api.yml
+++ b/permissions/plugin-prism-api.yml
@@ -1,12 +1,12 @@
 ---
 name: "prism-api"
-github: "jenkinsci/prism-api-plugin"
+github: &gh "jenkinsci/prism-api-plugin"
 paths:
   - "io/jenkins/plugins/prism-api"
 developers:
   - "drulli"
 issues:
-  - jira: 28824
+  - github: *gh
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- bootstrap4-api
- jquery3-api
- bootstrap5-api
- autograding
- echarts-api
- cobertura
- code-coverage-api
- data-tables-api
- forensics-api
- checks-api
- prism-api
- metrics-aggregation
- coverage
- popper-api
- font-awesome-api
- plugin-util-api
- popper2-api
- github-checks

@uhafner for approval

Let me know if any objections or questions

<!--
Jira to GitHub mapping:
bootstrap4-api-plugin:bootstrap4-api-plugin
jquery3-api-plugin:jquery3-api-plugin
bootstrap5-api-plugin:bootstrap5-api-plugin
autograding-plugin:autograding-plugin
echarts-api-plugin:echarts-api-plugin
cobertura-plugin:cobertura-plugin
code-coverage-api-plugin:code-coverage-api-plugin
data-tables-api-plugin:data-tables-api-plugin
forensics-api-plugin:forensics-api-plugin
checks-api-plugin:checks-api-plugin
prism-api-plugin:prism-api-plugin
git-forensics-plugin:git-forensics-plugin
metrics-aggregation-plugin:metrics-aggregation-plugin
coverage-plugin:coverage-plugin
popper-api-plugin:popper-api-plugin
font-awesome-api-plugin:font-awesome-api-plugin
plugin-util-api-plugin:plugin-util-api-plugin
popper2-api-plugin:popper2-api-plugin
github-checks-plugin:github-checks-plugin

-->