### PR TITLE
Revert "Block new releases of qualys-cs"

### DIFF
--- a/permissions/plugin-qualys-cs.yml
+++ b/permissions/plugin-qualys-cs.yml
@@ -3,7 +3,6 @@ name: "qualys-cs"
 github: "jenkinsci/qualys-cs-plugin"
 issues:
   - jira: '26526'  # qualys-cs-plugin
-releaseBlocked: true
 paths:
   - "com/qualys/plugins/qualys-cs"
 developers:


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#4847 so @Bhagyashri-Sapnar can proceed to a new release without any closed source code.

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/4917#issuecomment-3674604348
- https://github.com/jenkins-infra/helpdesk/issues/4917#issuecomment-3674611424

cc @daniel-beck @jenkins-infra/board FYI