### PR TITLE
Use new `issue-redirect.jenkins.io` service in autolinks

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Hoster.java
@@ -264,7 +264,7 @@ public class Hoster {
         r.setHomepage("https://plugins.jenkins.io/" + r.getName().replace("-plugin", "") + "/");
         r.createAutolink()
                 .withKeyPrefix("JENKINS-")
-                .withUrlTemplate("https://issues.jenkins.io/browse/JENKINS-<num>")
+                .withUrlTemplate("https://issue-redirect.jenkins.io/browse/JENKINS-<num>")
                 .withIsAlphanumeric(false)
                 .create();
         r.createAutolink()


### PR DESCRIPTION
This PR uses the new https://issue-redirect.jenkins.io redirection service put in place cf https://github.com/jenkins-infra/helpdesk/issues/4889.

FTR, an autolink is also now created in post-process of Jira migrations.

Refs:
- https://github.com/jenkins-infra/repository-permissions-updater/pull/4513
- https://github.com/jenkins-infra/repository-permissions-updater/issues/3800#issuecomment-3682114985
- https://github.com/jenkins-infra/helpdesk/issues/4889
- https://github.com/jenkins-infra/docker-issue-redirect/pull/9
- https://github.com/lemeurherve/jira-issues-importer/pull/79


