### PR TITLE
Leave a comment if `/hosting host` is executed by a non-hosting team member

### DIFF
--- a/.github/workflows/hosting-comment-hoster.yml
+++ b/.github/workflows/hosting-comment-hoster.yml
@@ -73,5 +73,5 @@ jobs:
               owner,
               repo,
               issue_number: context.issue.number,
-              body: `@${context.actor} only the hosting team can use this command to hosts the repository, once it's ready.`,
+              body: `@${context.actor} only the hosting team can use this command to host the repository, once it's ready.`,
             });


### PR DESCRIPTION
As the title says, and adds a 👎 to the user's comment.

I've seen people using the command occasionally and might wonder why nothing happens.