### PR TITLE
Migrate 13 plugins (timja) issues to GitHub

### DIFF
--- a/permissions/plugin-configuration-as-code.yml
+++ b/permissions/plugin-configuration-as-code.yml
@@ -16,5 +16,3 @@ cd:
   enabled: true
 issues:
   - github: *GH
-  - jira: 23170  # configuration-as-code-plugin
-    report: false

--- a/permissions/plugin-database-h2.yml
+++ b/permissions/plugin-database-h2.yml
@@ -1,8 +1,8 @@
 ---
 name: "database-h2"
-github: "jenkinsci/database-h2-plugin"
+github: &gh "jenkinsci/database-h2-plugin"
 issues:
-  - jira: '17445'  # database-h2-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/database-h2"
 developers:

--- a/permissions/plugin-database-mysql.yml
+++ b/permissions/plugin-database-mysql.yml
@@ -1,8 +1,8 @@
 ---
 name: "database-mysql"
-github: "jenkinsci/database-mysql-plugin"
+github: &gh "jenkinsci/database-mysql-plugin"
 issues:
-  - jira: '17550'  # database-mysql-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/database-mysql"
 developers:

--- a/permissions/plugin-database-postgresql.yml
+++ b/permissions/plugin-database-postgresql.yml
@@ -1,8 +1,8 @@
 ---
 name: "database-postgresql"
-github: "jenkinsci/database-postgresql-plugin"
+github: &gh "jenkinsci/database-postgresql-plugin"
 issues:
-  - jira: '17471'  # database-postgresql-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/database-postgresql"
 developers:

--- a/permissions/plugin-h2-api.yml
+++ b/permissions/plugin-h2-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "h2-api"
-github: "jenkinsci/h2-api-plugin"
+github: &gh "jenkinsci/h2-api-plugin"
 issues:
-  - jira: '25421'  # h2-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/h2-api"
 developers:

--- a/permissions/plugin-modernstatus.yml
+++ b/permissions/plugin-modernstatus.yml
@@ -1,8 +1,8 @@
 ---
 name: "modernstatus"
-github: "jenkinsci/modernstatus-plugin"
+github: &gh "jenkinsci/modernstatus-plugin"
 issues:
-  - jira: '19920'  # modernstatus-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/modernstatus"
 developers:

--- a/permissions/plugin-pipeline-graph-analysis.yml
+++ b/permissions/plugin-pipeline-graph-analysis.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-graph-analysis"
-github: "jenkinsci/pipeline-graph-analysis-plugin"
+github: &gh "jenkinsci/pipeline-graph-analysis-plugin"
 issues:
-  - jira: '21693'  # pipeline-graph-analysis-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/pipeline-graph-analysis"
 developers:

--- a/permissions/plugin-postbuild-task.yml
+++ b/permissions/plugin-postbuild-task.yml
@@ -1,8 +1,8 @@
 ---
 name: "postbuild-task"
-github: "jenkinsci/postbuild-task-plugin"
+github: &gh "jenkinsci/postbuild-task-plugin"
 issues:
-  - jira: '16010'  # postbuild-task-plugin
+  - github: *gh
 paths:
   - "org/jvnet/hudson/plugins/postbuild-task"
 cd:

--- a/permissions/plugin-postgresql-api.yml
+++ b/permissions/plugin-postgresql-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "postgresql-api"
-github: "jenkinsci/postgresql-api-plugin"
+github: &gh "jenkinsci/postgresql-api-plugin"
 issues:
-  - jira: '25426'  # postgresql-api-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/postgresql-api"
 developers:

--- a/permissions/plugin-release.yml
+++ b/permissions/plugin-release.yml
@@ -1,8 +1,8 @@
 ---
 name: "release"
-github: "jenkinsci/release-plugin"
+github: &gh "jenkinsci/release-plugin"
 issues:
-  - jira: '15622'  # release-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/release"
   - "org/jvnet/hudson/plugins/release"

--- a/permissions/plugin-run-condition.yml
+++ b/permissions/plugin-run-condition.yml
@@ -1,8 +1,8 @@
 ---
 name: "run-condition"
-github: "jenkinsci/run-condition-plugin"
+github: &gh "jenkinsci/run-condition-plugin"
 issues:
-  - jira: '16129'  # run-condition-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/run-condition"
 developers:

--- a/permissions/plugin-scm-api.yml
+++ b/permissions/plugin-scm-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "scm-api"
-github: "jenkinsci/scm-api-plugin"
+github: &gh "jenkinsci/scm-api-plugin"
 issues:
-  - jira: '18054'  # scm-api-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/scm-api"
 cd:

--- a/permissions/plugin-snakeyaml-api.yml
+++ b/permissions/plugin-snakeyaml-api.yml
@@ -2,7 +2,6 @@
 name: "snakeyaml-api"
 github: &gh "jenkinsci/snakeyaml-api-plugin"
 issues:
-  - jira: '27125'  # snakeyaml-plugin
   - github: *gh
 paths:
   - "io/jenkins/plugins/snakeyaml-api"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- configuration-as-code
- database-h2
- database-mysql
- database-postgresql
- h2-api
- modernstatus
- pipeline-graph-analysis
- postbuild-task
- postgresql-api
- release
- run-condition
- scm-api
- snakeyaml-api

<!--
Jira to GitHub mapping:
database-h2-plugin:database-h2-plugin
database-mysql-plugin:database-mysql-plugin
database-postgresql-plugin:database-postgresql-plugin
h2-api-plugin:h2-api-plugin
modernstatus-plugin:modernstatus-plugin
pipeline-graph-analysis-plugin:pipeline-graph-analysis-plugin
postbuild-task-plugin:postbuild-task-plugin
postgresql-api-plugin:postgresql-api-plugin
release-plugin:release-plugin
run-condition-plugin:run-condition-plugin
scm-api-plugin:scm-api-plugin
snakeyaml-plugin:snakeyaml-api-plugin

-->