### PR TITLE
Document Java 21+ requirement for local builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This repository contains both the definitions for Artifactory upload permissions
 
 **Note:** These permissions are specifically for _uploading_ artifacts to the Jenkins project's Maven repository. It is independent of GitHub repository permissions. You may have one without the other. Typically, you'll either have both, or just the GitHub repository access.
 
+Prerequisites
+-------------
+
+This project requires **Java 21 or newer** to build locally. If an older Java version is used, the build will fail early due to enforced version checks.
+
 Requesting Permissions
 ----------------------
 


### PR DESCRIPTION
### Summary
Document the Java version requirement needed to build this repository locally.

### Changes
- Added a **Prerequisites** section to the README
- Clarified that **Java 21 or newer** is required due to enforced build checks

### Motivation
Local builds fail early when using older Java versions, but this requirement was not explicitly documented.
This change makes onboarding clearer and reduces setup confusion for new contributors.

---

_Note: This PR is documentation-only and does not modify release permissions or CD configuration._
