### PR TITLE
Bump lowest pom version

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Requirements.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Requirements.java
@@ -6,8 +6,8 @@ import java.util.List;
  * Requirements for hosting Jenkins plugins repositories.
  */
 public class Requirements {
-    public static final Version LOWEST_PARENT_POM_VERSION = new Version(5, 28);
+    public static final Version LOWEST_PARENT_POM_VERSION = new Version(6, "2105.v0879858b_48d2");
     public static final Version PARENT_POM_WITH_JENKINS_VERSION = new Version(2);
-    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 492, 3);
+    public static final Version LOWEST_JENKINS_VERSION = new Version(2, 528, 3);
     public static final List<Integer> ALLOWED_JDK_VERSIONS = List.of(21, 25);
 }


### PR DESCRIPTION
The change proposed bumps the Jenkins version to the second oldest baseline (in a few weeks) and the minimum required plugin pom version to https://github.com/jenkinsci/plugin-pom/releases/tag/6.2105.v7d6ddb_2da_0d2, requiring Java 21.

I've made some modifications to make the CD-like release schemes work alongside the core semver-like schemes.