### PR TITLE
Migrate 9 plugins issues to GitHub

### DIFF
--- a/permissions/plugin-build-pipeline-plugin.yml
+++ b/permissions/plugin-build-pipeline-plugin.yml
@@ -1,8 +1,8 @@
 ---
 name: "build-pipeline-plugin"
-github: "jenkinsci/build-pipeline-plugin"
+github: &gh "jenkinsci/build-pipeline-plugin"
 issues:
-  - jira: '15962'  # build-pipeline-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/build-pipeline-plugin"
 developers:

--- a/permissions/plugin-commons-compress-api.yml
+++ b/permissions/plugin-commons-compress-api.yml
@@ -7,4 +7,4 @@ developers:
 - "basil"
 - "markewaite"
 issues:
-  - jira: 29424
+  - github: *GH

--- a/permissions/plugin-commons-httpclient3-api.yml
+++ b/permissions/plugin-commons-httpclient3-api.yml
@@ -6,4 +6,4 @@ paths:
 developers:
   - "markewaite"
 issues:
-  - jira: 29120
+  - github: *GH

--- a/permissions/plugin-conditional-buildstep.yml
+++ b/permissions/plugin-conditional-buildstep.yml
@@ -1,8 +1,8 @@
 ---
 name: "conditional-buildstep"
-github: "jenkinsci/conditional-buildstep-plugin"
+github: &gh "jenkinsci/conditional-buildstep-plugin"
 issues:
-  - jira: '15947'  # conditional-buildstep-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/conditional-buildstep"
 developers:

--- a/permissions/plugin-copyartifact.yml
+++ b/permissions/plugin-copyartifact.yml
@@ -1,8 +1,8 @@
 ---
 name: "copyartifact"
-github: "jenkinsci/copyartifact-plugin"
+github: &gh "jenkinsci/copyartifact-plugin"
 issues:
-  - jira: '15692'  # copyartifact-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/copyartifact"
   - "org/jvnet/hudson/plugins/copyartifact"

--- a/permissions/plugin-instance-identity.yml
+++ b/permissions/plugin-instance-identity.yml
@@ -1,8 +1,8 @@
 ---
 name: "instance-identity"
-github: "jenkinsci/instance-identity-plugin"
+github: &gh "jenkinsci/instance-identity-plugin"
 issues:
-  - jira: '23222'
+  - github: *gh
 paths:
   - "org/jenkins-ci/modules/instance-identity"
 cd:

--- a/permissions/plugin-jakarta-activation-api.yml
+++ b/permissions/plugin-jakarta-activation-api.yml
@@ -7,7 +7,7 @@ developers:
   - "basil"
   - "markewaite"
 issues:
-  - jira: 28835
+  - github: *GH
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-jakarta-mail-api.yml
+++ b/permissions/plugin-jakarta-mail-api.yml
@@ -7,7 +7,7 @@ developers:
   - "basil"
   - "markewaite"
 issues:
-  - jira: 28831
+  - github: *GH
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-jakarta-xml-bind-api.yml
+++ b/permissions/plugin-jakarta-xml-bind-api.yml
@@ -10,7 +10,7 @@ developers:
 - "markewaite"
 - "@cloudbees-developers"
 issues:
-  - jira: 29732
+  - github: *GH
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
Hi

Mark Waite would like more of the plugins he maintains to track their issues in GitHub

Plugins being migrated:
- build-pipeline-plugin
- commons-compress-api
- commons-httpclient3-api
- conditional-buildstep
- copyartifact
- instance-identity
- jakarta-activation-api
- jakarta-mail-api
- jakarta-xml-bind-api

@MarkEWaite approves of this change

<!--
Jira to GitHub mapping:
build-pipeline-plugin:build-pipeline-plugin
commons-compress-api-plugin:commons-compress-api-plugin
commons-httpclient3-api-plugin:commons-httpclient3-api-plugin
conditional-buildstep-plugin:conditional-buildstep-plugin
copyartifact-plugin:copyartifact-plugin
instance-identity-module:instance-identity-plugin
jakarta-activation-api-plugin:jakarta-activation-api-plugin
jakarta-xml-bind-api-plugin:jakarta-xml-bind-api-plugin

-->

<!-- left out at Herve's request to do in pair with Mark -->
<!--
jakarta-mail-api-plugin:jakarta-mail-api-plugin
-->