### PR TITLE
Add `cloudbees-developers` to `saml`

### DIFF
--- a/permissions/plugin-saml.yml
+++ b/permissions/plugin-saml.yml
@@ -10,6 +10,7 @@ developers:
   - "chengas123"
   - "mdonohue"
   - "sbower"
+  - "@cloudbees-developers"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/orgs/jenkinsci/teams/saml-plugin-developers seems to be empty (perhaps since https://github.com/jenkins-infra/repository-permissions-updater/pull/4791?) so I am not sure who could merge something like https://github.com/jenkinsci/saml-plugin/pull/576.

# When modifying release permission

Adding https://github.com/orgs/jenkinsci/teams/company-cloudbees-developers since I am not sure what else to do.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
