### PR TITLE
Revert "Add `cloudbees-developers` to `saml`"

### DIFF
--- a/permissions/plugin-saml.yml
+++ b/permissions/plugin-saml.yml
@@ -10,7 +10,6 @@ developers:
   - "chengas123"
   - "mdonohue"
   - "sbower"
-  - "@cloudbees-developers"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
Reverts jenkins-infra/repository-permissions-updater#4882

Per https://github.com/jenkins-infra/repository-permissions-updater/pull/4882#issuecomment-3719930142, that PR seems to have been prematurely merged. If @jglick and colleagues want to adopt this plugin, they should wait for a response (or timeout) from current maintainers.