### PR TITLE
Add `jglick` to `cloudbees-developers` team

### DIFF
--- a/teams/cloudbees-developers.yml
+++ b/teams/cloudbees-developers.yml
@@ -8,6 +8,7 @@ developers:
 - "batmat"
 - "carroll"
 - "dnusbaum"
+- "jglick"
 - "jpochat"
 - "mikecirioli"
 - "olamy"


### PR DESCRIPTION
I am not entirely clear on what this list is used for, but I am a @cloudbees employee who makes code changes to @jenkinsci plugins so I suppose I should be here.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
