### PR TITLE
Migrate issue tracker to GitHub issues

### DIFF
--- a/permissions/component-analysis-model.yml
+++ b/permissions/component-analysis-model.yml
@@ -1,6 +1,8 @@
 ---
 name: "analysis-model"
-github: "jenkinsci/analysis-model"
+github: &gh "jenkinsci/analysis-model"
+issues:
+  - github: *gh
 paths:
   - "edu/hm/hafner/analysis-model"
 developers:

--- a/permissions/component-coverage-model.yml
+++ b/permissions/component-coverage-model.yml
@@ -1,6 +1,8 @@
 ---
 name: "coverage-model"
-github: "jenkinsci/coverage-model"
+github: &gh "jenkinsci/coverage-model"
+issues:
+  - github: *gh
 paths:
   - "edu/hm/hafner/coverage-model"
 developers:

--- a/permissions/pom-analysis-pom.yml
+++ b/permissions/pom-analysis-pom.yml
@@ -1,6 +1,8 @@
 ---
 name: "analysis-pom"
-github: "jenkinsci/analysis-pom-plugin"
+github: &gh "jenkinsci/analysis-pom-plugin"
+issues:
+  - github: *gh
 paths:
   - "org/jvnet/hudson/plugins/analysis-pom"
 developers:


### PR DESCRIPTION
All my plugin libraries should also track their issues in GitHub.

Plugins being migrated:

- analysis-model
- coverage-model
- analysis-pom-plugin

<!--
analysis-model:analysis-model
coverage-model:coverage-model
plugin-pom:plugin-pom
-->
 
@uhafner approves this change