### PR TITLE
check for ban of commons-lang-2

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
@@ -526,7 +526,7 @@ public class MavenVerifier implements BuildSystemVerifier {
                 || !props.getProperty("ban-commons-lang-2.skip").equals("false")) {
             hostingIssues.add(new VerificationMessage(
                     VerificationMessage.Severity.REQUIRED,
-                    "Please define the property `ban-commons-lang-2.skips` and set it to `false`. This should help prevent accidental usage of the deprecated commons-lang-2 library that is "
+                    "Please define the property `ban-commons-lang-2.skip` and set it to `false`. This should help prevent accidental usage of the deprecated commons-lang-2 library that is "
                             + "included in core."));
         }
     }


### PR DESCRIPTION
Ensure that the commons-lang-2 ban check is included in the pom and not set to skipped.
So we ensure that new plugins are not using it and we can proceed with it's removal in core via https://github.com/jenkinsci/jenkins/pull/26105