### PR TITLE
migrate 4 plugins to github issues

### DIFF
--- a/permissions/plugin-agent-maintenance.yml
+++ b/permissions/plugin-agent-maintenance.yml
@@ -6,6 +6,6 @@ paths:
 developers:
   - "mawinter69"
 issues:
-  - jira: 28837
+  - github: *GH
 cd:
   enabled: true

--- a/permissions/plugin-favorite-view.yml
+++ b/permissions/plugin-favorite-view.yml
@@ -1,8 +1,8 @@
 ---
 name: "favorite-view"
-github: "jenkinsci/favorite-view-plugin"
+github: &gh "jenkinsci/favorite-view-plugin"
 issues:
-  - jira: '17569'  # favorite-view-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/favorite-view"
 developers:

--- a/permissions/plugin-favorite.yml
+++ b/permissions/plugin-favorite.yml
@@ -1,8 +1,8 @@
 ---
 name: "favorite"
-github: "jenkinsci/favorite-plugin"
+github: &gh "jenkinsci/favorite-plugin"
 issues:
-  - jira: '15752'  # favorite-plugin
+  - github: *gh
 paths:
   - "org/jvnet/hudson/plugins/favorite"
 developers:

--- a/permissions/plugin-statusmonitor.yml
+++ b/permissions/plugin-statusmonitor.yml
@@ -1,8 +1,8 @@
 ---
 name: "statusmonitor"
-github: "jenkinsci/statusmonitor-plugin"
+github: &gh "jenkinsci/statusmonitor-plugin"
 issues:
-  - jira: '15617'  # statusmonitor-plugin
+  - github: *gh
 paths:
   - "org/jvnet/hudson/plugins/statusmonitor"
   - "io/jenkins/plugins/statusmonitor"
@@ -10,4 +10,3 @@ developers:
   - "mawinter69"
 cd:
   enabled: true
-  exclusive: false


### PR DESCRIPTION
Plugins being migrated
- agent-maintenance
- favorite-view
- favorite
- statusmonitor

<!--
agent-maintenance-plugin:agent-maintenance-plugin
favorite-view-plugin:favorite-view-plugin
favorite-plugin:favorite-plugin
statusmonitor-plugin:statusmonitor-plugin
-->

I'm the maintainer of the 4 plugins.

@timja Could you please migrate