### PR TITLE
Let markewaite adopt mongodb plugin to deprecate it

### DIFF
--- a/permissions/plugin-mongodb.yml
+++ b/permissions/plugin-mongodb.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '16007'  # mongodb-plugin
 paths:
   - "org/jenkins-ci/plugins/mongodb"
-developers: []
+developers:
+  - "markewaite"


### PR DESCRIPTION
## Let markewaite adopt mongodb plugin to deprecate it

As noted in [JENKINS-76359](https://issues.jenkins.io/browse/JENKINS-76359), the MongoDB tool installer file has been empty since November 29, 2022.  The primary function of the MongoDB plugin is to provide an installer for MongoDB that can be used from a freestyle project, but the empty tool installer file means that function has not been provided for over 3 years.

No plugin user has reported the issue and the count of plugin installations is reported as less than 200.

MongoDB does not allow the Jenkins tool installer list generator to list their available community editions and appears to have not allowed that since at least Nov 29, 2022.

Since we can't list their available community editions from our list generator, that tool installer data will always be empty.

The plugin also has a [known security vulnerability](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1904) that was published over 5 years ago.

The plugin should be deprecated because it does not serve its primary function, has not served its primary function for over 3 years, and cannot serve its primary function without a complete rewrite of its tool installer list generator.

The plugin does not provide a feature to allow a local installer to be downloaded.  It only supports downloading one of the versions provided by the tool installer list generator, but that list has been empty for over 3 years.

The minimum Jenkins version supported by the plugin is so old that installing the plugin causes almost every detached plugin to be installed.

I don't think there is a strong enough argument to stop distributing the plugin, but we can certainly guide users away from the plugin by deprecating it.

After I've deprecated it, I will again place it up for adoption and remove myself from the maintainer list.

Alternatively, a jenkinsci GitHub organization administrator could place the `deprecated` topic on the https://github.com/jenkinsci/mongodb-plugin repository and I don't need to adopt the plugin.

# Link to GitHub repository

https://github.com/jenkinsci/mongodb-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- `@MarkEWaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
