### PR TITLE
Add quay-tag-parameter plugin

### DIFF
--- a/permissions/plugin-quay-tag-parameter.yml
+++ b/permissions/plugin-quay-tag-parameter.yml
@@ -1,0 +1,6 @@
+  name: "quay-tag-parameter"
+  github: "jenkinsci/quay-tag-parameter"
+  paths:
+  - "io/jenkins/plugins/quay-tag-parameter"
+  developers:
+  - "mohitsalvi"


### PR DESCRIPTION
 Title:
  Add quay-tag-parameter plugin

  Body:
  # Link to GitHub repository

  https://github.com/MohitSalvi16/quay-tag-parameter

  # When modifying release permission

  List the GitHub usernames of the users who should have commit permissions below:
  - `@MohitSalvi16`

  This is needed in order to cut releases of the plugin or component.

  ### Release permission checklist (for submitters)

  - [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
  - [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.     
  - [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

  **Note:** This is a NEW plugin hosting request. There is no existing team member yet.

  ## Plugin Information

  **Plugin name:** quay-tag-parameter
  **Description:** Provides a build parameter that displays a dropdown of available image tags from a Quay.io repository.

  **Features:**
  - Fetches tags from public/private Quay.io repositories
  - Jenkins Credentials integration for private repos
  - Pipeline compatible
  - CSRF protection and permission checks

  **License:** MIT