### PR TITLE
Migrate mina-sshd-api plugin issues to GitHub

### DIFF
--- a/permissions/plugin-mina-sshd-api.yml
+++ b/permissions/plugin-mina-sshd-api.yml
@@ -14,7 +14,7 @@ developers:
   - "jglick"
   - "allan_burdajewicz"
 issues:
-  - jira: 28925
+  - github: *GH
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- mina-sshd-api

@jglick 

Let me know if any objections or questions

<!--
Jira to GitHub mapping:

-->