### PR TITLE
Deprecate typetalk-plugin

### DIFF
--- a/permissions/plugin-typetalk.yml
+++ b/permissions/plugin-typetalk.yml
@@ -10,3 +10,5 @@ cd:
 developers:
   - "ikikko"
   - "yasuyuki_baba"
+deprecated: true
+reason: "The Typetalk service was terminated in December 2025. This plugin is no longer functional and is no longer maintained."


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/typetalk-plugin

# When modifying release permission

*N/A (This is a request for deprecation, not for adding new committers)*

### Release permission checklist (for submitters)

- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to accounts.jenkins.io.
- [ ] All users added have logged in to Artifactory and Jira once.
- [ ] I have mentioned an existing team member of the plugin or component team to approve this request.

---

## Summary of the request: Deprecation due to Service EOL

The **Typetalk** service (messaging app) was officially terminated in December 2025. 
https://nulab.com/blog/company-news/typetalk-sunsetting/
As a developer of the service, I am requesting to deprecate this plugin as it is no longer functional.

### Context:
- **Service Status:** Shut down (End of Life).
- **Maintainer Status:** The registered maintainers (`ikikko`, `yasuyuki_baba`) have already left the company and are no longer active in this project.
- **Request:** 1. Please mark the plugin as **deprecated** in the Update Center.
  2. Since I do not have write access to the repository, I would appreciate it if the Infrastructure team could **archive** the GitHub repository (`jenkinsci/typetalk-plugin`) and update the README to reflect that the service has ended.

## When enabling automated releases (cd: true)

*N/A (CD is already configured in the YAML, no changes made to CD settings)*

### Link to the PR enabling CD in your plugin

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.