### PR TITLE
Adopt authorize-project plugin

### DIFF
--- a/permissions/plugin-authorize-project.yml
+++ b/permissions/plugin-authorize-project.yml
@@ -5,5 +5,7 @@ issues:
   - jira: '18155'  # authorize-project-plugin
 paths:
   - "org/jenkins-ci/plugins/authorize-project"
+cd:
+  enabled: true
 developers:
   - "andreahlert"


### PR DESCRIPTION
I am adopting the authorize-project plugin per the [Adopt a Plugin](https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/) process.

- Plugin: https://github.com/jenkinsci/authorize-project-plugin
- Status: for adoption (no maintainers in RPU, so proceeding immediately)
- GitHub: andreahlert
- Jenkins ID: andreahlert

I will send the adoption announcement to the jenkinsci-dev mailing list with a link to this PR.