### PR TITLE
Adopt leastload plugin

### DIFF
--- a/permissions/plugin-leastload.yml
+++ b/permissions/plugin-leastload.yml
@@ -8,5 +8,6 @@ paths:
 developers:
   - "bstick12"
   - "hashar"
+  - "sag47"
 cd:
   enabled: true


### PR DESCRIPTION
It appears abandoned since it hasn't been updated in 2 years.

GitHub Repo
-----------

https://github.com/jenkinsci/leastload-plugin

GitHub username (myself)
------------------------

- `@samrocketman`

I have [opened a pull request][pr] to reformat the base code and apply a bugfix.

Should old maintainers be removed?

Release checklist
-----------------

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

Reviewer checklist
------------------

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.

[pr]: https://github.com/jenkinsci/leastload-plugin/pull/20