### PR TITLE
re-add the Jira users check

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JenkinsProjectUserVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JenkinsProjectUserVerifier.java
@@ -17,12 +17,21 @@ public class JenkinsProjectUserVerifier implements Verifier {
             String missingInArtifactory = jenkinsProjectUsers.stream()
                     .filter(user -> !KnownUsers.existsInArtifactory(user))
                     .collect(Collectors.joining(", "));
+            String missingInJira = jenkinsProjectUsers.stream()
+                    .filter(user -> !KnownUsers.existsInJira(user))
+                    .collect(Collectors.joining(", "));
 
             if (StringUtils.isNotBlank(missingInArtifactory)) {
                 hostingIssues.add(new VerificationMessage(
                         VerificationMessage.Severity.REQUIRED,
                         "The following usernames in 'Jenkins project users to have release permission' need to log into [Artifactory](https://repo.jenkins-ci.org/): %s (reports are re-synced hourly, wait to re-check for a bit after logging in)",
                         missingInArtifactory));
+            }
+            if (StringUtils.isNotBlank(missingInJira)) {
+                hostingIssues.add(new VerificationMessage(
+                        VerificationMessage.Severity.REQUIRED,
+                        "The following usernames in 'Jenkins project users to have release permission' need to log into [Jira](https://issues.jenkins.io): %s (reports are re-synced hourly, wait to re-check for a bit after logging in)",
+                        missingInJira));
             }
         } else {
             hostingIssues.add(new VerificationMessage(


### PR DESCRIPTION
while we don't allow hosting issues in Jira any longer Jira access should still be enforced as security tickets will be opened there. That was accidently removed when removing the possibility to use Jira as issue tracker with #4777

Tested locally with #4932 and this reports the user has not logged in to Jira