### PR TITLE
Migrate update-sites-manager plugin issues to GitHub

### DIFF
--- a/permissions/plugin-update-sites-manager.yml
+++ b/permissions/plugin-update-sites-manager.yml
@@ -1,8 +1,8 @@
 ---
 name: "update-sites-manager"
-github: "jenkinsci/update-sites-manager-plugin"
+github: &gh "jenkinsci/update-sites-manager-plugin"
 issues:
-  - jira: '17576'  # update-sites-manager-plugin
+  - github: *gh
 paths:
   - "jp/ikedam/jenkins/plugins/update-sites-manager"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- update-sites-manager

Let me know if any objections or questions

<!--
Jira to GitHub mapping:
update-sites-manager-plugin:update-sites-manager-plugin

-->