### PR TITLE
migration script: Add --no-rebase to git pull

### DIFF
--- a/bin/migrate-to-github.sh
+++ b/bin/migrate-to-github.sh
@@ -162,7 +162,7 @@ if [ ${#processed[@]} -gt 0 ]; then
     fi
 
     git checkout master
-    git pull
+    git pull --no-rebase
     git checkout -b "$branch_name"
     
     # Add all processed files


### PR DESCRIPTION
Adds --no-rebase to git pull since someone may have rebase as the default pull behavior. This causes an issue when the yaml file(s) have been modified before the pull. With a rebase, it causes an error because there are modified files. So, we just enforce a --no-rebase for the git pull.

@timja 
