### PR TITLE
Migrate 3 plugins issues to GitHub

### DIFF
--- a/permissions/plugin-change-assembly-version-plugin.yml
+++ b/permissions/plugin-change-assembly-version-plugin.yml
@@ -1,8 +1,8 @@
 ---
 name: "change-assembly-version-plugin"
-github: "jenkinsci/change-assembly-version-plugin"
+github: &gh "jenkinsci/change-assembly-version-plugin"
 issues:
-  - jira: '19020'  # change-assembly-version-plugin
+  - github: *gh
 paths:
   - "org/jenkinsci/plugins/change-assembly-version-plugin"
 developers:

--- a/permissions/plugin-figlet-buildstep.yml
+++ b/permissions/plugin-figlet-buildstep.yml
@@ -1,8 +1,8 @@
 ---
 name: "figlet-buildstep"
-github: "jenkinsci/figlet-buildstep-plugin"
+github: &gh "jenkinsci/figlet-buildstep-plugin"
 issues:
-  - jira: '18758'  # figlet-buildstep-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/figlet-buildstep"
 developers:

--- a/permissions/plugin-token-macro.yml
+++ b/permissions/plugin-token-macro.yml
@@ -1,8 +1,8 @@
 ---
 name: "token-macro"
-github: "jenkinsci/token-macro-plugin"
+github: &gh "jenkinsci/token-macro-plugin"
 issues:
-  - jira: '15832'  # token-macro-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/token-macro"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- figlet-buildstep
- token-macro
- change-assembly-version-plugin

Let me know if any objections or questions

<!--
Jira to GitHub mapping:
figlet-buildstep-plugin:figlet-buildstep-plugin
token-macro-plugin:token-macro-plugin
change-assembly-version-plugin:change-assembly-version-plugin

-->