### PR TITLE
Enable CD for authorize-project plugin

### DIFF
--- a/permissions/plugin-authorize-project.yml
+++ b/permissions/plugin-authorize-project.yml
@@ -5,4 +5,6 @@ issues:
   - jira: '18155'  # authorize-project-plugin
 paths:
   - "org/jenkins-ci/plugins/authorize-project"
+cd:
+  enabled: true
 developers: []


### PR DESCRIPTION
Enable continuous delivery (JEP-229) for the authorize-project plugin.

Companion to jenkinsci/authorize-project-plugin#349, which adds the CD workflow and updates the POM to use fully automated versioning.