### PR TITLE
permissions/plugin-github-autostatus.yml: request co-maintainership

### DIFF
--- a/permissions/plugin-github-autostatus.yml
+++ b/permissions/plugin-github-autostatus.yml
@@ -8,3 +8,4 @@ paths:
   - "org/jenkins-ci/plugins/github-autostatus"
 developers:
   - "jeffpearce"
+  - "jimklimov"


### PR DESCRIPTION
Adding "jimklimov" as co-maintainer: Want to merge a few outstanding pull requests...

Last release 6 years ago, last master-branch commit 4 years ago.

Current maintainer @jeffpearce was last active on GitHub in 2024; not asking to remove from maintainer list at this point.

CD streamlining PRs not proposed yet, so not filling that part of the questionnaire. Hope to enable it later.

# Link to GitHub repository

<!-- Provide a link to the plugin or component repository you want to modify -->
https://github.com/jenkinsci/github-autostatus-plugin/pull/

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@jeffpearce`
- `@jimklimov`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
