### PR TITLE
Migrate authorize-project plugin issues to GitHub

### DIFF
--- a/permissions/plugin-authorize-project.yml
+++ b/permissions/plugin-authorize-project.yml
@@ -1,8 +1,8 @@
 ---
 name: "authorize-project"
-github: "jenkinsci/authorize-project-plugin"
+github: &gh "jenkinsci/authorize-project-plugin"
 issues:
-  - jira: '18155'  # authorize-project-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/authorize-project"
 cd:


### PR DESCRIPTION
Plugins being migrated:
- authorize-project

<!--
Jira to GitHub mapping:
authorize-project-plugin:authorize-project-plugin
-->