### PR TITLE
Removing myself from `antisamy-markup-formatter`

### DIFF
--- a/permissions/plugin-antisamy-markup-formatter.yml
+++ b/permissions/plugin-antisamy-markup-formatter.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/antisamy-markup-formatter"
 developers:
-  - "jglick"
   - "schristou"
   - "batmat"
   - "egutierrez"


### PR DESCRIPTION
https://github.com/jenkinsci/antisamy-markup-formatter-plugin/pull/174#issuecomment-4060027435 Probably I was grandfathered in years ago; IIRC this plugin was split from core.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
