### PR TITLE
Adopt chucknorris plugin

### DIFF
--- a/permissions/plugin-chucknorris.yml
+++ b/permissions/plugin-chucknorris.yml
@@ -9,5 +9,6 @@ developers:
   - "batmat"
   - "oleg_nenashev"
   - "mPokornyETM"
+  - "darinpope"
 cd:
   enabled: true


### PR DESCRIPTION
No releases for 3+ years.

I have not opened any PRs against the project yet. The plan is to bring the plugin up to date with Jira->GitHub, resolve outstanding PRs, bring health score back to 100 and have a monthly-ish release schedule to have fresh facts.

# Link to GitHub repository

https://github.com/jenkinsci/chucknorris-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- `@darinpope`

This is needed in order to cut releases of the plugin or component.

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request. (cc: @mPokornyETM) 

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
