### PR TITLE
Enable CD for Swarm

### DIFF
--- a/permissions/component-swarm-client.yml
+++ b/permissions/component-swarm-client.yml
@@ -4,6 +4,8 @@ github: "jenkinsci/swarm-plugin"
 paths:
   - "org/jenkins-ci/plugins/swarm-client"
   - "org/jvnet/hudson/plugins/swarm-client"
+cd:
+  enabled: true
 developers:
   - "basil"
   - "mindjiver"

--- a/permissions/plugin-swarm.yml
+++ b/permissions/plugin-swarm.yml
@@ -6,6 +6,8 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/swarm"
   - "org/jvnet/hudson/plugins/swarm"
+cd:
+  enabled: true
 developers:
   - "basil"
   - "mindjiver"

--- a/permissions/pom-swarm-plugin.yml
+++ b/permissions/pom-swarm-plugin.yml
@@ -4,6 +4,8 @@ github: "jenkinsci/swarm-plugin"
 paths:
   - "org/jenkins-ci/plugins/swarm-plugin"
   - "org/jvnet/hudson/plugins/swarm-plugin"
+cd:
+  enabled: true
 developers:
   - "basil"
   - "mindjiver"


### PR DESCRIPTION
Following up #4991.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/swarm-plugin/pull/756

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
