### PR TITLE
Switch Swarm issues from Jira to GitHub

### DIFF
--- a/permissions/plugin-swarm.yml
+++ b/permissions/plugin-swarm.yml
@@ -1,8 +1,8 @@
 ---
 name: "swarm"
-github: "jenkinsci/swarm-plugin"
+github: &GH "jenkinsci/swarm-plugin"
 issues:
-  - jira: '15741'  # swarm-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/swarm"
   - "org/jvnet/hudson/plugins/swarm"


### PR DESCRIPTION
Following up #4991. Please migrate issues in [this component](https://issues.jenkins.io/issues/?jql=resolution%20is%20EMPTY%20and%20component%3D15741) from Jira to GitHub Issues.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
