### PR TITLE
add gilhartman_appdome

### DIFF
--- a/permissions/plugin-appdome-build-2secure.yml
+++ b/permissions/plugin-appdome-build-2secure.yml
@@ -6,5 +6,6 @@ paths:
 developers:
 - "idanhauser"
 - "avie"
+- "gilhartman_appdome"
 issues:
   - github: *GH

--- a/permissions/plugin-appdome-validate-2secure.yml
+++ b/permissions/plugin-appdome-validate-2secure.yml
@@ -6,5 +6,6 @@ paths:
 developers:
 - "idanhauser"
 - "avie"
+- "gilhartman_appdome"
 issues:
   - github: *GH


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/appdome-build-2secure-plugin
https://github.com/jenkinsci/appdome-validate-2secure-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@gilhartman`
- `@SivanTelTzur-appdome`

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

**Approval requested from existing maintainers (per `plugin-appdome-build-2secure.yml`):** `@idanhauser` `@avie`

**Note:** This PR adds Jenkins LDAP user `gilhartman_appdome` to `developers` for release uploads to Artifactory.

## When enabling automated releases (cd: true)

_Not applicable — this PR does not enable CD._

### Link to the PR enabling CD in your plugin

_N/A_

### CD checklist (for submitters)

_N/A_

### Reviewer checklist

_Leave for reviewers._