### PR TITLE
Adopt docker-swarm plugin

### DIFF
--- a/permissions/plugin-docker-swarm.yml
+++ b/permissions/plugin-docker-swarm.yml
@@ -9,3 +9,4 @@ paths:
 developers:
   - "surya548"
   - "roemer"
+  - "mbSmaga"


### PR DESCRIPTION
Adopting the docker-swarm plugin which has been unmaintained for 5+ years (last release: v1.11).
There is an unresolved security vulnerability [SECURITY-2811 / CVE-2023-40350](https://www.jenkins.io/security/advisory/2023-08-16/) (stored XSS) with no fix released. I have a fix ready along with POM modernization and Docker API 1.44 compatibility improvements.

Pinging existing maintainers: @suryagaddipati @Roemer

# Link to GitHub repository

https://github.com/jenkinsci/docker-swarm-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@mbSmaga`

This is needed in order to cut releases of the plugin or component.

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request. (cc: @suryagaddipati @Roemer)

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
