### PR TITLE
Add Last9 plugin permissions

### DIFF
--- a/permissions/plugin-last9.yml
+++ b/permissions/plugin-last9.yml
@@ -1,0 +1,9 @@
+---
+name: "last9"
+github: "last9/last9-jenkins-plugin"
+issues:
+  - github: "last9/last9-jenkins-plugin"
+paths:
+  - "io/last9/jenkins/plugins/last9"
+developers:
+  - "prathamesh_sonpatki"


### PR DESCRIPTION
## New plugin: last9

Requesting upload permissions for the Last9 Jenkins plugin.

- **Plugin**: [last9-jenkins-plugin](https://github.com/last9/last9-jenkins-plugin)
- **Artifact**: `io.last9.jenkins.plugins:last9`
- **Developer**: `prathamesh_sonpatki` (has logged into Artifactory and Jira)

The plugin sends deployment markers to [Last9's Change Events API](https://docs.last9.io/docs/change-events/) from Jenkins Pipeline and Freestyle jobs, so teams can correlate releases with performance changes, error spikes, and APDEX shifts on their service dashboards.