### PR TITLE
adopt Configuration slicing plugin

### DIFF
--- a/permissions/plugin-configurationslicing.yml
+++ b/permissions/plugin-configurationslicing.yml
@@ -13,3 +13,4 @@ developers:
   - "mdonohue"
   - "ninian"
   - "guysoft"
+  - "jgyprime"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/configurationslicing-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@jgyprime`

This is needed in order to cut releases of the plugin or component.

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
