### PR TITLE
Adopt multibranch-job-tear-down plugin

### DIFF
--- a/permissions/plugin-multibranch-job-tear-down.yml
+++ b/permissions/plugin-multibranch-job-tear-down.yml
@@ -7,3 +7,4 @@ paths:
   - "com/fuzzpro/jenkins-plugins/multibranch-job-tear-down"
 developers:
   - "fuzzcaguilar"
+  - "clemstoquart"


### PR DESCRIPTION
No release for 8+ years.

The plugin isn't working anymore with current Jenkins release.
My plan is to merge the following PRs (https://github.com/jenkinsci/multibranch-job-tear-down-plugin/pull/5 and https://github.com/jenkinsci/multibranch-job-tear-down-plugin/pull/4). I've been tested them with success on my own Jenkins instance.

# Link to GitHub repository

https://github.com/jenkinsci/multibranch-job-tear-down-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@clemstoquart`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request. (cc @caguilar187)

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
