### PR TITLE
Record correct issue tracker for Publish over CIFS plugin

### DIFF
--- a/permissions/plugin-publish-over-cifs.yml
+++ b/permissions/plugin-publish-over-cifs.yml
@@ -2,7 +2,7 @@
 name: "publish-over-cifs"
 github: "jenkinsci/publish-over-cifs-plugin"
 issues:
-  - jira: '15850'  # publish-over-cifs-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/publish-over-cifs"
 developers:

--- a/permissions/plugin-publish-over-cifs.yml
+++ b/permissions/plugin-publish-over-cifs.yml
@@ -1,6 +1,6 @@
 ---
 name: "publish-over-cifs"
-github: "jenkinsci/publish-over-cifs-plugin"
+github: &gh "jenkinsci/publish-over-cifs-plugin"
 issues:
   - github: *gh
 paths:


### PR DESCRIPTION
## Record correct issue tracker for Publish over CIFS plugin

Wrong issue tracker is on https://plugins.jenkins.io/publish-over-cifs

Fixes #5032

# Link to GitHub repository

N/A - fixing the issue tracker in the official record of issue trackers

# When modifying release permission

Not modifying release permission

<!--
List the GitHub usernames of the users who should have commit permissions below:
- N/A

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:
-->

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
