### PR TITLE
Add mPokornyETM to label-linked-jobs developers

### DIFF
--- a/permissions/plugin-label-linked-jobs.yml
+++ b/permissions/plugin-label-linked-jobs.yml
@@ -2,9 +2,10 @@
 name: "label-linked-jobs"
 github: "jenkinsci/label-linked-jobs-plugin"
 issues:
-  - jira: '19522'  # label-linked-jobs-plugin
+  - github
 paths:
   - "org/jenkins-ci/plugins/label-linked-jobs"
 developers:
   - "dominiquebrice"
   - "surenpi"
+  - "mPokornyETM"

--- a/permissions/plugin-label-linked-jobs.yml
+++ b/permissions/plugin-label-linked-jobs.yml
@@ -2,7 +2,7 @@
 name: "label-linked-jobs"
 github: "jenkinsci/label-linked-jobs-plugin"
 issues:
-  - github
+  - jira: '19522'  # label-linked-jobs-plugin
 paths:
   - "org/jenkins-ci/plugins/label-linked-jobs"
 developers:


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/label-linked-jobs-plugin/

I found this plugin https://github.com/jenkinsci/label-linked-jobs-plugin/ and has try to build it locally
It is extreme old one and was necessary to provide many changes to build it.
As it was never officially published, I will to do it now.
I hope, I do it in correct way
https://github.com/jenkinsci/label-linked-jobs-plugin/pull/26

My next steps here will be:

+ keep the plugin dependencies up to date
+ extend UI with better views for labels.
+ AI support for labels diagnostic

Why I do it:

because there are many opened Jenkins issues for better label handlings (UI) and it is hard to do not destroy the core Jenkins as well.
This plugin might be the solution for that. Of course I will update the Jenkins issues (this as that has been solved it this plugin) and the Jenkins core team might decide to close the issues or not. What ever, it will be great to have new , modern and better UX pages for Jenkins labels.
thx a lot

# When modifying release permission

@dominiquebrice

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->
https://github.com/jenkinsci/label-linked-jobs-plugin/pull/26

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
