### PR TITLE
Add markewaite as a zoom plugin maintainer

### DIFF
--- a/permissions/plugin-zoom.yml
+++ b/permissions/plugin-zoom.yml
@@ -7,3 +7,4 @@ paths:
   - "io/jenkins/plugins/zoom"
 developers:
   - "zoom_us"
+  - "markewaite"


### PR DESCRIPTION
## Add markewaite as a zoom plugin maintainer

[JENKINS-76442](https://issues.jenkins.io/browse/JENKINS-76442) reports a class not found exception in the Zoom plugin due to a class loading issue with the Jackson 2 API plugin.  The issue is confirmed resolved by pull request:

* https://github.com/jenkinsci/zoom-plugin/pull/23

When I submitted the pull request, I mentioned @ZeyuCai-ZOOM and @LukasLuZoom asking them to merge and release the pull request so that other users of the Zoom plugin could receive the fix.  There has been no response to that request in the last week.

Yesterday I sent email to the zoom_us email address from issues.jenkins.io.

I would like to be added as a maintainer so that I can merge and release pull request:

* https://github.com/jenkinsci/zoom-plugin/pull/23

That pull request replaces several other pending pull requests on the plugin, including:

* https://github.com/jenkinsci/zoom-plugin/pull/22
* https://github.com/jenkinsci/zoom-plugin/pull/21
* https://github.com/jenkinsci/zoom-plugin/pull/20
* https://github.com/jenkinsci/zoom-plugin/pull/15
* https://github.com/jenkinsci/zoom-plugin/pull/14
* https://github.com/jenkinsci/zoom-plugin/pull/9

I do not intend to add new features to the plugin.  I plan to merge the one pull request, close the pull requests that it replaces, and take the necessary steps to switch the plugin to use automated releases.

# Link to GitHub repository

https://github.com/jenkinsci/zoom-plugin

Existing team members to approve this pull request:

* @ZeyuCai-ZOOM
* @LukasLuZoom

I would prefer that they merge and release the fix so that I don't need to become a maintainer of the plugin.  However, if they don't merge and release the fix, then it is better that I become a maintainer instead of requiring multiple users to install the [incremental build](https://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/zoom/1.7-rc94.83b_5084070b_3/zoom-1.7-rc94.83b_5084070b_3.hpi) with the fix.  Installing an incremental build is more complicated and the incremental build will only remain in our artifact repository for 3 months before it is deleted.

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- `@markewaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
