### PR TITLE
Remove ifernandezcalvo from Jenkins plugins

### DIFF
--- a/permissions/plugin-opentelemetry-api.yml
+++ b/permissions/plugin-opentelemetry-api.yml
@@ -5,7 +5,6 @@ paths:
 - "io/jenkins/plugins/opentelemetry-api"
 developers:
 - "cleclerc"
-- "ifernandezcalvo"
 cd:
   enabled: true
 issues:

--- a/permissions/plugin-opentelemetry.yml
+++ b/permissions/plugin-opentelemetry.yml
@@ -5,7 +5,6 @@ paths:
   - "io/jenkins/plugins/opentelemetry"
 developers:
   - "cleclerc"
-  - "ifernandezcalvo"
   - "v2v"
 issues:
   - github: *GH


### PR DESCRIPTION
Remove the user ifernandezcalvo from the developers section in the OpenTelemetry plugin permissions files. This change updates the list of developers with commit permissions.

