### PR TITLE
Let markewaite adopt discord-notifier-plugin

### DIFF
--- a/permissions/plugin-discord-notifier.yml
+++ b/permissions/plugin-discord-notifier.yml
@@ -7,5 +7,6 @@ paths:
   - "nz/co/jammehcow/discord-notifier"
 developers:
   - "kocproz"
+  - "markewaite"
 cd:
   enabled: true


### PR DESCRIPTION
## Let markewaite adopt discord-notifier-plugin

The [plugin page](https://plugins.jenkins.io/discord-notifier/) shows that the plugin is up for adoption.

I'd like to adopt it so that I can merge and release pull request:

* https://github.com/jenkinsci/discord-notifier-plugin/pull/151

A user has confirmed that the pull request resolves a class not found exception reported as:

* https://github.com/jenkinsci/discord-notifier-plugin/pull/150

The pull request also modernizes the pom file of the plugin and replaces other pull requests:

* https://github.com/jenkinsci/discord-notifier-plugin/pull/150
* https://github.com/jenkinsci/discord-notifier-plugin/pull/146
* https://github.com/jenkinsci/discord-notifier-plugin/pull/147

I don't plan to add significant functionality and will probably leave the plugin as "up for adoption" so that I can encourage others to help maintain it.

# Link to GitHub repository

https://plugins.jenkins.io/discord-notifier/)

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@markewaite`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

<!-- Provide a link to the pull request containing the necessary changes in your plugin -->

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
