### PR TITLE
JENKINS-76455 Adopt matrix-sorter-plugin

### DIFF
--- a/permissions/plugin-Matrix-sorter-plugin.yml
+++ b/permissions/plugin-Matrix-sorter-plugin.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/Matrix-sorter-plugin"
 developers:
   - "olivergondza"
+  - "kanaduchi"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/Matrix-sorter-plugin/

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- @Kanaduchi
- @olivergondza

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
