### PR TITLE
Migrate zoom plugin issues to GitHub

### DIFF
--- a/permissions/plugin-zoom.yml
+++ b/permissions/plugin-zoom.yml
@@ -1,8 +1,8 @@
 ---
 name: "zoom"
-github: "jenkinsci/zoom-plugin"
+github: &gh "jenkinsci/zoom-plugin"
 issues:
-  - jira: '25025'  # zoom-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/zoom"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- zoom

@markewaite approves

<!--
Jira to GitHub mapping:
zoom-plugin:zoom-plugin

-->