### PR TITLE
Migrate 8 plugins issues to GitHub

### DIFF
--- a/permissions/plugin-javax-activation-api.yml
+++ b/permissions/plugin-javax-activation-api.yml
@@ -7,7 +7,7 @@ developers:
   - "basil"
   - "markewaite"
 issues:
-  - jira: 28834
+  - github: *GH
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-javax-mail-api.yml
+++ b/permissions/plugin-javax-mail-api.yml
@@ -7,7 +7,7 @@ developers:
   - "basil"
   - "markewaite"
 issues:
-  - jira: 28833
+  - github: *GH
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-jersey2-api.yml
+++ b/permissions/plugin-jersey2-api.yml
@@ -6,6 +6,6 @@ paths:
 developers:
   - "markewaite"
 issues:
-  - jira: 28832
+  - github: *GH
 cd:
   enabled: true

--- a/permissions/plugin-jquery.yml
+++ b/permissions/plugin-jquery.yml
@@ -1,8 +1,8 @@
 ---
 name: "jquery"
-github: "jenkinsci/jquery-plugin"
+github: &gh "jenkinsci/jquery-plugin"
 issues:
-  - jira: '16017'  # jquery-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/jquery"
 developers:

--- a/permissions/plugin-plot.yml
+++ b/permissions/plugin-plot.yml
@@ -1,8 +1,8 @@
 ---
 name: "plot"
-github: "jenkinsci/plot-plugin"
+github: &gh "jenkinsci/plot-plugin"
 issues:
-  - jira: '15564'  # plot-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/plot"
 developers:

--- a/permissions/plugin-schedule-build.yml
+++ b/permissions/plugin-schedule-build.yml
@@ -1,8 +1,8 @@
 ---
 name: "schedule-build"
-github: "jenkinsci/schedule-build-plugin"
+github: &gh "jenkinsci/schedule-build-plugin"
 issues:
-  - jira: '18422'  # schedule-build-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/schedule-build"
 developers:

--- a/permissions/plugin-variant.yml
+++ b/permissions/plugin-variant.yml
@@ -1,8 +1,8 @@
 ---
 name: "variant"
-github: "jenkinsci/variant-plugin"
+github: &gh "jenkinsci/variant-plugin"
 issues:
-  - jira: '21930'  # variant-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/variant"
 developers:

--- a/permissions/plugin-xshell.yml
+++ b/permissions/plugin-xshell.yml
@@ -1,8 +1,8 @@
 ---
 name: "xshell"
-github: "jenkinsci/xshell-plugin"
+github: &gh "jenkinsci/xshell-plugin"
 issues:
-  - jira: '16098'  # xshell-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/xshell"
   - "org/jvnet/hudson/plugins/xshell"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like plugins that I maintain to be migrated. 

Plugins being migrated:
- xshell
- variant
- schedule-build
- plot
- jquery
- jersey2-api
- javax-mail-api
- javax-activation-api

@markewaite approves the migration

<!--
Jira to GitHub mapping:
xshell-plugin:xshell-plugin
variant-plugin:variant-plugin
schedule-build-plugin:schedule-build-plugin
plot-plugin:plot-plugin
jquery-plugin:jquery-plugin
javax-mail-api-plugin:javax-mail-api-plugin
jersey2-api-plugin:jersey2-api-plugin
javax-activation-api-plugin:javax-activation-api-plugin
-->