### PR TITLE
Proposing repo `jenkins-enforcer-rules`

### DIFF
--- a/permissions/component-jenkins-enforcer-rules.yml
+++ b/permissions/component-jenkins-enforcer-rules.yml
@@ -1,0 +1,11 @@
+---
+name: "jenkins-enforcer-rules"
+github: &GH "jenkinsci/jenkins-enforcer-rules"
+issues:
+  - github: *GH
+paths:
+  - "io/jenkins/tools/maven/jenkins-enforcer-rules"
+cd:
+  enabled: true
+developers:
+  - "@core"


### PR DESCRIPTION
# Link to GitHub repository

I am proposing a new tool repo `jenkinsci/jenkins-enforcer-rules` with an artifact named `io.jenkins.tools.maven:jenkins-enforcer-rules` to host Jenkins-specific or Jenkins-oriented rules in line with
* https://github.com/apache/maven-enforcer
* https://github.com/mojohaus/extra-enforcer-rules

Specifically while working on https://github.com/jenkinsci/maven-hpi-plugin/pull/883 and its integration in https://github.com/jenkinsci/plugin-pom/pull/1381 I found it awkward to be mixing Enforcer and mojo dependencies, and loading the same artifact into a single Maven JVM in two different class loaders feels at best confusing. I did prototyping this way just to save time, but for (proposed) production use a dedicated repository feels appropriate.

Modelled loosely after https://github.com/jenkins-infra/repository-permissions-updater/blob/a1743a666a61fa0d2dce901a9cd2e487a6b75a00/permissions/component-maven-hpi-plugin.yml#L1-L10 and https://github.com/jenkins-infra/repository-permissions-updater/blob/a1743a666a61fa0d2dce901a9cd2e487a6b75a00/permissions/component-license-maven-plugin.yml#L1-L12 though I am omitting the generic path https://github.com/jenkins-infra/repository-permissions-updater/blob/a1743a666a61fa0d2dce901a9cd2e487a6b75a00/permissions/component-license-maven-plugin.yml#L7 which does not seem to be necessary here unless I am missing something.

The package name would I suppose follow the same pattern `io.jenkins.tools.maven:jenkins_enforcer_rules`? Currently there is a single rule which warns about both `<dependencyManagement>` and `<properties>` though if I am going to have the luxury of a dedicated repo I may split that into two rules (but would likely still keep a single skip property for convenience).

Note that I have not prepared the dedicated repo—mostly just a routine matter of copying over relevant `pom.xml` / `Jenkinsfile` setup from `maven-hpi-plugin`, importing commits from the current draft PR into a PR in the new repo, and similar.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
