### PR TITLE
Switch remaining Pipeline-suite plugins to GitHub Issues

### DIFF
--- a/permissions/plugin-pipeline-build-step.yml
+++ b/permissions/plugin-pipeline-build-step.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-build-step"
-github: "jenkinsci/pipeline-build-step-plugin"
+github: &GH "jenkinsci/pipeline-build-step-plugin"
 issues:
-  - jira: '21707'  # pipeline-build-step-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/pipeline-build-step"
 cd:

--- a/permissions/plugin-pipeline-github-lib.yml
+++ b/permissions/plugin-pipeline-github-lib.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-github-lib"
-github: "jenkinsci/pipeline-github-lib-plugin"
+github: &GH "jenkinsci/pipeline-github-lib-plugin"
 issues:
-  - jira: '21833'  # pipeline-github-lib-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/pipeline-github-lib"
 cd:

--- a/permissions/plugin-pipeline-groovy-lib.yml
+++ b/permissions/plugin-pipeline-groovy-lib.yml
@@ -12,7 +12,7 @@ developers:
   - "carroll"
   - "bitwiseman"
 issues:
-  - jira: 28923
+  - github: *GH
 security:
   contacts:
     jira: "cloudbees_security_members"

--- a/permissions/plugin-pipeline-input-step.yml
+++ b/permissions/plugin-pipeline-input-step.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-input-step"
-github: "jenkinsci/pipeline-input-step-plugin"
+github: &GH "jenkinsci/pipeline-input-step-plugin"
 issues:
-  - jira: '21708'  # pipeline-input-step-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/pipeline-input-step"
 developers:

--- a/permissions/plugin-pipeline-milestone-step.yml
+++ b/permissions/plugin-pipeline-milestone-step.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-milestone-step"
-github: "jenkinsci/pipeline-milestone-step-plugin"
+github: &GH "jenkinsci/pipeline-milestone-step-plugin"
 issues:
-  - jira: '21448'  # pipeline-milestone-step-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/pipeline-milestone-step"
 developers:

--- a/permissions/plugin-pipeline-model-api.yml
+++ b/permissions/plugin-pipeline-model-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-model-api"
-github: "jenkinsci/pipeline-model-definition-plugin"
+github: &GH "jenkinsci/pipeline-model-definition-plugin"
 issues:
-  - jira: '21706'  # pipeline-model-definition-plugin
+  - github: *GH
 paths:
   - "org/jenkinsci/plugins/pipeline-model-api"
 developers:

--- a/permissions/plugin-pipeline-model-declarative-agent.yml
+++ b/permissions/plugin-pipeline-model-declarative-agent.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-model-declarative-agent"
-github: "jenkinsci/pipeline-model-definition-plugin"
+github: &GH "jenkinsci/pipeline-model-definition-plugin"
 issues:
-  - jira: '21706'  # pipeline-model-definition-plugin
+  - github: *GH
 paths:
   - "org/jenkinsci/plugins/pipeline-model-declarative-agent"
 developers:

--- a/permissions/plugin-pipeline-model-extensions.yml
+++ b/permissions/plugin-pipeline-model-extensions.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-model-extensions"
-github: "jenkinsci/pipeline-model-definition-plugin"
+github: &GH "jenkinsci/pipeline-model-definition-plugin"
 issues:
-  - jira: '21706'  # pipeline-model-definition-plugin
+  - github: *GH
 paths:
   - "org/jenkinsci/plugins/pipeline-model-extensions"
 developers:

--- a/permissions/plugin-pipeline-stage-step.yml
+++ b/permissions/plugin-pipeline-stage-step.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-stage-step"
-github: "jenkinsci/pipeline-stage-step-plugin"
+github: &GH "jenkinsci/pipeline-stage-step-plugin"
 issues:
-  - jira: '21709'  # pipeline-stage-step-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/pipeline-stage-step"
 developers:

--- a/permissions/plugin-workflow-api.yml
+++ b/permissions/plugin-workflow-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-api"
-github: "jenkinsci/workflow-api-plugin"
+github: &GH "jenkinsci/workflow-api-plugin"
 issues:
-  - jira: '21711'  # workflow-api-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-api"
 developers:

--- a/permissions/plugin-workflow-scm-step.yml
+++ b/permissions/plugin-workflow-scm-step.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-scm-step"
-github: "jenkinsci/workflow-scm-step-plugin"
+github: &GH "jenkinsci/workflow-scm-step-plugin"
 issues:
-  - jira: '21717'  # workflow-scm-step-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-scm-step"
 developers:

--- a/permissions/plugin-workflow-step-api.yml
+++ b/permissions/plugin-workflow-step-api.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-step-api"
-github: "jenkinsci/workflow-step-api-plugin"
+github: &GH "jenkinsci/workflow-step-api-plugin"
 issues:
-  - jira: '21718'  # workflow-step-api-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-step-api"
 developers:

--- a/permissions/plugin-workflow-support.yml
+++ b/permissions/plugin-workflow-support.yml
@@ -1,8 +1,8 @@
 ---
 name: "workflow-support"
-github: "jenkinsci/workflow-support-plugin"
+github: &GH "jenkinsci/workflow-support-plugin"
 issues:
-  - jira: '21719'  # workflow-support-plugin
+  - github: *GH
 paths:
   - "org/jenkins-ci/plugins/workflow/workflow-support"
 developers:


### PR DESCRIPTION
@timja already did many of them, but I guess some were forgotten or deferred and I just noticed this.

I would like the usual migration please: Issues enabled on the repo, all existing Jira issues in the component migrated, the Jira component closed for new entries.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
