### PR TITLE
Remove CloudBees as security contact for BlueOcean plugins

### DIFF
--- a/permissions/plugin-blueocean-autofavorite.yml
+++ b/permissions/plugin-blueocean-autofavorite.yml
@@ -18,6 +18,3 @@ developers:
   - "kshultz"
   - "bitwiseman"
   - "olamy"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-bitbucket-pipeline.yml
+++ b/permissions/plugin-blueocean-bitbucket-pipeline.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-commons.yml
+++ b/permissions/plugin-blueocean-commons.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-config.yml
+++ b/permissions/plugin-blueocean-config.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-core-js.yml
+++ b/permissions/plugin-blueocean-core-js.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-dashboard.yml
+++ b/permissions/plugin-blueocean-dashboard.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-display-url.yml
+++ b/permissions/plugin-blueocean-display-url.yml
@@ -19,6 +19,3 @@ developers:
   - "olamy"
   - "imeredith"
   - "jamesdumay"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-events.yml
+++ b/permissions/plugin-blueocean-events.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-executor-info.yml
+++ b/permissions/plugin-blueocean-executor-info.yml
@@ -19,6 +19,3 @@ developers:
   - "olamy"
   - "imeredith"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-git-pipeline.yml
+++ b/permissions/plugin-blueocean-git-pipeline.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-github-pipeline.yml
+++ b/permissions/plugin-blueocean-github-pipeline.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-i18n.yml
+++ b/permissions/plugin-blueocean-i18n.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-jira.yml
+++ b/permissions/plugin-blueocean-jira.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-jwt.yml
+++ b/permissions/plugin-blueocean-jwt.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-personalization.yml
+++ b/permissions/plugin-blueocean-personalization.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-pipeline-api-impl.yml
+++ b/permissions/plugin-blueocean-pipeline-api-impl.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-pipeline-editor.yml
+++ b/permissions/plugin-blueocean-pipeline-editor.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-pipeline-scm-api.yml
+++ b/permissions/plugin-blueocean-pipeline-scm-api.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-rest-impl.yml
+++ b/permissions/plugin-blueocean-rest-impl.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-rest.yml
+++ b/permissions/plugin-blueocean-rest.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean-web.yml
+++ b/permissions/plugin-blueocean-web.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-blueocean.yml
+++ b/permissions/plugin-blueocean.yml
@@ -19,6 +19,3 @@ developers:
   - "olamy"
   - "tscherler"
   - "jpochat"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-jenkins-design-language.yml
+++ b/permissions/plugin-jenkins-design-language.yml
@@ -18,6 +18,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-pubsub-light.yml
+++ b/permissions/plugin-pubsub-light.yml
@@ -12,6 +12,3 @@ developers:
   - "tscherler"
   - "jamesdumay"
   - "olamy"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-sse-gateway.yml
+++ b/permissions/plugin-sse-gateway.yml
@@ -19,6 +19,3 @@ developers:
   - "kshultz"
   - "bitwiseman"
   - "olamy"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/pom-blueocean-parent.yml
+++ b/permissions/pom-blueocean-parent.yml
@@ -16,6 +16,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "tscherler"
-security:
-  contacts:
-    jira: "cloudbees_security_members"


### PR DESCRIPTION
Hello :wave:

CloudBees is dropping support for BlueOcean, so I'm removing the CloudBees Security Contact for all BlueOcean-related plugins.

Thanks a lot for your help and attention :bow: 