### PR TITLE
Migrate 11 plugins issues to GitHub

### DIFF
--- a/permissions/plugin-authentication-tokens.yml
+++ b/permissions/plugin-authentication-tokens.yml
@@ -1,8 +1,8 @@
 ---
 name: "authentication-tokens"
-github: "jenkinsci/authentication-tokens-plugin"
+github: &gh "jenkinsci/authentication-tokens-plugin"
 issues:
-  - jira: '20323'  # authentication-tokens-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/authentication-tokens"
 cd:

--- a/permissions/plugin-aws-global-configuration.yml
+++ b/permissions/plugin-aws-global-configuration.yml
@@ -1,8 +1,8 @@
 ---
 name: "aws-global-configuration"
-github: "jenkinsci/aws-global-configuration-plugin"
+github: &gh "jenkinsci/aws-global-configuration-plugin"
 issues:
-  - jira: '23929'  # aws-global-configuration-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/aws-global-configuration"
 cd:

--- a/permissions/plugin-build-symlink.yml
+++ b/permissions/plugin-build-symlink.yml
@@ -1,8 +1,8 @@
 ---
 name: "build-symlink"
-github: "jenkinsci/build-symlink-plugin"
+github: &gh "jenkinsci/build-symlink-plugin"
 issues:
-  - jira: '25121'  # build-symlink-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/build-symlink"
 developers:

--- a/permissions/plugin-docker-commons.yml
+++ b/permissions/plugin-docker-commons.yml
@@ -1,8 +1,8 @@
 ---
 name: "docker-commons"
-github: "jenkinsci/docker-commons-plugin"
+github: &gh "jenkinsci/docker-commons-plugin"
 issues:
-  - jira: '20628'  # docker-commons-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/docker-commons"
 cd:

--- a/permissions/plugin-groovy.yml
+++ b/permissions/plugin-groovy.yml
@@ -1,8 +1,8 @@
 ---
 name: "groovy"
-github: "jenkinsci/groovy-plugin"
+github: &gh "jenkinsci/groovy-plugin"
 issues:
-  - jira: '15549' # groovy-plugin
+  - github: *gh
 cd:
   enabled: true
 paths:

--- a/permissions/plugin-mock-security-realm.yml
+++ b/permissions/plugin-mock-security-realm.yml
@@ -1,8 +1,8 @@
 ---
 name: "mock-security-realm"
-github: "jenkinsci/mock-security-realm-plugin"
+github: &gh "jenkinsci/mock-security-realm-plugin"
 issues:
-  - jira: '17121'  # mock-security-realm-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/mock-security-realm"
 cd:

--- a/permissions/plugin-mock-slave.yml
+++ b/permissions/plugin-mock-slave.yml
@@ -1,10 +1,10 @@
 ---
 name: "mock-slave"
-github: "jenkinsci/mock-slave-plugin"
+github: &gh "jenkinsci/mock-slave-plugin"
 cd:
   enabled: true
 issues:
-  - jira: '17334' # mock-slave-plugin
+  - github: *gh
 paths:
   - "org/jenkinci/plugins/mock-slave"
   - "org/jenkins-ci/plugins/mock-slave"

--- a/permissions/plugin-pipeline-cloudwatch-logs.yml
+++ b/permissions/plugin-pipeline-cloudwatch-logs.yml
@@ -1,8 +1,8 @@
 ---
 name: "pipeline-cloudwatch-logs"
-github: "jenkinsci/pipeline-cloudwatch-logs-plugin"
+github: &gh "jenkinsci/pipeline-cloudwatch-logs-plugin"
 issues:
-  - jira: '23949'  # pipeline-cloudwatch-logs-plugin
+  - github: *gh
 paths:
   - "io/jenkins/plugins/pipeline-cloudwatch-logs"
 cd:

--- a/permissions/plugin-plain-credentials.yml
+++ b/permissions/plugin-plain-credentials.yml
@@ -1,8 +1,8 @@
 ---
 name: "plain-credentials"
-github: "jenkinsci/plain-credentials-plugin"
+github: &gh "jenkinsci/plain-credentials-plugin"
 issues:
-  - jira: '18123'  # plain-credentials-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/plain-credentials"
 cd:

--- a/permissions/plugin-ssh-agent.yml
+++ b/permissions/plugin-ssh-agent.yml
@@ -1,8 +1,8 @@
 ---
 name: "ssh-agent"
-github: "jenkinsci/ssh-agent-plugin"
+github: &gh "jenkinsci/ssh-agent-plugin"
 issues:
-  - jira: '17509'  # ssh-agent-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/ssh-agent"
 cd:

--- a/permissions/plugin-structs.yml
+++ b/permissions/plugin-structs.yml
@@ -1,8 +1,8 @@
 ---
 name: "structs"
-github: "jenkinsci/structs-plugin"
+github: &gh "jenkinsci/structs-plugin"
 issues:
-  - jira: '21442'  # structs-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/structs"
 developers:


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- authentication-tokens
- aws-global-configuration
- build-symlink
- docker-commons
- groovy
- mock-security-realm
- mock-slave
- pipeline-cloudwatch-logs
- plain-credentials
- ssh-agent
- structs

@ for approval

Let me know if any objections or questions

<!--
Jira to GitHub mapping:
authentication-tokens-plugin:authentication-tokens-plugin
aws-global-configuration-plugin:aws-global-configuration-plugin
build-symlink-plugin:build-symlink-plugin
docker-commons-plugin:docker-commons-plugin
groovy-plugin:groovy-plugin
mock-security-realm-plugin:mock-security-realm-plugin
mock-slave-plugin:mock-slave-plugin
pipeline-cloudwatch-logs-plugin:pipeline-cloudwatch-logs-plugin
plain-credentials-plugin:plain-credentials-plugin
ssh-agent-plugin:ssh-agent-plugin
structs-plugin:structs-plugin

-->

----

I just looked for files listing me as a maintainer and picked some of them. For the remainder:
  - external-monitor-job, kubernetes-client-api, secure-requester-whitelist — may have more active maintainers
  - cloudbees-enterprise-plugins — dead for years
  - workflow-stm — never released
