### PR TITLE
Add cloudbees-developers as co-maintainers of github-plugin

### DIFF
--- a/permissions/plugin-github.yml
+++ b/permissions/plugin-github.yml
@@ -9,6 +9,7 @@ developers:
   - "integer"
   - "lanwen"
   - "oleg_nenashev"
+  - "@cloudbees-developers"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
## Summary
- Adds `@cloudbees-developers` team as co-maintainers of the GitHub plugin

## Motivation

CloudBees has an open pull request on the GitHub plugin that fixes a Java 25 PCT compatibility issue and has been approved by community members, but cannot be merged without maintainer access:
https://github.com/jenkinsci/github-plugin/pull/793