### PR TITLE
Remove developer entry for discord-notifier

### DIFF
--- a/permissions/plugin-discord-notifier.yml
+++ b/permissions/plugin-discord-notifier.yml
@@ -6,7 +6,6 @@ issues:
 paths:
   - "nz/co/jammehcow/discord-notifier"
 developers:
-  - "kocproz"
   - "markewaite"
 cd:
   enabled: true


### PR DESCRIPTION
I want to remove myself from developers list.

# Link to GitHub repository
https://github.com/jenkinsci/discord-notifier-plugin

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
