### PR TITLE
JENKINS-76455 Move Matrix-sorter-plugin to github actions

### DIFF
--- a/permissions/plugin-Matrix-sorter-plugin.yml
+++ b/permissions/plugin-Matrix-sorter-plugin.yml
@@ -1,10 +1,12 @@
 ---
 name: "Matrix-sorter-plugin"
-github: "jenkinsci/Matrix-sorter-plugin"
+github: &gh "jenkinsci/Matrix-sorter-plugin"
 issues:
-  - jira: '17581'  # matrix-sorter-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/Matrix-sorter-plugin"
+cd:
+  enabled: true
 developers:
   - "olivergondza"
   - "kanaduchi"


### PR DESCRIPTION
The Matrix-sorter-plugin plugin should be enabled in the CD process after adoption. 

# Link to GitHub repository

[Matrix-sorter-plugin](https://github.com/jenkinsci/Matrix-sorter-plugin)

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

Matrix-sorter-plugin has all the necessary changes in the code - https://github.com/jenkinsci/Matrix-sorter-plugin/blob/master/.github/workflows/cd.yaml

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
