### PR TITLE
Enable cd for multibranch-job-tear-down

### DIFF
--- a/permissions/plugin-multibranch-job-tear-down.yml
+++ b/permissions/plugin-multibranch-job-tear-down.yml
@@ -5,6 +5,8 @@ issues:
   - github: *gh
 paths:
   - "com/fuzzpro/jenkins-plugins/multibranch-job-tear-down"
+cd:
+  enabled: true
 developers:
   - "fuzzcaguilar"
   - "clemstoquart"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/multibranch-job-tear-down-plugin

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/multibranch-job-tear-down-plugin/pull/16

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
