### PR TITLE
Enable CD and update maintainers for appcircle-testing-distribution a…

### DIFF
--- a/permissions/plugin-appcircle-enterprise-store.yml
+++ b/permissions/plugin-appcircle-enterprise-store.yml
@@ -1,9 +1,11 @@
 ---
 name: "appcircle-enterprise-store"
-github: &GH "jenkinsci/appcircle-enterprise-store-plugin"
+github: &GH "jenkinsci/appcircle-enterprise-app-store-plugin"
 paths:
 - "io/jenkins/plugins/appcircle-enterprise-store"
 developers:
 - "appcircle"
+cd:
+  enabled: true
 issues:
   - github: *GH

--- a/permissions/plugin-appcircle-testing-distribution.yml
+++ b/permissions/plugin-appcircle-testing-distribution.yml
@@ -4,7 +4,6 @@ github: &GH "jenkinsci/appcircle-testing-distribution-plugin"
 paths:
 - "io/jenkins/plugins/appcircle-testing-distribution"
 developers:
-- "brkyld"
 - "appcircle"
 cd:
   enabled: true

--- a/permissions/plugin-appcircle-testing-distribution.yml
+++ b/permissions/plugin-appcircle-testing-distribution.yml
@@ -4,7 +4,7 @@ github: &GH "jenkinsci/appcircle-testing-distribution-plugin"
 paths:
 - "io/jenkins/plugins/appcircle-testing-distribution"
 developers:
-- "BrkYld"
+- "brkyld"
 - "appcircle"
 cd:
   enabled: true

--- a/permissions/plugin-appcircle-testing-distribution.yml
+++ b/permissions/plugin-appcircle-testing-distribution.yml
@@ -4,7 +4,9 @@ github: &GH "jenkinsci/appcircle-testing-distribution-plugin"
 paths:
 - "io/jenkins/plugins/appcircle-testing-distribution"
 developers:
-- "guvenkaranfil"
+- "BrkYld"
 - "appcircle"
+cd:
+  enabled: true
 issues:
   - github: *GH


### PR DESCRIPTION
Enable CD for appcircle-testing-distribution and appcircle-enterprise-store (and update TD maintainers)

# Link to GitHub repository

- https://github.com/jenkinsci/appcircle-testing-distribution-plugin
- https://github.com/jenkinsci/appcircle-enterprise-app-store-plugin

This PR:
- Enables automated releases (`cd: enabled: true`) for both plugins.
- Updates the `developers` list of **appcircle-testing-distribution** (removes `guvenkaranfil`, adds `BrkYld`; `appcircle` retained).
- Fixes the stale `github:` field of **appcircle-enterprise-store** from `jenkinsci/appcircle-enterprise-store-plugin` (renamed/redirected) to the current `jenkinsci/appcircle-enterprise-app-store-plugin`.

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

**appcircle-testing-distribution**
- `@BrkYld`
- `@appcircle`

**appcircle-enterprise-store**
- `@appcircle`

This is needed in order to cut releases of the plugin or component.

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

cc @envergokmen @ozcanovunc — team members of the appcircle plugins, please approve this request.

## When enabling automated releases (cd: true)

Set up per the [CD documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/). The plugin PRs add the `.github/workflows/cd.yaml` (official `jenkins-infra/.../maven-cd.yml@v1`) and the `${revision}${changelist}` versioning is already in place.

### Link to the PR enabling CD in your plugin

- appcircle-testing-distribution: https://github.com/jenkinsci/appcircle-testing-distribution-plugin/pull/3
- appcircle-enterprise-app-store: https://github.com/jenkinsci/appcircle-enterprise-app-store-plugin/pull/3

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.