### PR TITLE
Add Pitxyoki as a developer in gitlab-branch-source plugin

### DIFF
--- a/permissions/plugin-gitlab-branch-source.yml
+++ b/permissions/plugin-gitlab-branch-source.yml
@@ -14,6 +14,7 @@ developers:
   - "jetersen"
   - "surenpi"
   - "markewaite"
+  - "pitxyoki"
 security:
   contacts:
     jira: "cloudbees_security_members"


### PR DESCRIPTION
I was invited by Basil Crow in https://github.com/jenkinsci/gitlab-branch-source-plugin/pull/495#issuecomment-3110170665 to become a maintainer for this plugin.

I am mostly interested in bringing just a couple of improvements into it.

Mentioning some developers to get their attention to this: @jetersen @MarkEWaite @basil.

# Link to GitHub repository

https://github.com/jenkinsci/gitlab-branch-source-plugin/

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- @pitxyoki

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.