### PR TITLE
Add zerlinpi as build-token-trigger developer

### DIFF
--- a/permissions/plugin-build-token-trigger.yml
+++ b/permissions/plugin-build-token-trigger.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '23535'  # build-token-trigger-plugin
 paths:
   - "org/jenkins-ci/plugins/build-token-trigger"
-developers: []
+developers:
+  - "zerlinpi"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/build-token-trigger-plugin

# When modifying release permission

The Jenkins infrastructure account that should receive release permission is:

- `zerlinpi` (GitHub: `@zerlinpi`)

This request is part of adopting the Build Token Trigger plugin, which is
explicitly marked for adoption and currently has no developers listed in this
repository.

### Release permission checklist (for submitters)

- [x] The username added to the `developers` section is the same username used
  to log in to accounts.jenkins.io.
- [x] The user has logged in to Artifactory and Jira once.
- [x] I have mentioned an existing team member of the plugin team to approve
  this request.

There is no existing developer listed in
`permissions/plugin-build-token-trigger.yml`. Per the Jenkins Adopt a Plugin
documentation, no two-week wait is required when no maintainers are listed in
Repository Permission Updater:
https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/

The adoption announcement was published to the Jenkins Developers mailing list
on 2026-07-14 with links to this request and the initial maintenance pull
request:
https://groups.google.com/g/jenkinsci-dev/c/iqsUDlXGs9c

Initial maintenance pull request:
https://github.com/jenkinsci/build-token-trigger-plugin/pull/6

## When enabling automated releases (cd: true)

Not part of this change.
