### PR TITLE
Enable CD in plugin-ansible-tower.yml

### DIFF
--- a/permissions/plugin-ansible-tower.yml
+++ b/permissions/plugin-ansible-tower.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '23177'  # ansible-tower-plugin
 paths:
   - "org/jenkins-ci/plugins/ansible-tower"
+cd:
+  enabled: true
 developers:
   - "johnwestcottiv"
   - "nupinto"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/ansible-tower-plugin

# When modifying release permission

<!-- Not applicable. This request is only for enabling automated releases (CD). -->

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/ansible-tower-plugin/pull/38


### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.


### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.