### PR TITLE
Enable CD for build-token-trigger

### DIFF
--- a/permissions/plugin-build-token-trigger.yml
+++ b/permissions/plugin-build-token-trigger.yml
@@ -7,3 +7,5 @@ paths:
   - "org/jenkins-ci/plugins/build-token-trigger"
 developers:
   - "zerlinpi"
+cd:
+  enabled: true


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/build-token-trigger-plugin

# When modifying release permission

Enable exclusive JEP-229 continuous delivery for the adopted Build Token Trigger plugin.

The plugin-side CD and Incrementals configuration is included in:
https://github.com/jenkinsci/build-token-trigger-plugin/pull/6
Official plugin CI is passing: https://ci.jenkins.io/job/Plugins/job/build-token-trigger-plugin/job/PR-6/6/

The adoption and developer permission request was approved and merged in:
https://github.com/jenkins-infra/repository-permissions-updater/pull/5149

The plugin BOM follow-up requested during review is tracked in:
https://github.com/jenkinsci/bom/pull/7076

## When enabling automated releases (cd: true)

- [x] The plugin PR contains `.mvn/extensions.xml`, `.mvn/maven.config`, and `.github/workflows/cd.yaml`.
- [x] This request links to the plugin-side CD changes for hosting-team review.