### PR TITLE
Migrate bitbucket plugin issues to GitHub

### DIFF
--- a/permissions/plugin-bitbucket.yml
+++ b/permissions/plugin-bitbucket.yml
@@ -1,8 +1,8 @@
 ---
 name: "bitbucket"
-github: "jenkinsci/bitbucket-plugin"
+github: &gh "jenkinsci/bitbucket-plugin"
 issues:
-  - jira: '18755'  # bitbucket-plugin
+  - github: *gh
 paths:
   - "org/jenkins-ci/plugins/bitbucket"
 developers:


### PR DESCRIPTION
Hi

I would like to migrate the Bitbucket plugin from Jira to GitHub Issues.

Plugin being migrated:
- bitbucket

I approve this migration as a plugin maintainer.

Let me know if there are any objections or questions.

<!--
Jira to GitHub mapping:
bitbucket-plugin:bitbucket-plugin
-->