### PR TITLE
Grant nbuckwalt and golfhackerdave access to plugin-contrast-continuous-application-security.yml

### DIFF
--- a/permissions/plugin-contrast-continuous-application-security.yml
+++ b/permissions/plugin-contrast-continuous-application-security.yml
@@ -11,3 +11,5 @@ developers:
   - "cgperez"
   - "NoahContrast"
   - "arturo_contrast"
+  - "nbuckwalt"
+  - "golfhackerdave"

--- a/permissions/plugin-contrast-continuous-application-security.yml
+++ b/permissions/plugin-contrast-continuous-application-security.yml
@@ -12,4 +12,3 @@ developers:
   - "NoahContrast"
   - "arturo_contrast"
   - "nbuckwalt"
-  - "golfhackerdave"


### PR DESCRIPTION
# Description

Grant @nbuckwalt and @golfhackerdave "Maintain" permissions to contrast-continuous-application-security

cc @arturoespinoza15 

https://github.com/jenkinsci/contrast-continuous-application-security-plugin

# Submitter checklist for changing permissions

### Always

- [x] Add link to plugin/component Git repository in description above

### When adding new uploaders (this includes newly created permissions files)

- [x] [Make sure to `@`mention an existing maintainer to confirm the permissions request, if applicable](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)
- [x] Use the Jenkins community (LDAP) account name in the YAML file, not the GitHub account name
- [x] [All newly added users have logged in to Artifactory at least once](https://github.com/jenkins-infra/repository-permissions-updater/#requesting-permissions)


### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

There are [IRC Bot commands](https://jenkins.io/projects/infrastructure/ircbot/#issue-tracker-management) for it.
