### PR TITLE
Enable CD for testingbot plugin

### DIFF
--- a/permissions/plugin-testingbot.yml
+++ b/permissions/plugin-testingbot.yml
@@ -5,6 +5,8 @@ issues:
   - jira: '17570'  # testingbot-plugin
 paths:
   - "testingbot/testingbot"
+cd:
+  enabled: true
 developers:
   - "testingbot"
   - "jochen_testingbot"


### PR DESCRIPTION
Enables JEP-229 continuous delivery for the `testingbot` plugin (`jenkinsci/testingbot-plugin`).

The plugin has been set up for CD on the repository side (incrementals versioning via `.mvn/extensions.xml` + `.mvn/maven.config`, `<version>${revision}.${changelist}</version>`, and `.github/workflows/cd.yaml` from the standard template). This PR adds `cd: enabled: true` so the `MAVEN_USERNAME`/`MAVEN_TOKEN` secrets are provisioned and automated releases can run.

Repository CD setup PR: https://github.com/jenkinsci/testingbot-plugin (modernization merged to master; cd.yaml + incrementals in place).
