### PR TITLE
chore(Jenkinsfile) run every 2 hours instead of 3 in trusted.ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,8 @@ if (!env.CHANGE_ID && (!env.BRANCH_NAME || env.BRANCH_NAME == 'master')) {
         // Check for code change every 5 minutes as there are no webhooks on trusted.ci.jenkins.io
         // The goal is to run RPU as soon as possible for any code change
         triggers += pollSCM('H/5 * * * *')
-        // Run every 3 hours
-        triggers += cron('H H/3 * * *')
+        // Run every 2 hours: tokens expire after 3h and each build may take 10 to 40 min
+        triggers += cron('H H/2 * * *')
     } else {
         // elsewhere, it still should get built periodically
         // apparently this spikes load on Artifactory pretty badly, so don't run often


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5225#issuecomment-4999574483 (and https://github.com/jenkins-infra/helpdesk/issues/5218)
