### PR TITLE
add test that validates the parent pom

### DIFF
--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/hosting/RequirementsTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/hosting/RequirementsTest.java
@@ -11,5 +11,6 @@ public class RequirementsTest {
         String suffix = Requirements.LOWEST_PARENT_POM_VERSION.suffix();
         String[] segments = suffix.split("\\.");
         assertThat(segments.length).isEqualTo(2);
+        assertThat(segments[0]).containsOnlyDigits();
     }
 }

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/hosting/RequirementsTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/hosting/RequirementsTest.java
@@ -1,0 +1,15 @@
+package io.jenkins.infra.repository_permissions_updater.hosting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class RequirementsTest {
+
+    @Test
+    void validateLowestParentPom() {
+        String suffix = Requirements.LOWEST_PARENT_POM_VERSION.suffix();
+        String[] segments = suffix.split("\\.");
+        assertThat(segments.length).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
avoids that we add the full version in the suffix when updating parent pom.

