### PR TITLE
extend and improve checks

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GitHubVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GitHubVerifier.java
@@ -22,8 +22,14 @@ public class GitHubVerifier implements Verifier {
             "It was detected that you have files in the `%s` folder or that you had in the past files in that folder. "
                     + "Please remove the `target` folder and also rewrite the git history to never have contained any files in the `%s` folder.";
 
+    private final HashSet<VerificationMessage> hostingIssues;
+
+    public GitHubVerifier(HashSet<VerificationMessage> hostingIssues) {
+        this.hostingIssues = hostingIssues;
+    }
+
     @Override
-    public void verify(HostingRequest request, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    public void verify(HostingRequest request) throws IOException {
         GitHub github = GitHub.connect();
         String forkFrom = request.getRepositoryUrl();
         List<String> users = request.getGithubUsers();
@@ -83,11 +89,11 @@ public class GitHubVerifier implements Verifier {
                 }
 
                 if (repo != null) {
-                    checkReadme(repo, hostingIssues);
-                    checkLicense(repo, hostingIssues);
-                    checkForkedFromJenkinsCi(repo, hostingIssues, forkFrom);
-                    checkForkedIntoJenkinsCi(repo, hostingIssues, forkFrom);
-                    checkUnwantedFiles(repo, hostingIssues);
+                    checkReadme(repo);
+                    checkLicense(repo);
+                    checkForkedFromJenkinsCi(repo, forkFrom);
+                    checkForkedIntoJenkinsCi(repo, forkFrom);
+                    checkUnwantedFiles(repo);
                 }
             } else {
                 hostingIssues.add(new VerificationMessage(
@@ -96,8 +102,7 @@ public class GitHubVerifier implements Verifier {
         }
     }
 
-    private void checkForkedIntoJenkinsCi(
-            GHRepository repo, HashSet<VerificationMessage> hostingIssues, String forkFrom) {
+    private void checkForkedIntoJenkinsCi(GHRepository repo, String forkFrom) {
         // now need to check if there are any forks INTO jenkinsci already from this repo
         try {
             List<String> badForks = new ArrayList<>();
@@ -107,7 +112,7 @@ public class GitHubVerifier implements Verifier {
                 }
             }
 
-            if (badForks.size() > 0) {
+            if (!badForks.isEmpty()) {
                 hostingIssues.add(new VerificationMessage(
                         VerificationMessage.Severity.REQUIRED,
                         "Repository '%s' already has the following forks in the jenkinsci org: %s",
@@ -119,8 +124,7 @@ public class GitHubVerifier implements Verifier {
         }
     }
 
-    private void checkForkedFromJenkinsCi(
-            GHRepository repo, HashSet<VerificationMessage> hostingIssues, String forkFrom) {
+    private void checkForkedFromJenkinsCi(GHRepository repo, String forkFrom) {
         // check if the repo was originally forked from jenkinsci
         try {
             GHRepository parent = repo.getParent();
@@ -135,7 +139,7 @@ public class GitHubVerifier implements Verifier {
         }
     }
 
-    private void checkLicense(GHRepository repo, HashSet<VerificationMessage> hostingIssues) {
+    private void checkLicense(GHRepository repo) {
         try {
             GHLicense license = repo.getLicense();
             if (license == null) {
@@ -152,7 +156,7 @@ public class GitHubVerifier implements Verifier {
         }
     }
 
-    private void checkReadme(GHRepository repo, HashSet<VerificationMessage> hostingIssues) {
+    private void checkReadme(GHRepository repo) {
         try {
             GHContent readme = repo.getReadme();
             if (readme == null) {
@@ -169,7 +173,7 @@ public class GitHubVerifier implements Verifier {
         }
     }
 
-    private void checkUnwantedFiles(GHRepository repo, HashSet<VerificationMessage> hostingIssues) {
+    private void checkUnwantedFiles(GHRepository repo) {
         boolean foundTargetFolder = false;
         boolean foundWorkFolder = false;
         for (GHCommit commit : repo.listCommits()) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/GradleVerifier.java
@@ -78,8 +78,14 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
     private String forkTo;
     private String forkFrom;
 
+    private final HashSet<VerificationMessage> hostingIssues;
+
+    public GradleVerifier(HashSet<VerificationMessage> hostingIssues) {
+        this.hostingIssues = hostingIssues;
+    }
+
     @Override
-    public void verify(HostingRequest issue, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    public void verify(HostingRequest issue) throws IOException {
         GitHub github = GitHub.connect();
         forkFrom = issue.getRepositoryUrl();
         forkTo = issue.getNewRepoName();
@@ -111,25 +117,22 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
                                     if (mc.getMethodAsString().equals("plugins")) {
                                         // make sure we get the correct version of the gradle jpi plugin
                                         checkPluginVersion(
-                                                ((ArgumentListExpression) mc.getArguments()).getExpression(0),
-                                                hostingIssues);
+                                                ((ArgumentListExpression) mc.getArguments()).getExpression(0));
                                     } else if (mc.getMethodAsString().equals("repositories")) {
                                         // verify that any references to repo.jenkins-ci.org are correct
                                         checkRepositories(
-                                                ((ArgumentListExpression) mc.getArguments()).getExpression(0),
-                                                hostingIssues);
+                                                ((ArgumentListExpression) mc.getArguments()).getExpression(0));
                                     } else if (mc.getMethodAsString().equals("jenkinsPlugin")) {
                                         // verify the things that will make it into the pom.xml that is published
                                         checkJenkinsPlugin(
-                                                ((ArgumentListExpression) mc.getArguments()).getExpression(0),
-                                                hostingIssues);
+                                                ((ArgumentListExpression) mc.getArguments()).getExpression(0));
                                     }
                                 } else if (e instanceof BinaryExpression be) {
                                     VariableExpression v = (VariableExpression) be.getLeftExpression();
                                     if (v.getName().equals("group")) {
-                                        checkGroup(be.getRightExpression(), hostingIssues);
+                                        checkGroup(be.getRightExpression());
                                     } else if (v.getName().equals("targetCompatibility")) {
-                                        checkTargetCompatibility(be.getRightExpression(), hostingIssues);
+                                        checkTargetCompatibility(be.getRightExpression());
                                     }
                                 }
                             }
@@ -241,7 +244,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         return res;
     }
 
-    private void checkPluginVersion(Expression plugins, HashSet<VerificationMessage> hostingIssues) {
+    private void checkPluginVersion(Expression plugins) {
         if (plugins instanceof ClosureExpression c) {
             for (Statement st : ((BlockStatement) c.getCode()).getStatements()) {
                 Expression e = ((ExpressionStatement) st).getExpression();
@@ -277,7 +280,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         }
     }
 
-    private void checkRepositories(Expression repositories, HashSet<VerificationMessage> hostingIssues) {
+    private void checkRepositories(Expression repositories) {
         if (repositories instanceof ClosureExpression c) {
             for (Statement st : ((BlockStatement) c.getCode()).getStatements()) {
                 Expression e = ((ExpressionStatement) st).getExpression();
@@ -315,7 +318,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         }
     }
 
-    private void checkJenkinsPlugin(Expression jenkinsPlugin, HashSet<VerificationMessage> hostingIssues) {
+    private void checkJenkinsPlugin(Expression jenkinsPlugin) {
         if (jenkinsPlugin instanceof ClosureExpression c) {
             for (Statement st : ((BlockStatement) c.getCode()).getStatements()) {
                 ExpressionStatement s = (ExpressionStatement) st;
@@ -326,23 +329,23 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
                                 VerificationMessage.Severity.REQUIRED,
                                 "`coreVersion` is deprecated, please use `jenkinsVersion`"));
                     } else if (be.getLeftExpression().getText().equals("jenkinsVersion")) {
-                        checkJenkinsVersion(be.getRightExpression(), hostingIssues);
+                        checkJenkinsVersion(be.getRightExpression());
                     } else if (be.getLeftExpression().getText().equals("shortName")) {
-                        checkShortName(be.getRightExpression(), hostingIssues);
+                        checkShortName(be.getRightExpression());
                     } else if (be.getLeftExpression().getText().equals("displayName")) {
-                        checkDisplayName(be.getRightExpression(), hostingIssues);
+                        checkDisplayName(be.getRightExpression());
                     }
                 } else if (s.getExpression() instanceof MethodCallExpression) {
                     MethodCallExpression mc = (MethodCallExpression) s.getExpression();
                     if (mc.getMethodAsString().equals("licenses")) {
-                        checkLicenses(((ArgumentListExpression) mc.getArguments()).getExpression(0), hostingIssues);
+                        checkLicenses(((ArgumentListExpression) mc.getArguments()).getExpression(0));
                     }
                 }
             }
         }
     }
 
-    private void checkGroup(Expression e, HashSet<VerificationMessage> hostingIssues) {
+    private void checkGroup(Expression e) {
         if (e instanceof ConstantExpression) {
             String groupId = e.getText();
             if (StringUtils.isBlank(groupId)) {
@@ -359,7 +362,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         }
     }
 
-    private void checkTargetCompatibility(Expression e, HashSet<VerificationMessage> hostingIssues) {
+    private void checkTargetCompatibility(Expression e) {
         if (e instanceof ConstantExpression) {
             Version targetCompatVersion = new Version(e.getText());
             if (targetCompatVersion.compareTo(JAVA_COMPATIBILITY_VERSION) != 0) {
@@ -371,7 +374,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         }
     }
 
-    private void checkLicenses(Expression e, HashSet<VerificationMessage> hostingIssues) {
+    private void checkLicenses(Expression e) {
         if (e instanceof ClosureExpression c) {
             for (Statement st : ((BlockStatement) c.getCode()).getStatements()) {
                 e = ((ExpressionStatement) st).getExpression();
@@ -397,7 +400,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         }
     }
 
-    private void checkJenkinsVersion(Expression e, HashSet<VerificationMessage> hostingIssues) {
+    private void checkJenkinsVersion(Expression e) {
         if (e instanceof ConstantExpression) {
             Version jenkinsVersion = new Version(e.getText());
             if (jenkinsVersion.compareTo(LOWEST_JENKINS_VERSION) < 0) {
@@ -413,7 +416,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         }
     }
 
-    private void checkShortName(Expression e, HashSet<VerificationMessage> hostingIssues) {
+    private void checkShortName(Expression e) {
         if (e instanceof ConstantExpression) {
             String shortName = e.getText();
             if (StringUtils.isNotBlank(shortName)) {
@@ -447,7 +450,7 @@ public class GradleVerifier extends CodeVisitorSupport implements BuildSystemVer
         }
     }
 
-    private void checkDisplayName(Expression e, HashSet<VerificationMessage> hostingIssues) {
+    private void checkDisplayName(Expression e) {
         if (e instanceof ConstantExpression) {
             String name = e.getText();
             if (StringUtils.isNotBlank(name)) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingChecker.java
@@ -35,12 +35,13 @@ public class HostingChecker {
         boolean debug = System.getProperty("debugHosting", "false").equalsIgnoreCase("true");
 
         ArrayList<Triplet<String, Verifier, ConditionChecker>> verifications = new ArrayList<>();
-        verifications.add(Triplet.with("Request", new HostingFieldVerifier(), null));
-        verifications.add(Triplet.with("GitHub", new GitHubVerifier(), null));
-        verifications.add(Triplet.with("Maven", new MavenVerifier(), new FileExistsConditionChecker("pom.xml")));
-        verifications.add(Triplet.with("JenkinsProjectUsers", new JenkinsProjectUserVerifier(), null));
-        verifications.add(Triplet.with("Jelly", new JellyVerifier(), null));
-        verifications.add(Triplet.with("RequiredFiles", new RequiredFilesVerifier(), null));
+        verifications.add(Triplet.with("Request", new HostingFieldVerifier(hostingIssues), null));
+        verifications.add(Triplet.with("GitHub", new GitHubVerifier(hostingIssues), null));
+        verifications.add(
+                Triplet.with("Maven", new MavenVerifier(hostingIssues), new FileExistsConditionChecker("pom.xml")));
+        verifications.add(Triplet.with("JenkinsProjectUsers", new JenkinsProjectUserVerifier(hostingIssues), null));
+        verifications.add(Triplet.with("Jelly", new JellyVerifier(hostingIssues), null));
+        verifications.add(Triplet.with("RequiredFiles", new RequiredFilesVerifier(hostingIssues), null));
 
         final HostingRequest hostingRequest = HostingRequestParser.retrieveAndParse(issueID);
 
@@ -50,7 +51,7 @@ public class HostingChecker {
                         verifier.getValue2() == null || verifier.getValue2().checkCondition(hostingRequest);
                 if (runIt) {
                     LOGGER.info("Running verification '{}'", verifier.getValue0());
-                    verifier.getValue1().verify(hostingRequest, hostingIssues);
+                    verifier.getValue1().verify(hostingRequest);
                 }
 
                 if (verifier.getValue1() instanceof BuildSystemVerifier) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingFieldVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/HostingFieldVerifier.java
@@ -8,8 +8,14 @@ import org.apache.commons.lang3.StringUtils;
 
 public class HostingFieldVerifier implements Verifier {
 
+    private final HashSet<VerificationMessage> hostingIssues;
+
+    public HostingFieldVerifier(HashSet<VerificationMessage> hostingIssues) {
+        this.hostingIssues = hostingIssues;
+    }
+
     @Override
-    public void verify(HostingRequest issue, HashSet<VerificationMessage> hostingIssues) {
+    public void verify(HostingRequest issue) {
         String forkTo = issue.getNewRepoName();
         String forkFrom = issue.getRepositoryUrl();
         List<String> users = issue.getGithubUsers();

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JellyVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JellyVerifier.java
@@ -43,8 +43,14 @@ public class JellyVerifier implements Verifier {
             "One or more usages of inline javascript tags, style tags or event handlers have been identified. See "
                     + "https://www.jenkins.io/doc/developer/security/csp/ for more information how to make your jelly files CSP compliant";
 
+    private final HashSet<VerificationMessage> hostingIssues;
+
+    public JellyVerifier(HashSet<VerificationMessage> hostingIssues) {
+        this.hostingIssues = hostingIssues;
+    }
+
     @Override
-    public void verify(HostingRequest issue, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    public void verify(HostingRequest issue) throws IOException {
         GitHub github = GitHub.connect();
         String forkFrom = issue.getRepositoryUrl();
         if (StringUtils.isNotBlank(forkFrom)) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JenkinsProjectUserVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JenkinsProjectUserVerifier.java
@@ -9,8 +9,14 @@ import org.apache.commons.lang3.StringUtils;
 
 public class JenkinsProjectUserVerifier implements Verifier {
 
+    private final HashSet<VerificationMessage> hostingIssues;
+
+    public JenkinsProjectUserVerifier(HashSet<VerificationMessage> hostingIssues) {
+        this.hostingIssues = hostingIssues;
+    }
+
     @Override
-    public void verify(HostingRequest request, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    public void verify(HostingRequest request) throws IOException {
 
         List<String> jenkinsProjectUsers = request.getJenkinsProjectUsers();
         if (!jenkinsProjectUsers.isEmpty()) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/MavenVerifier.java
@@ -66,9 +66,14 @@ public class MavenVerifier implements BuildSystemVerifier {
 
     public static final String DEPENDENCY_SHOULD_USE_API_PLUGIN =
             "The dependency `%s` should be replaced with a dependency to the api plugin `%s` %s";
+    private final HashSet<VerificationMessage> hostingIssues;
+
+    public MavenVerifier(HashSet<VerificationMessage> hostingIssues) {
+        this.hostingIssues = hostingIssues;
+    }
 
     @Override
-    public void verify(HostingRequest issue, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    public void verify(HostingRequest issue) throws IOException {
         GitHub github = GitHub.connect();
         String forkTo = issue.getNewRepoName();
         String forkFrom = issue.getRepositoryUrl();
@@ -89,21 +94,21 @@ public class MavenVerifier implements BuildSystemVerifier {
                         Model model = reader.read(contents);
 
                         try {
-                            checkArtifactId(model, forkTo, hostingIssues);
-                            checkParentInfoAndJenkinsVersion(model, hostingIssues);
-                            checkName(model, hostingIssues);
-                            checkLicenses(model, hostingIssues);
-                            checkGroupId(model, hostingIssues);
-                            checkRepositories(model, hostingIssues);
-                            checkPluginRepositories(model, hostingIssues);
-                            checkSoftwareConfigurationManagementField(model, hostingIssues);
-                            checkDependencies(model, hostingIssues);
-                            checkDependencyManagement(model, hostingIssues);
-                            checkDevelopersTag(model, hostingIssues);
-                            checkProperties(model, hostingIssues);
-                            checkUrl(model, hostingIssues);
+                            checkArtifactId(model, forkTo);
+                            checkParentInfoAndJenkinsVersion(model);
+                            checkName(model);
+                            checkLicenses(model);
+                            checkGroupId(model);
+                            checkRepositories(model);
+                            checkPluginRepositories(model);
+                            checkSoftwareConfigurationManagementField(model);
+                            checkDependencies(model);
+                            checkDependencyManagement(model);
+                            checkDevelopersTag(model);
+                            checkProperties(model);
+                            checkUrl(model);
                             if (issue.isEnableCD()) {
-                                checkAutomaticReleasesSettings(model, hostingIssues);
+                                checkAutomaticReleasesSettings(model);
                             }
                         } catch (Exception e) {
                             LOGGER.error("Failed looking at pom.xml", e);
@@ -123,7 +128,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkUrl(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkUrl(Model model) {
         Properties props = model.getProperties();
         props.put("project.artifactId", model.getArtifactId());
         RegexBasedInterpolator interpolator = new RegexBasedInterpolator();
@@ -147,22 +152,30 @@ public class MavenVerifier implements BuildSystemVerifier {
         return HostingChecker.fileExistsInRepo(issue, "pom.xml");
     }
 
-    private void checkAutomaticReleasesSettings(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkAutomaticReleasesSettings(Model model) {
         Properties props = model.getProperties();
-        if (!props.containsKey("changelist") || !props.getProperty("changelist").equals("999999-SNAPSHOT")) {
-            hostingIssues.add(new VerificationMessage(
-                    VerificationMessage.Severity.REQUIRED,
-                    "The property `changelist` must be defined and set to `999999-SNAPSHOT` when CD is enabled."));
-        }
+        requireProperty(
+                "changelist",
+                "999999-SNAPSHOT",
+                props,
+                "This is required for automatic releases to work correctly."
+                        + " See https://www.jenkins.io/doc/developer/publishing/releasing-cd/ for best practices.");
         String version = model.getVersion();
         if (!version.contains("${changelist}")) {
             hostingIssues.add(new VerificationMessage(
                     VerificationMessage.Severity.REQUIRED,
                     "The version in the pom.xml must contain `${changelist}` when CD is enabled."));
         }
+        if (version.contains("${revision}${changelist}")) {
+            hostingIssues.add(
+                    new VerificationMessage(
+                            VerificationMessage.Severity.WARNING,
+                            "Using ${revision}${changelist} for the version is not recommended."
+                                    + " See https://www.jenkins.io/doc/developer/publishing/releasing-cd/ for best practices."));
+        }
     }
 
-    private void checkArtifactId(Model model, String forkTo, HashSet<VerificationMessage> hostingIssues) {
+    private void checkArtifactId(Model model, String forkTo) {
         try {
             if (StringUtils.isBlank(forkTo)) {
                 hostingIssues.add(new VerificationMessage(
@@ -225,7 +238,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkGroupId(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkGroupId(Model model) {
         try {
             String groupId = model.getGroupId();
             if (StringUtils.isNotBlank(groupId)) {
@@ -252,7 +265,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkName(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkName(Model model) {
         try {
             String name = model.getName();
             if (StringUtils.isNotBlank(name)) {
@@ -296,7 +309,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         return res;
     }
 
-    private void checkParentInfoAndJenkinsVersion(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkParentInfoAndJenkinsVersion(Model model) {
         try {
             Parent parent = model.getParent();
             if (parent != null) {
@@ -345,7 +358,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkDevelopersTag(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkDevelopersTag(Model model) {
         if (!model.getDevelopers().isEmpty()) {
             hostingIssues.add(
                     new VerificationMessage(
@@ -354,7 +367,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkLicenses(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkLicenses(Model model) {
         // first check the pom.xml
         List<License> licenses = model.getLicenses();
         if (licenses.isEmpty()) {
@@ -362,7 +375,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkRepositories(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkRepositories(Model model) {
         for (Repository r : model.getRepositories()) {
             if (r.getUrl().contains("repo.jenkins-ci.org") || r.getId().contains("repo.jenkins-ci.org")) {
                 try {
@@ -383,7 +396,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkPluginRepositories(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkPluginRepositories(Model model) {
         for (Repository r : model.getPluginRepositories()) {
             if (r.getUrl().contains("repo.jenkins-ci.org") || r.getId().contains("repo.jenkins-ci.org")) {
                 try {
@@ -404,7 +417,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkSoftwareConfigurationManagementField(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkSoftwareConfigurationManagementField(Model model) {
         if (model.getScm() == null) {
             hostingIssues.add(
                     new VerificationMessage(
@@ -445,7 +458,7 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkDependencyManagement(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkDependencyManagement(Model model) {
         JenkinsVersion jenkinsVersion = getJenkinsVersion(model);
         if (jenkinsVersion != null) {
             HashSet<VerificationMessage> dependencyManagementIssues = new HashSet<>();
@@ -531,7 +544,15 @@ public class MavenVerifier implements BuildSystemVerifier {
         }
     }
 
-    private void checkProperties(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void requireProperty(String name, String value, Properties props, String message) {
+        if (!props.containsKey(name) || !props.getProperty(name).equals(value)) {
+            hostingIssues.add(new VerificationMessage(
+                    VerificationMessage.Severity.REQUIRED,
+                    "Please define the property `" + name + "` and set it to `" + value + "`. " + message));
+        }
+    }
+
+    private void checkProperties(Model model) {
         Properties props = model.getProperties();
         List<String> illegalProps =
                 Arrays.asList("java.level", "maven.compiler.source", "maven.compiler.target", "maven.compiler.release");
@@ -549,38 +570,36 @@ public class MavenVerifier implements BuildSystemVerifier {
                             VerificationMessage.Severity.REQUIRED,
                             "Please define the property `jenkins.baseline` and use this property in `<jenkins.version>${jenkins.baseline}.3</jenkins.version>` and the artifactId of the bom."));
         }
-        if (!props.containsKey("hpi.strictBundledArtifacts")
-                || !props.getProperty("hpi.strictBundledArtifacts").equals("true")) {
-            hostingIssues.add(
-                    new VerificationMessage(
-                            VerificationMessage.Severity.REQUIRED,
-                            "Please define the property `hpi.strictBundledArtifacts` and set it to `true`. This should help prevent accidental library bundling when adding and updating dependencies."
-                                    + "See [Bundling third-party libraries](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#bundling-third-party-libraries)."));
-        }
-        if (!props.containsKey("ban-commons-lang-2.skip")
-                || !props.getProperty("ban-commons-lang-2.skip").equals("false")) {
-            hostingIssues.add(new VerificationMessage(
-                    VerificationMessage.Severity.REQUIRED,
-                    "Please define the property `ban-commons-lang-2.skip` and set it to `false`. This should help prevent accidental usage of the deprecated commons-lang-2 library that is "
-                            + "included in core."));
-        }
-        if (!props.containsKey("ban-deprecated-stapler.skip")
-                || !props.getProperty("ban-deprecated-stapler.skip").equals("false")) {
-            hostingIssues.add(new VerificationMessage(
-                    VerificationMessage.Severity.REQUIRED,
-                    "Please define the property `ban-deprecated-stapler.skip` and set it to `false`. This should help prevent usage of deprecated stapler and javax.servlet classes."
-                            + " included in core."));
-        }
-        if (!props.containsKey("ban-junit4-imports.skip")
-                || !props.getProperty("ban-junit4-imports.skip").equals("false")) {
-            hostingIssues.add(
-                    new VerificationMessage(
-                            VerificationMessage.Severity.REQUIRED,
-                            "Please define the property `ban-junit4-imports.skip` and set it to `false`. This should help prevent usage of deprecated junit 4 classes."));
-        }
+        requireProperty(
+                "hpi.strictBundledArtifacts",
+                "true",
+                props,
+                "This should help prevent accidental library bundling when adding and updating dependencies."
+                        + "See [Bundling third-party libraries](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#bundling-third-party-libraries).");
+        requireProperty(
+                "ban-commons-lang-2.skip",
+                "false",
+                props,
+                "This should help prevent accidental usage of the deprecated commons-lang-2 library that is included in core.");
+        requireProperty(
+                "ban-deprecated-stapler.skip",
+                "false",
+                props,
+                "This should help prevent usage of deprecated stapler and javax.servlet classes."
+                        + " included in core.");
+        requireProperty(
+                "ban-junit4-imports.skip",
+                "false",
+                props,
+                "This should help prevent usage of deprecated junit 4 classes.");
+        requireProperty(
+                "banObsoleteDependencyOverrides.skip",
+                "false",
+                props,
+                "This should help identify unnecessary overrides that can be removed when updating BOM versions or parent POMs.");
     }
 
-    private void checkDependencies(Model model, HashSet<VerificationMessage> hostingIssues) {
+    private void checkDependencies(Model model) {
         Map<String, String> bd = getBannedDependencies();
         model.getDependencies().forEach(d -> {
             String dep = d.getGroupId() + ":" + d.getArtifactId();

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
@@ -377,7 +377,10 @@ public class RequiredFilesVerifier implements Verifier {
                 }
             }
 
-        } catch (IOException | GroovyRuntimeException e) {
+        } catch (IOException e) {
+            hostingIssues.add(
+                    new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Could not read Jenkinsfile."));
+        } catch (GroovyRuntimeException e) {
             hostingIssues.add(
                     new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Could not parse Jenkinsfile."));
         }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/RequiredFilesVerifier.java
@@ -4,6 +4,7 @@ import static io.jenkins.infra.repository_permissions_updater.hosting.Requiremen
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyRuntimeException;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -43,8 +44,14 @@ import org.kohsuke.github.GitHub;
 
 public class RequiredFilesVerifier implements Verifier {
 
+    private final HashSet<VerificationMessage> hostingIssues;
+
+    public RequiredFilesVerifier(HashSet<VerificationMessage> hostingIssues) {
+        this.hostingIssues = hostingIssues;
+    }
+
     @Override
-    public void verify(HostingRequest request, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    public void verify(HostingRequest request) throws IOException {
 
         GitHub github = GitHub.connect();
         String forkFrom = request.getRepositoryUrl();
@@ -58,20 +65,19 @@ public class RequiredFilesVerifier implements Verifier {
                 String repoName = m.group(2);
 
                 GHRepository repo = github.getRepository(owner + "/" + repoName);
-                checkJenkinsfile(repo, hostingIssues);
-                checkSecurityScan(repo, hostingIssues);
-                checkCodeOwners(repo, hostingIssues, forkTo);
-                checkGitignore(repo, hostingIssues);
-                checkDependencyBot(repo, hostingIssues);
+                checkJenkinsfile(repo);
+                checkSecurityScan(repo);
+                checkCodeOwners(repo, forkTo);
+                checkGitignore(repo);
+                checkDependencyBot(repo);
                 if (request.isEnableCD()) {
-                    checkFilesForCD(repo, hostingIssues);
+                    checkFilesForCD(repo);
                 }
             }
         }
     }
 
-    private void checkCodeOwners(GHRepository repo, HashSet<VerificationMessage> hostingIssues, String forkTo)
-            throws IOException {
+    private void checkCodeOwners(GHRepository repo, String forkTo) throws IOException {
         String expected = "* @jenkinsci/" + forkTo + "-developers";
         GHContent file = null;
         try {
@@ -92,7 +98,7 @@ public class RequiredFilesVerifier implements Verifier {
         }
     }
 
-    private void checkJenkinsfile(GHRepository repo, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    private void checkJenkinsfile(GHRepository repo) throws IOException {
         GHContent file = null;
         try {
             file = repo.getFileContent("Jenkinsfile");
@@ -103,10 +109,10 @@ public class RequiredFilesVerifier implements Verifier {
                             "Missing file `Jenkinsfile`. Please add a Jenkinsfile to your repo so it can be built on ci.jenkins.io. A suitable version can be downloaded [here](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile)"));
             return;
         }
-        validateJenkinsFile(file, hostingIssues);
+        validateJenkinsFile(file);
     }
 
-    private void checkGitignore(GHRepository repo, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    private void checkGitignore(GHRepository repo) throws IOException {
         GHContent file = null;
         try {
             file = repo.getFileContent(".gitignore");
@@ -137,7 +143,7 @@ public class RequiredFilesVerifier implements Verifier {
         }
     }
 
-    private void checkSecurityScan(GHRepository repo, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    private void checkSecurityScan(GHRepository repo) throws IOException {
         if (fileNotExistsInRepo(repo, ".github/workflows/jenkins-security-scan.yml")
                 && fileNotExistsInRepo(repo, ".github/workflows/jenkins-security-scan.yaml")) {
             hostingIssues.add(
@@ -148,7 +154,7 @@ public class RequiredFilesVerifier implements Verifier {
         }
     }
 
-    private void checkDependencyBot(GHRepository repo, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    private void checkDependencyBot(GHRepository repo) throws IOException {
         if (fileNotExistsInRepo(repo, ".github/dependabot.yml")
                 && fileNotExistsInRepo(repo, ".github/dependabot.yaml")
                 && fileNotExistsInRepo(repo, "renovate.json")
@@ -164,7 +170,7 @@ public class RequiredFilesVerifier implements Verifier {
         }
     }
 
-    private void checkFilesForCD(GHRepository repo, HashSet<VerificationMessage> hostingIssues) throws IOException {
+    private void checkFilesForCD(GHRepository repo) throws IOException {
 
         if (fileNotExistsInRepo(repo, ".mvn/extensions.xml")) {
             hostingIssues.add(
@@ -217,7 +223,7 @@ public class RequiredFilesVerifier implements Verifier {
     }
 
     @SuppressWarnings("unchecked")
-    public static void validateJenkinsFile(GHContent file, HashSet<VerificationMessage> hostingIssues) {
+    public void validateJenkinsFile(GHContent file) {
         try {
             GroovyClassLoader loader = new GroovyClassLoader();
             CompilerConfiguration config = new CompilerConfiguration();
@@ -371,7 +377,7 @@ public class RequiredFilesVerifier implements Verifier {
                 }
             }
 
-        } catch (IOException e) {
+        } catch (IOException | GroovyRuntimeException e) {
             hostingIssues.add(
                     new VerificationMessage(VerificationMessage.Severity.REQUIRED, "Could not parse Jenkinsfile."));
         }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Verifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/Verifier.java
@@ -1,8 +1,7 @@
 package io.jenkins.infra.repository_permissions_updater.hosting;
 
 import java.io.IOException;
-import java.util.HashSet;
 
 public interface Verifier {
-    void verify(HostingRequest request, HashSet<VerificationMessage> hostingIssues) throws IOException;
+    void verify(HostingRequest request) throws IOException;
 }


### PR DESCRIPTION
- add a check for banObsoleteDependencyOverrides.skip property
- refactor verify method to not require the hosting issues. Instead pass them to the class constructor. That avoids that we need to pass the hosting issues to all the inner methods
- Catch malformed Jenkinsfile and report it
- Check version for `${revision}${changelist}`
- Hint to releasing best practices
