### PR TITLE
Remove CloudBees as security contact for plugins CloudBees is not supporting

### DIFF
--- a/permissions/plugin-async-http-client.yml
+++ b/permissions/plugin-async-http-client.yml
@@ -11,6 +11,3 @@ developers:
   - "egutierrez"
   - "fcojfernandez"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-azure-publishersettings-credentials.yml
+++ b/permissions/plugin-azure-publishersettings-credentials.yml
@@ -8,7 +8,3 @@ paths:
 developers:
   - "batmat"
   - "markwm"
-  - "@cloudbees-developers"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-azure-publishersettings-credentials.yml
+++ b/permissions/plugin-azure-publishersettings-credentials.yml
@@ -8,3 +8,4 @@ paths:
 developers:
   - "batmat"
   - "markwm"
+  - "@cloudbees-developers"

--- a/permissions/plugin-bootstrap.yml
+++ b/permissions/plugin-bootstrap.yml
@@ -10,6 +10,3 @@ developers:
   - "egutierrez"
   - "fcojfernandez"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-bootstrap4-api.yml
+++ b/permissions/plugin-bootstrap4-api.yml
@@ -7,6 +7,3 @@ paths:
   - "io/jenkins/plugins/bootstrap4-api"
 developers:
   - "drulli"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-build-timeout.yml
+++ b/permissions/plugin-build-timeout.yml
@@ -9,6 +9,3 @@ paths:
 developers:
   - "oleg_nenashev"
   - "krisstern"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-conditional-buildstep.yml
+++ b/permissions/plugin-conditional-buildstep.yml
@@ -13,6 +13,3 @@ developers:
   - "teilo"
   - "rarabaolaza"
   - "markewaite"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-deployed-on-column.yml
+++ b/permissions/plugin-deployed-on-column.yml
@@ -8,6 +8,3 @@ paths:
 developers:
   - "batmat"
   - "recena"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-deployer-framework.yml
+++ b/permissions/plugin-deployer-framework.yml
@@ -16,8 +16,5 @@ developers:
   - "teilo"
   - "rarabaolaza"
   - "jm_meessen"
-security:
-  contacts:
-    jira: "cloudbees_security_members"
 cd:
   enabled: true

--- a/permissions/plugin-docker-build-publish.yml
+++ b/permissions/plugin-docker-build-publish.yml
@@ -10,6 +10,3 @@ developers:
   - "michaelneale"
   - "oleg_nenashev"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-external-monitor-job.yml
+++ b/permissions/plugin-external-monitor-job.yml
@@ -14,6 +14,3 @@ developers:
   - "egutierrez"
   - "fcojfernandez"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-form-element-path.yml
+++ b/permissions/plugin-form-element-path.yml
@@ -7,6 +7,3 @@ paths:
   - "org/jenkins-ci/plugins/form-element-path"
 developers:
   - "vlatombe"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-handlebars.yml
+++ b/permissions/plugin-handlebars.yml
@@ -10,6 +10,3 @@ developers:
   - "egutierrez"
   - "fcojfernandez"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-jira.yml
+++ b/permissions/plugin-jira.yml
@@ -9,6 +9,3 @@ paths:
 developers:
   - "warden"
   - "olamy"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-jquery-detached.yml
+++ b/permissions/plugin-jquery-detached.yml
@@ -10,6 +10,3 @@ developers:
   - "egutierrez"
   - "fcojfernandez"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-jquery.yml
+++ b/permissions/plugin-jquery.yml
@@ -9,6 +9,3 @@ developers:
   - "basil"
   - "kohsuke"
   - "markewaite"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-maven-plugin.yml
+++ b/permissions/plugin-maven-plugin.yml
@@ -13,6 +13,3 @@ developers:
   - "olamy"
   - "aheritier"
   - "jtaboada"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-mercurial.yml
+++ b/permissions/plugin-mercurial.yml
@@ -16,6 +16,3 @@ developers:
   - "dnusbaum"
   - "markewaite"
   - "poddingue"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-momentjs.yml
+++ b/permissions/plugin-momentjs.yml
@@ -10,6 +10,3 @@ developers:
   - "egutierrez"
   - "fcojfernandez"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-mstestrunner.yml
+++ b/permissions/plugin-mstestrunner.yml
@@ -9,6 +9,3 @@ developers:
   - "armfergom"
   - "batmat"
   - "ido_ran"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-numeraljs.yml
+++ b/permissions/plugin-numeraljs.yml
@@ -10,6 +10,3 @@ developers:
   - "egutierrez"
   - "fcojfernandez"
   - "rsandell"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-one-shot-executor.yml
+++ b/permissions/plugin-one-shot-executor.yml
@@ -6,6 +6,3 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/one-shot-executor"
 developers: []
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-opentelemetry.yml
+++ b/permissions/plugin-opentelemetry.yml
@@ -11,6 +11,3 @@ issues:
   - github: *GH
 cd:
   enabled: true
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-parameterized-trigger.yml
+++ b/permissions/plugin-parameterized-trigger.yml
@@ -15,6 +15,3 @@ developers:
   - "jondaley"
 cd:
   enabled: true
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-pipeline-model-declarative-agent.yml
+++ b/permissions/plugin-pipeline-model-declarative-agent.yml
@@ -12,6 +12,3 @@ developers:
   - "bitwiseman"
   - "dnusbaum"
   - "carroll"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-popper-api.yml
+++ b/permissions/plugin-popper-api.yml
@@ -7,6 +7,3 @@ paths:
   - "io/jenkins/plugins/popper-api"
 developers:
   - "drulli"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-promoted-builds.yml
+++ b/permissions/plugin-promoted-builds.yml
@@ -16,8 +16,5 @@ developers:
   - "teilo"
   - "markewaite"
   - "poddingue"
-security:
-  contacts:
-    jira: "cloudbees_security_members"
 cd:
   enabled: true

--- a/permissions/plugin-run-condition.yml
+++ b/permissions/plugin-run-condition.yml
@@ -11,8 +11,5 @@ developers:
   - "markewaite"
   - "poddingue"
   - "zack_aayush"
-security:
-  contacts:
-    jira: "cloudbees_security_members"
 cd:
   enabled: true

--- a/permissions/plugin-view-job-filters.yml
+++ b/permissions/plugin-view-job-filters.yml
@@ -11,6 +11,3 @@ cd:
 developers:
   - "svenschoenung"
   - "@cloudbees-developers"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-windows-slaves.yml
+++ b/permissions/plugin-windows-slaves.yml
@@ -14,6 +14,3 @@ developers:
   - "bitwiseman"
   - "olamy"
   - "poddingue"
-security:
-  contacts:
-    jira: "cloudbees_security_members"

--- a/permissions/plugin-workflow-cps-global-lib.yml
+++ b/permissions/plugin-workflow-cps-global-lib.yml
@@ -15,8 +15,5 @@ developers:
   - "bitwiseman"
   - "kshultz"
   - "jtaboada"
-security:
-  contacts:
-    jira: "cloudbees_security_members"
 cd:
   enabled: true


### PR DESCRIPTION
CloudBees is not supporting the following plugins, hence removing it from the contact list for security.