### PR TITLE
Add a hosting security scan action as replacement for the bot

### DIFF
--- a/.github/security-scan-intro.md
+++ b/.github/security-scan-intro.md
@@ -1,0 +1,28 @@
+### Security audit, information and commands
+
+The security team is auditing all the hosting requests, to ensure a better security by default.
+
+This message informs you that a [Jenkins Security Scan](https://www.jenkins.io/redirect/jenkins-security-scan/) was triggered on your repository.
+It takes ~10 minutes to complete.
+
+<details><summary>Commands</summary>
+
+The bot will parse all comments, and it will check if any line start with a command.
+
+Security team only:
+<ul>
+    <li><code>/audit-ok</code> => the audit is complete, the hosting can continue :tada:.</li>
+    <li><code>/audit-skip</code> => the audit is not necessary, the hosting can continue :tada:.</li>
+    <li><code>/audit-findings</code> => the audit reveals some issues that require corrections :pencil2:.</li>
+</ul>
+
+Anyone:
+<ul>
+    <li><code>/request-security-scan</code> => the findings from the <a href="https://www.jenkins.io/redirect/jenkins-security-scan/" rel="nofollow">Jenkins Security Scan</a> were corrected, this command will re-scan your repository :mag:.</li>
+    <li><code>/audit-review</code> => the findings from the audit were corrected, this command will ping the security team to review the findings :eyes:.
+    It's only applicable when the previous audit required changes.</li>
+</ul>
+
+<i>Only one command can be requested per comment.</i>
+
+</details>

--- a/.github/workflows/hosting-security-scan.yaml
+++ b/.github/workflows/hosting-security-scan.yaml
@@ -62,6 +62,10 @@ jobs:
         with:
           repository: ${{ steps.extract-repo.outputs.repo }}
 
+      - name: Capture plugin repository commit SHA
+        id: plugin-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Java
         uses: actions/setup-java@v5.6.0
         with:
@@ -125,7 +129,7 @@ jobs:
             const DOC_BASE = 'https://github.com/jenkins-infra/jenkins-codeql/blob/main/src/';
 
             const sarif = JSON.parse(fs.readFileSync('jenkins-security-scan.sarif', 'utf8'));
-            const repoRef = sarif.runs?.[0]?.versionControlProvenance?.[0]?.revisionId || 'HEAD';
+            const repoRef = sarif.runs?.[0]?.versionControlProvenance?.[0]?.revisionId || '${{ steps.plugin-sha.outputs.sha }}';
 
             // Group results by ruleId
             const byRule = new Map();
@@ -161,13 +165,13 @@ jobs:
                   : '';
                 const findingItems = findings.map(f => {
                   const summary = f.githubLink ? `<a href="${f.githubLink}">${f.linkLabel}</a>` : f.linkLabel;
-                  return `<details><summary>${summary}</summary>\n\n\`\`\`\n${f.message}\n\`\`\`\n\n</details>`;
+                  return `<details><summary>${summary}</summary>\n\n\`${f.message}\`\n\n</details>`;
                 });
                 sections.push(`## ${title}\n\n${docLine}\n\n${findingItems.join('\n')}`);
               }
               body = `### Jenkins Security Scan\n\nThe Jenkins Security Scan discovered ${totalCount} finding(s) 🔍.\n\nFor every identified issue, please do one of the following:\n\n- Implement the recommended fix to address the issue.\n- If you think it's a false positive, suppress the warning directly within the code.\n- Alternative, you write an explanation here about why you think it's irrelevant. That will require a manual review, leading to a slower process.\n\nAfter addressing the findings through one of the above methods:\n\n- If all modifications have been made to the code, please initiate a new security scan by triggering the \`/request-security-scan\` command.\n- If there are any unresolved findings (those not corrected or suppressed), request a review from the Jenkins security team by using the \`/audit-review\` command.\n\n---\n\n${sections.join('\n\n')}`;
             } else {
-              body = `### Jenkins Security Scan\n\nThe security scan of [${repoUrl}](${repoUrl}) found no issues.`;
+              body = `### Jenkins Security Scan\n\nThe security scan of [${repoUrl}](${repoUrl}) did not find anything dangerous with your plugin, congratulations! 🎉`;
             }
 
             await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });

--- a/.github/workflows/hosting-security-scan.yaml
+++ b/.github/workflows/hosting-security-scan.yaml
@@ -1,0 +1,197 @@
+name: Hosting Security Scan
+
+on:
+  issues:
+    types:
+      - opened
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.issue.labels.*.name, 'hosting-request') &&
+      (github.event_name == 'issues' ||
+       (github.event_name == 'issue_comment' && github.event.comment.body == '/request-security-scan'))
+    steps:
+      - name: Post security audit introduction
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const response = await fetch(
+              'https://raw.githubusercontent.com/jenkins-infra/repository-permissions-updater/master/.github/security-scan-intro.md'
+            );
+            const body = await response.text();
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });
+
+      - name: Extract repository URL from issue
+        id: extract-repo
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const match = body.match(/### Repository URL\s+(\S+)/);
+            if (!match) {
+              core.setFailed('Could not find Repository URL in issue body');
+              return;
+            }
+            const url = match[1];
+            const repoMatch = url.match(/https:\/\/github\.com\/([^\/]+)\/([^\/]+)/);
+            if (!repoMatch) {
+              core.setFailed(`Repository URL '${url}' is not a valid GitHub repository URL`);
+              return;
+            }
+            core.setOutput('repo-url', url);
+            core.setOutput('repo', `${repoMatch[1]}/${repoMatch[2]}`);
+
+      - name: Check out plugin repository
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ steps.extract-repo.outputs.repo }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v5.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: maven
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.37.3
+        with:
+          languages: java
+          config: |
+            disable-default-queries: true
+            packs:
+            - jenkins-infra/jenkins-codeql@0.0.3
+            - codeql/java-queries:AlertSuppression.ql
+            - codeql/java-queries:AlertSuppressionAnnotations.ql
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4.37.3
+
+      - name: Run CodeQL
+        id: generate-sarif
+        uses: github/codeql-action/analyze@v4.37.3
+        with:
+          category: Jenkins Security Scan
+          upload: never
+
+      - name: Process SARIF
+        run: |
+          jq 'setpath(path(.runs[].tool.driver.name); "Jenkins Security Scan") | setpath(path(.runs[].tool.driver.organization); "Jenkins Project") | del(.runs[].results[] | select( .suppressions | length != 0 ))' ../results/java.sarif > jenkins-security-scan.sarif
+          mv -v ../results/java.sarif .
+
+      - name: Archive SARIF
+        uses: actions/upload-artifact@v7
+        with:
+          path: '*.sarif'
+          name: Jenkins Security Scan SARIF
+
+      - name: Post results to issue
+        if: steps.generate-sarif.outcome == 'success'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const repoUrl = '${{ steps.extract-repo.outputs.repo-url }}';
+            const issueNumber = context.issue.number;
+            const { owner, repo } = context.repo;
+
+            const CHECKS = {
+              'jenkins/callable-without-role-check':          { title: 'Remoting: Unsafe Callable',                                                       doc: 'BadRoleCheck.md' },
+              'jenkins/credentials-fill-without-permission-check': { title: 'Jenkins: Missing permission check on a form fill web method with credentials lookup', doc: 'CredentialsEnumeration.md' },
+              'jenkins/file-from-rest-of-path':               { title: 'Use of StaplerRequest#getRestOfPath to construct a file path',                    doc: 'FileFromRestOfPath.md' },
+              'jenkins/has-permission-return-value-ignored':  { title: 'Result of hasPermission call is ignored',                                          doc: 'HasPermissionReturnIgnored.md' },
+              'jenkins/plaintext-storage':                    { title: 'Jenkins: Plaintext password storage',                                              doc: 'PlaintextPasswordStorage.md' },
+              'jenkins/unsafe-calls':                         { title: 'Jenkins: Generally unsafe method calls',                                           doc: 'UnsafeCalls.md' },
+              'jenkins/unsafe-classes':                       { title: 'Jenkins: Potentially unsafe classes',                                              doc: 'UnsafeClassUses.md' },
+              'jenkins/no-permission-check':                  { title: 'Stapler: Missing permission check',                                                doc: 'WebMethodMissingPermissionCheck.md' },
+              'jenkins/csrf':                                 { title: 'Stapler: Missing POST/RequirePOST annotation',                                     doc: 'WebMethodMissingPostAnnotation.md' },
+            };
+            const DOC_BASE = 'https://github.com/jenkins-infra/jenkins-codeql/blob/main/src/';
+
+            const sarif = JSON.parse(fs.readFileSync('jenkins-security-scan.sarif', 'utf8'));
+            const repoRef = sarif.runs?.[0]?.versionControlProvenance?.[0]?.revisionId || 'HEAD';
+
+            // Group results by ruleId
+            const byRule = new Map();
+            for (const run of (sarif.runs || [])) {
+              for (const result of (run.results || [])) {
+                const ruleId = result.ruleId || 'unknown';
+                if (!byRule.has(ruleId)) byRule.set(ruleId, []);
+                const location = result.locations?.[0]?.physicalLocation;
+                const filePath = location?.artifactLocation?.uri?.replace(/^src:\/\//, '') || '';
+                const line = location?.region?.startLine;
+                const githubLink = filePath
+                  ? `${repoUrl}/blob/${repoRef}/${filePath}` + (line ? `#L${line}` : '')
+                  : null;
+                const fileName = filePath.split('/').pop() || filePath;
+                const linkLabel = fileName + (line ? `#${line}` : '');
+                const message = result.message?.text || '';
+                byRule.get(ruleId).push({ linkLabel, githubLink, message });
+              }
+            }
+
+            const hasFindings = byRule.size > 0;
+
+            let body;
+            if (hasFindings) {
+              const totalCount = [...byRule.values()].reduce((sum, arr) => sum + arr.length, 0);
+              const sections = [];
+              for (const [ruleId, findings] of byRule) {
+                const check = CHECKS[ruleId];
+                const title = check?.title || ruleId;
+                const docUrl = check ? DOC_BASE + check.doc : null;
+                const docLine = docUrl
+                  ? `You can find detailed information about this finding [here](${docUrl}).`
+                  : '';
+                const findingItems = findings.map(f => {
+                  const summary = f.githubLink ? `<a href="${f.githubLink}">${f.linkLabel}</a>` : f.linkLabel;
+                  return `<details><summary>${summary}</summary>\n\n\`\`\`\n${f.message}\n\`\`\`\n\n</details>`;
+                });
+                sections.push(`## ${title}\n\n${docLine}\n\n${findingItems.join('\n')}`);
+              }
+              body = `### Jenkins Security Scan\n\nThe Jenkins Security Scan discovered ${totalCount} finding(s) 🔍.\n\nFor every identified issue, please do one of the following:\n\n- Implement the recommended fix to address the issue.\n- If you think it's a false positive, suppress the warning directly within the code.\n- Alternative, you write an explanation here about why you think it's irrelevant. That will require a manual review, leading to a slower process.\n\nAfter addressing the findings through one of the above methods:\n\n- If all modifications have been made to the code, please initiate a new security scan by triggering the \`/request-security-scan\` command.\n- If there are any unresolved findings (those not corrected or suppressed), request a review from the Jenkins security team by using the \`/audit-review\` command.\n\n---\n\n${sections.join('\n\n')}`;
+            } else {
+              body = `### Jenkins Security Scan\n\nThe security scan of [${repoUrl}](${repoUrl}) found no issues.`;
+            }
+
+            await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+
+            const addLabel = hasFindings ? 'security-audit-needs-correction' : 'security-audit-done';
+            const removeLabel = hasFindings ? 'security-audit-done' : 'security-audit-needs-correction';
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: [addLabel] });
+
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: removeLabel });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+      - name: Post scan failure to issue
+        if: steps.generate-sarif.outcome != 'success'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const repoUrl = '${{ steps.extract-repo.outputs.repo-url }}';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### Jenkins Security Scan\n\nThe security scan of [${repoUrl}](${repoUrl}) encountered an error. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`,
+            });


### PR DESCRIPTION
Mostly done by claude

fixes #5189

Runs on hosting issue creation and on the usual comment.

Currently the mapping from ruleId to the docs and the title is hard coded in the script. Probably would be better to have that mapping in the jenkins codeql repo and fetch that

The initial message is fetched from the repo (github didn't like it to be inline)

When merging the existing trigger would need to be disabled.

On my tests what was annoying is that it prints many warnings of the form:
```
This run of the CodeQL Action does not have permission to access the CodeQL Action API endpoints. This could be because the Action is running on a pull request from a fork. If not, please ensure the workflow has at least the 'security-events: read' permission. Details: Resource not accessible by integration - https://docs.github.com/rest
```
And also an error
```
Maximum retry attempts exhausted (4), aborting database upload
```
though the error doesn't stop the action from running fine.


Sample: https://github.com/mawinter69/rpu2/issues/12