### PR TITLE
Update integrity plugin maintainers

### DIFF
--- a/permissions/plugin-integrity-plugin.yml
+++ b/permissions/plugin-integrity-plugin.yml
@@ -6,5 +6,5 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/integrity-plugin"
 developers:
-  - "cdsouza"
-  - "integrity_jenkins_plugin"
+  - "ppeddamure"
+  - "agaurkhede"

--- a/permissions/plugin-integrity-plugin.yml
+++ b/permissions/plugin-integrity-plugin.yml
@@ -7,4 +7,3 @@ paths:
   - "org/jenkins-ci/plugins/integrity-plugin"
 developers:
   - "ppeddamure"
-  - "agaurkhede"

--- a/permissions/plugin-integrity-plugin.yml
+++ b/permissions/plugin-integrity-plugin.yml
@@ -7,3 +7,4 @@ paths:
   - "org/jenkins-ci/plugins/integrity-plugin"
 developers:
   - "ppeddamure"
+  - "agaurkhede"


### PR DESCRIPTION
This PR updates the maintainers for the Integrity Plugin.

Changes:
- Remove existing maintainers:
  - cdsouza
  - integrity_jenkins_plugin
- Add new maintainer:
  - ppeddamure

The new maintainers will be responsible for future plugin maintenance and releases.

Repository:
https://github.com/jenkinsci/integrity-plugin