### PR TITLE
Enable CD for agent-server-parameter plugin

### DIFF
--- a/permissions/plugin-agent-server-parameter.yml
+++ b/permissions/plugin-agent-server-parameter.yml
@@ -5,5 +5,7 @@ issues:
   - jira: '27422'  # agent-server-parameter-plugin
 paths:
   - "io/jenkins/plugins/agent-server-parameter"
+cd:
+  enabled: true
 developers:
   - "bluersw"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/agent-server-parameter-plugin

# When modifying release permission

No manual release permissions are changed. The existing developers list remains unchanged.

### Release permission checklist (for submitters)

- [ ] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [ ] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Enable JEP-229 continuous delivery for agent-server-parameter. The plugin pull request adds the official CD workflow and required incrementals versioning configuration. It will remain open until this request is reviewed.

### Link to the PR enabling CD in your plugin

https://github.com/jenkinsci/agent-server-parameter-plugin/pull/8

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the $pluginId Developers team has Admin permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently @Wadeck) in this pull request. If an email contact is changed, wait for approval from the security officer.
