### PR TITLE
Leaving `ssh-agent` maintainer list

### DIFF
--- a/permissions/plugin-ssh-agent.yml
+++ b/permissions/plugin-ssh-agent.yml
@@ -8,7 +8,6 @@ paths:
 cd:
   enabled: true
 developers:
-  - "jglick"
   - "kohsuke"
   - "recena"
   - "batmat"


### PR DESCRIPTION
Removed 'jglick' from the list of developers. Already left https://github.com/orgs/jenkinsci/teams/ssh-agent-plugin-developers. I do not need to be asked for review on random stuff like https://github.com/jenkinsci/ssh-agent-plugin/pull/292. @ogulcanaydogan is sole maintainer AFAIK.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
