### PR TITLE
Update developers list in plugin permissions file

### DIFF
--- a/permissions/plugin-fortify-on-demand-uploader.yml
+++ b/permissions/plugin-fortify-on-demand-uploader.yml
@@ -7,9 +7,6 @@ issues:
 paths:
   - "org/jenkins-ci/plugins/fortify-on-demand-uploader"
 developers:
-  - "makropod"
   - "c0d3m0nky"
-  - "aishkotni"
-  - "ciuppinho"
   - "vpasupathi"
-  - "ankit2995"
+  - "amoghng7"


### PR DESCRIPTION
Adding Amogh to developers list.

# Link to GitHub repository

https://github.com/jenkinsci/fortify-on-demand-uploader-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

- amoghng7

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to accounts.jenkins.io.
- [x] All users added have logged in to Artifactory and Jira once.
- [x] I have mentioned an existing team member of the plugin or component team to approve this request.

## Additional Information

I am a maintainer of the Fortify on Demand Uploader plugin and am requesting
release permissions for `amoghng7`.

The user has:
- Commit access to the plugin repository.
- A Jenkins community account.
- Logged into Jenkins Jira and Artifactory.

Plugin repository:
https://github.com/jenkinsci/fortify-on-demand-uploader-plugin

### Reviewer
@c0d3m0nky
