### PR TITLE
Add mykola_shestopal as maintainer of deploy-dashboard-plugin

### DIFF
--- a/permissions/plugin-deploy-dashboard.yml
+++ b/permissions/plugin-deploy-dashboard.yml
@@ -8,6 +8,4 @@ paths:
 developers:
   - "vetal2409"
   - "namecheap_jenkins"
-  - "StyleT"
-  - "yuriypuchkov"
   - "mykola_shestopal"

--- a/permissions/plugin-deploy-dashboard.yml
+++ b/permissions/plugin-deploy-dashboard.yml
@@ -10,3 +10,4 @@ developers:
   - "namecheap_jenkins"
   - "StyleT"
   - "yuriypuchkov"
+  - "mykola_shestopal"


### PR DESCRIPTION
Adding myself as a maintainer of deploy-dashboard-plugin (Namecheap-owned). I am taking over maintenance and need release permission for the upcoming 0.2.0 release (https://github.com/jenkinsci/deploy-dashboard-plugin/pull/11 — fixes broken deploy links on modern cores and the JENKINS-74429 CSP debt).

GitHub: @nick4eva
Jenkins account: mykola_shestopal

Approval from an existing maintainer will follow in the comments.