### PR TITLE
Enable CD for declarative-pipeline-migration-assistant

### DIFF
--- a/permissions/plugin-declarative-pipeline-migration-assistant-api.yml
+++ b/permissions/plugin-declarative-pipeline-migration-assistant-api.yml
@@ -16,3 +16,5 @@ developers:
 security:
   contacts:
     jira: "cloudbees_security_members"
+cd:
+  enabled: true

--- a/permissions/plugin-declarative-pipeline-migration-assistant.yml
+++ b/permissions/plugin-declarative-pipeline-migration-assistant.yml
@@ -17,3 +17,5 @@ developers:
 security:
   contacts:
     jira: "cloudbees_security_members"
+cd:
+  enabled: true

--- a/permissions/pom-declarative-pipeline-migration-assistant-parent.yml
+++ b/permissions/pom-declarative-pipeline-migration-assistant-parent.yml
@@ -14,3 +14,5 @@ developers:
 security:
   contacts:
     jira: "cloudbees_security_members"
+cd:
+  enabled: true


### PR DESCRIPTION
Enable the continuous delivery release process for the [declarative-pipeline-migration-assistant-plugin](https://github.com/jenkinsci/declarative-pipeline-migration-assistant-plugin).

Adds `cd: enabled: true` to the three artifacts published from that repository (plugin, api, and parent POM) so the `MAVEN_USERNAME` / `MAVEN_TOKEN` secrets get provisioned.

Companion to jenkinsci/declarative-pipeline-migration-assistant-plugin#365, which adds the `cd.yaml` workflow and switches the build to the CD versioning scheme.