### PR TITLE
Add kitos9112 as maintainer of kerberos-sso plugin

### DIFF
--- a/permissions/plugin-kerberos-sso.yml
+++ b/permissions/plugin-kerberos-sso.yml
@@ -10,3 +10,4 @@ cd:
 developers:
   - "rsandell"
   - "t_westling"
+  - "kitos9112"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/kerberos-sso-plugin

Adopting this plugin per the [adopt-a-plugin](https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/) process, abandoned-plugin path. No `adopt-this-plugin` label was set, but the plugin appears abandoned: the last release was 247.v5b_3c2105a_9e3 on 2024-12-19 with no commits since, and the registered developers' most recent commits to the repository are 2016-09-26 (rsandell) and 2015-03-23 (t_westling). All work since 2023 has come from non-registered contributors and Dependabot.

PR ready to deliver: https://github.com/jenkinsci/kerberos-sso-plugin/pull/87 — fixes [JENKINS-75881](https://issues.jenkins.io/browse/JENKINS-75881), where the plugin challenges `/login` with a 401 even though Jenkins core guarantees it is always readable, so inbound remoting agents cannot connect at all.

Contact attempt: pinged the registered developers on PR #87 on 2026-08-19. Happy to wait the customary two weeks, and equally happy to withdraw this if a current maintainer would rather keep it.

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@kitos9112`

This is needed in order to cut releases of the plugin or component.

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Not applicable — CD is already enabled for this plugin. `cd: enabled: true` has been present in `permissions/plugin-kerberos-sso.yml` since it was turned on in https://github.com/jenkinsci/kerberos-sso-plugin/pull/70 (December 2024), and `.github/workflows/cd.yaml` is in place. This PR only adds a developer; it makes no CD changes.

### Link to the PR enabling CD in your plugin

N/A — CD already enabled, see above.

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.

cc @rsandell @TWestling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
