### PR TITLE
Add user 'longhn0710' to Aqua security scanner permissions

### DIFF
--- a/permissions/plugin-aqua-security-scanner.yml
+++ b/permissions/plugin-aqua-security-scanner.yml
@@ -20,6 +20,7 @@ developers:
   - "kumar99"
   - "kedarnadhsharma"
   - "sairohith592"
+  - "longhn0710"
 security:
   contacts:
     jira: aqua_maintainers


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/aqua-security-scanner-plugin

I would like to help maintain the Aqua Security Scanner plugin and request commit/release permissions.

I currently have an open PR ready for review:

https://github.com/jenkinsci/aqua-security-scanner-plugin/pull/82

The PR was opened on 2026-06-18. I have tried to contact the existing maintainers/developers for review, including a follow-up about two weeks ago, but have not received a review yet.

The plugin appears to have limited maintainer activity, and I would like to help maintain it, address outstanding issues, review and merge appropriate contributions, and cut releases when needed.

Hi developers:

@oranmoshai @aqua_maintainers @ppandrangi @Ank13 @prakhar_jenkins @srinivas0731 @KoppulaRajender @rajinikanthj @devaquasec @nsreenivas0731 @udaykiran_aqua @kumar99 @Kedarnadhsharma @sairohith592

Could one of the existing plugin team members please review and approve this request? I am also happy to withdraw the request if an active maintainer would prefer to continue maintaining the plugin.

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:

* `@longhn0710`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

<!-- If you're enabling CD only, leave the following checklist blank! -->

### Release permission checklist (for submitters)

* [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [[accounts.jenkins.io](https://accounts.jenkins.io/)](https://accounts.jenkins.io/).
* [x] All users added have logged in to [[Artifactory](https://repo.jenkins-ci.org/)](https://repo.jenkins-ci.org/) and [[Jira](https://issues.jenkins.io/)](https://issues.jenkins.io/) once.
* [x] I have mentioned an [[existing team member](https://github.com/orgs/jenkinsci/teams)](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Not applicable — this pull request only adds `@longhn0710` to the plugin's developers list and does not enable or modify CD.

### Link to the PR enabling CD in your plugin

N/A — CD is not being enabled by this pull request.

### CD checklist (for submitters)

* [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

* [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
* [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
* [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.