### PR TITLE
feat: enable cd for plugin-mqtt-notification-plugin.yml

### DIFF
--- a/permissions/plugin-mqtt-notification-plugin.yml
+++ b/permissions/plugin-mqtt-notification-plugin.yml
@@ -7,3 +7,5 @@ paths:
   - "jenkins/plugins/mqtt-notification-plugin"
 developers:
   - "gareth_western"
+cd:
+  enabled: true


### PR DESCRIPTION
Enable automatic CD

# Link to GitHub repository

https://github.com/jenkinsci/mqtt-notification-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@gdubya`


### Link to the PR enabling CD in your plugin

Plugin repository has been prepared with CD workflows and POM changelist configuration:
https://github.com/jenkinsci/mqtt-notification-plugin/commit/e63ecb0

### CD checklist (for submitters)

- [x] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
