### PR TITLE
Add scm-trait-commit-skip-common component

### DIFF
--- a/permissions/component-scm-trait-commit-skip-common.yml
+++ b/permissions/component-scm-trait-commit-skip-common.yml
@@ -1,0 +1,7 @@
+---
+name: "scm-trait-commit-skip-common"
+github: "jenkinsci/scm-trait-commit-skip-plugin"
+paths:
+  - "org/jenkins-ci/plugins/scm-trait-commit-skip-common"
+developers:
+  - "askalski85"


### PR DESCRIPTION
The `scm-trait-commit-skip-plugin` reactor builds three artifacts that have RPU entries — `pom-scm-trait-commit-skip-parent.yml`, `plugin-bitbucket-scm-trait-commit-skip.yml`, `plugin-github-scm-trait-commit-skip.yml` — plus the shared `scm-trait-commit-skip-common` jar, which has none.

The common module sets `maven-deploy-plugin skip=true`, so releases never noticed. But the incrementals publisher uploads the whole archived local repository of a build, and the missing path entry makes every incrementals deployment of that repository fail: the plugin has never published an incrementals build (its incrementals directory is empty), even though PR builds are green — most recently jenkinsci/scm-trait-commit-skip-plugin#30, which consumers are waiting to pin.

The new entry mirrors `pom-scm-trait-commit-skip-parent.yml` (same github mapping, same developer list).