### PR TITLE
Add release permissions for github-pr-approval plugin

### DIFF
--- a/permissions/plugin-github-pr-approval.yml
+++ b/permissions/plugin-github-pr-approval.yml
@@ -1,0 +1,11 @@
+---
+name: "github-pr-approval"
+github: &gh "jenkinsci/github-pr-approval-plugin"
+issues:
+  - github: *gh
+paths:
+  - "io/jenkins/plugins/github-pr-approval"
+developers:
+  - "olamy"
+cd:
+  enabled: true


### PR DESCRIPTION
Adds release permissions (CD enabled) for the `io.jenkins.plugins:github-pr-approval` plugin.

Follows hosting request #5243.