### PR TITLE
[plugin-propelo-job-reporter] ADD: Harness maintainers for propelo-job-reporter plugin

### DIFF
--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -11,7 +11,6 @@ developers:
 - "ashish_harness"
 - "nishith_patel"
 - "harshit_trivedi01"
-- "risana_1200"
 issues:
   - jira: 29121
 cd:

--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -12,8 +12,8 @@ developers:
 - "nishith_patel"
 - "harshit_trivedi01"
 - "risana_1200"
-- "ayuahmantri"
 - "gaurav_baranwal"
+- "ayuahmantri"
 issues:
   - jira: 29121
 cd:

--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -13,6 +13,7 @@ developers:
 - "harshit_trivedi01"
 - "risana_1200"
 - "gaurav_baranwal"
+- "ayuahmantri"
 issues:
   - jira: 29121
 cd:

--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -12,7 +12,6 @@ developers:
 - "nishith_patel"
 - "harshit_trivedi01"
 - "risana_1200"
-- "ayushmantri"
 - "gaurav_baranwal"
 issues:
   - jira: 29121

--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -10,6 +10,10 @@ developers:
 - "sid_propelo"
 - "ashish_harness"
 - "nishith_patel"
+- "harshit_trivedi01"
+- "risana_1200"
+- "ayushmantri"
+- "gaurav_baranwal"
 issues:
   - jira: 29121
 cd:

--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -12,7 +12,6 @@ developers:
 - "nishith_patel"
 - "harshit_trivedi01"
 - "risana_1200"
-- "gaurav_baranwal"
 issues:
   - jira: 29121
 cd:

--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -12,8 +12,8 @@ developers:
 - "nishith_patel"
 - "harshit_trivedi01"
 - "risana_1200"
-- "gaurav_baranwal"
 - "ayuahmantri"
+- "gaurav_baranwal"
 issues:
   - jira: 29121
 cd:

--- a/permissions/plugin-propelo-job-reporter.yml
+++ b/permissions/plugin-propelo-job-reporter.yml
@@ -11,6 +11,8 @@ developers:
 - "ashish_harness"
 - "nishith_patel"
 - "harshit_trivedi01"
+- "risana_1200"
+- "gaurav_baranwal"
 issues:
   - jira: 29121
 cd:


### PR DESCRIPTION
The propelo-job-reporter plugin was originally maintained by Harness. The previous maintainer has left the company and is no longer available to approve a permission transfer.

We need to continue maintaining the plugin and would like to add new maintainers from our organization under the Jenkins plugin adoption process.

## New maintainers

| GitHub username | Jenkins infrastructure ID |
|---|---|
| harshit-trivedi01 | harshit_trivedi01 |
| risana-rasheed | risana_1200 |
| gauravbaranwal133 | gaurav_baranwal |
| ayushmantri | ayuahmantri |


## Link to GitHub repository

https://github.com/jenkinsci/propelo-job-reporter-plugin

## When modifying release permission

```[tasklist]
### Release permission checklist (for submitters)
- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.
```

```[tasklist]
### Reviewer checklist
- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
```

Previous maintainer has left Harness. Requesting adoption under the Jenkins Plugin Adoption Process.