### PR TITLE
Adopt groovy-postbuild plugin

### DIFF
--- a/permissions/plugin-groovy-postbuild.yml
+++ b/permissions/plugin-groovy-postbuild.yml
@@ -9,3 +9,4 @@ paths:
   - "org/jvnet/hudson/plugins/groovy-postbuild"
 developers:
   - "markewaite"
+  - "sekator778"


### PR DESCRIPTION
# Link to GitHub repository

https://github.com/jenkinsci/groovy-postbuild-plugin

This PR adds the Jenkins infrastructure account `sekator778` as a developer of the Groovy Postbuild plugin as part of the [plugin adoption process](https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/).

The plugin is marked `adopt-this-plugin` with @MarkEWaite as its only listed maintainer. First planned act: merge jenkinsci/groovy-postbuild-plugin#191 (badge-plugin 3.x compatibility — green CI, approved after a test install, requested by users since April), re-enable the tests that were disabled for that incompatibility, and release through the existing CD pipeline; then review #197 and triage the issues migrated from JENKINS.

Existing maintainer @MarkEWaite: please review and approve this adoption request.

# When modifying release permission

GitHub username requesting commit permissions:

- @Sekator778

Jenkins infrastructure account added to the YAML definition:

- `sekator778`

### Release permission checklist (for submitters)

- [x] The username added to the `developers` section is the username used to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] The added user has logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) at least once.
- [x] The existing plugin team member is mentioned above to approve this request.

Adoption request on the Jenkins Developers mailing list: link to follow in a comment once posted.
