### PR TITLE
Migrate allure-jenkins-plugin plugin issues to GitHub

### DIFF
--- a/permissions/plugin-allure-jenkins-plugin.yml
+++ b/permissions/plugin-allure-jenkins-plugin.yml
@@ -3,8 +3,6 @@ name: "allure-jenkins-plugin"
 github: &gh "jenkinsci/allure-plugin"
 issues:
   - github: *gh
-  - jira: '18926'  # allure-plugin
-    report: false
 paths:
   - "ru/yandex/qatools/allure/allure-jenkins-plugin"
   - "org/allurereport/jenkins/allure-jenkins-plugin"


### PR DESCRIPTION
Hi

Now that all the core components are migrated to GitHub from Jira, I'd like to start migrating plugins. 

Plugins being migrated:
- allure-jenkins-plugin

@baev for approval

Jira component number for the allure-plugin is 18926

Let me know if any objections or questions

<!--
Jira to GitHub mapping:
allure-plugin:allure-plugin
-->