### PR TITLE
Add leduchieu_101 as maintainer of discord-notifier-plugin

### DIFF
--- a/permissions/plugin-discord-notifier.yml
+++ b/permissions/plugin-discord-notifier.yml
@@ -7,5 +7,6 @@ paths:
   - "nz/co/jammehcow/discord-notifier"
 developers:
   - "markewaite"
+  - "leduchieu_101"
 cd:
   enabled: true


### PR DESCRIPTION
Hello @MarkEWaite,

I would like to join you as a maintainer of the discord-notifier plugin. You marked the plugin for adoption in #5058 to encourage others to help maintain it — I'd like to take you up on that offer.

I plan to:
- Triage the open issue backlog (23 open issues)
- Land https://github.com/jenkinsci/discord-notifier-plugin/pull/159 (PlasticSCM changeset IDs, fixes) after review
- Review the remaining open PRs (https://github.com/jenkinsci/discord-notifier-plugin/pull/158, https://github.com/jenkinsci/discord-notifier-plugin/pull/138)
- Replace the bundled unirest-java 3.14.5 dependency with the httpcomponents client and refresh the stale `<developers>` section in the POM
- Keep the `adopt-this-plugin` topic up, in line with your stated approach — happy to reconsider if you prefer otherwise

Mark, your approval on this PR would be much appreciated. I have also opened jenkinsci/discord-notifier-plugin#164 to ask directly.

# Link to GitHub repository

https://github.com/jenkinsci/discord-notifier-plugin

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `@h3nr1-d14z`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [x] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request. (CC @MarkEWaite)
