### PR TITLE
Add leduchieu_101 to http-request-plugin developers

### DIFF
--- a/permissions/plugin-http_request.yml
+++ b/permissions/plugin-http_request.yml
@@ -8,6 +8,7 @@ paths:
 developers:
   - "janario"
   - "markewaite"
+  - "leduchieu_101"
   - "oleg_nenashev"
   - "sandi2382"
   - "ralnoc"


### PR DESCRIPTION
Following the [Adopt-a-Plugin process](https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/), requesting write access to [http-request-plugin](https://github.com/jenkinsci/http-request-plugin) for @leduchieu_101 (GitHub: h3nr1-d14z).

Adoption request filed as jenkinsci/http-request-plugin#342, where I've pinged the current developers (@janario @markewaite @oleg-nenashev @sandi2382 @ralnoc) for feedback.

Context: I recently adopted discord-notifier-plugin via the same process (RPU #5271, @markewaite's approval) and have since shipped a bug-fix release and opened a dependency-modernization PR there. http-request has 30k+ installations and no active day-to-day maintainer — its recent history is almost entirely dependabot bumps. Relevant experience: my discord-notifier PR #165 is a unirest-java → Apache HttpComponents migration, which is this plugin's core territory.

— h3nr1-d14z
