### PR TITLE
Skip artifactory check for plugins using CD

### DIFF
--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JenkinsProjectUserVerifier.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/hosting/JenkinsProjectUserVerifier.java
@@ -27,7 +27,7 @@ public class JenkinsProjectUserVerifier implements Verifier {
                     .filter(user -> !KnownUsers.existsInJira(user))
                     .collect(Collectors.joining(", "));
 
-            if (StringUtils.isNotBlank(missingInArtifactory)) {
+            if (!request.isEnableCD() && StringUtils.isNotBlank(missingInArtifactory)) {
                 hostingIssues.add(new VerificationMessage(
                         VerificationMessage.Severity.REQUIRED,
                         "The following usernames in 'Jenkins project users to have release permission' need to log into [Artifactory](https://repo.jenkins-ci.org/): %s (reports are re-synced hourly, wait to re-check for a bit after logging in)",


### PR DESCRIPTION
With CD enabled there is no need to use Artifactory so we can skip this check
