### PR TITLE
fix typo in hiddenlayer plugin developer list

### DIFF
--- a/permissions/plugin-hiddenlayer-model-scanner.yml
+++ b/permissions/plugin-hiddenlayer-model-scanner.yml
@@ -8,6 +8,6 @@ cd:
 developers:
 - "blucas_hl"
 - "travis_hiddenlayer"
-- "adrummond_hl"
+- "adrummond-hl"
 issues:
   - github: *GH


### PR DESCRIPTION
Fix typo in the developer's list for hiddenlayer plugin. Previous PR adding typoed username was done by this same user: https://github.com/jenkins-infra/repository-permissions-updater/pull/4280. Other developers in the list are no longer with the company and not available to approve.

# Link to GitHub repository

[[HiddenLayer Jenkins Model Scanner Plugin](https://github.com/jenkinsci/hiddenlayer-model-scanner-plugin)](https://github.com/jenkinsci/hiddenlayer-model-scanner-plugin)

# When modifying release permission

List the GitHub usernames of the users who should have commit permissions below:
- `adrummond-hl`

This is needed in order to cut releases of the plugin or component.

If you are modifying the release permission of your plugin or component, fill out the following checklist:

### Release permission checklist (for submitters)

- [X] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [X] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

Follow the [documentation](https://www.jenkins.io/doc/developer/publishing/releasing-cd/) to ensure, your pull request is set up properly. Don't merge it yet.
In case of changes requested by the hosting team, an open PR facilitates future reviews, without derailing work across multiple PRs.

### Link to the PR enabling CD in your plugin

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
