### PR TITLE
Enable CD for openstack-cloud-parent

### DIFF
--- a/permissions/pom-openstack-cloud-parent.yml
+++ b/permissions/pom-openstack-cloud-parent.yml
@@ -1,5 +1,8 @@
 ---
 name: "openstack-cloud-parent"
+github: "jenkinsci/openstack-cloud-plugin"
+cd:
+  enabled: true
 paths:
   - "org/jenkins-ci/plugins/openstack-cloud-parent"
 developers:


### PR DESCRIPTION
## Summary
- Enable JEP-229 CD for `org.jenkins-ci.plugins:openstack-cloud-parent` so plugin CD can deploy the aggregator POM.
- The existing `pom-openstack-cloud-parent.yml` only granted named developers the parent path. Exclusive CD tokens from `plugin-openstack-cloud.yml` can upload `org/jenkins-ci/plugins/openstack-cloud` but not `org/jenkins-ci/plugins/openstack-cloud-parent`, which causes `403` on `mvn deploy` of the parent POM.

The plugin repo is renaming the aggregator from `org.jenkins-ci.plugins.openstack-cloud:parent` to `org.jenkins-ci.plugins:openstack-cloud-parent` so the GAV matches this path and RPU `name` filter (`openstack-cloud-*`).