### PR TITLE
Add developer entry for chaos-butler plugin

### DIFF
--- a/permissions/plugin-chaos-butler.yml
+++ b/permissions/plugin-chaos-butler.yml
@@ -5,4 +5,5 @@ issues:
   - jira: '21730'  # chaos-butler-plugin
 paths:
   - "org/jenkins-ci/plugins/chaos-butler"
-developers: []
+developers:
+  - "ayyYoSam"


### PR DESCRIPTION
## Link to GitHub repository

https://github.com/jenkinsci/chaos-butler-plugin

# When modifying release permission

- @ayyYoSam

## Release permission checklist (for submitters)

- [x] The usernames of the users added to the "developers" section in the .yml file are the same the users use to log in to [accounts.jenkins.io](https://accounts.jenkins.io/).
- [x] All users added have logged in to [Artifactory](https://repo.jenkins-ci.org/) and [Jira](https://issues.jenkins.io/) once.
- [ ] I have mentioned an [existing team member](https://github.com/orgs/jenkinsci/teams) of the plugin or component team to approve this request.

## When enabling automated releases (cd: true)

### Link to the PR enabling CD in your plugin

Not applicable. This PR only requests developer/release permissions for plugin adoption.

### CD checklist (for submitters)

- [ ] I have provided a link to the pull request in my plugin, which enables CD according to the documentation.

### Reviewer checklist

- [ ] Check that the `$pluginId Developers` team has `Admin` permissions while granting the access.
- [ ] In the case of plugin adoption, ensure that the Jenkins Jira default assignee is either removed or changed to the new maintainer.
- [ ] If security contacts are changed (this includes add/remove), ping the security officer (currently `@Wadeck`) in this pull request. If an email contact is changed, wait for approval from the security officer.
