### PR TITLE
Adopt copy-project-link plugin

### DIFF
--- a/permissions/plugin-copy-project-link.yml
+++ b/permissions/plugin-copy-project-link.yml
@@ -6,6 +6,7 @@ issues:
 paths:
   - "hudson/plugins/copyProjectLink/copy-project-link"
   - "org/jenkins-ci/plugins/copy-project-link"
-developers: []
+developers: 
+  - "AbdulRepo54"
 cd:
   enabled: true


### PR DESCRIPTION
I would like to adopt the Copy Project Link plugin.

Plugin:
https://plugins.jenkins.io/copy-project-link/

Repository:
https://github.com/jenkinsci/copy-project-link-plugin

Status: for adoption

GitHub username: AbdulRepo54
Jenkins Infrastructure ID: AbdulRepo54

The plugin currently has no developers listed in the Repository Permissions Updater.

I would like to help maintain the plugin, including issue and pull request triage, dependency and Jenkins compatibility updates, testing, documentation, and future releases.

I have logged into Jenkins Jira and Artifactory with my Jenkins infrastructure account.