### PR TITLE
Start managing some GitHub permissions as code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,11 @@ node('maven-25 ') {
             def javaArgs = ' -DdefinitionsDir=$PWD/permissions' +
                     ' -DartifactoryApiTempDir=$PWD/json' +
                     ' -DartifactoryUserNamesJsonListUrl=https://reports.jenkins.io/artifactory-ldap-users-report.json' +
+                    // Controls whether opted-in (manageGitHubPermissions/manageGitHubTeam) GitHub team
+                    // membership is actually reconciled (false) or only computed/reported (true, the safe
+                    // default). Kept explicit here for visibility; flip to false only once the diff report
+                    // has been reviewed. See docs/rollout-of-github-permissions-sync.md.
+                    ' -DgithubPermissionsDryRun=true' +
                     ' -Djava.util.logging.SimpleFormatter.format="%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s: %5$s%6$s%n"' +
                     ' -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar' +
                     ' sync'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,9 @@ node('maven-25 ') {
             archiveArtifacts 'json/*.json'
             if (infra.isTrusted()) {
                 dir('json') {
-                    publishReports(['issues.index.json', 'maintainers.index.json', 'github.index.json'], [useWorkloadIdentity: true])
+                    publishReports(
+                            ['issues.index.json', 'maintainers.index.json', 'github.index.json', 'github-permissions-diff.json'],
+                            [useWorkloadIdentity: true])
                 }
                 stage ('Publish build report') {
                     publishBuildStatusReport()

--- a/README.md
+++ b/README.md
@@ -139,6 +139,75 @@ cd:
 ```
 
 
+Managing GitHub Permissions (experimental)
+-------------------------------------------
+
+RPU is gaining the ability to also manage GitHub repository/team access as code, in addition to Artifactory
+upload permissions. This is a new, **opt-in, report-only** feature: nothing changes for a component unless its
+YAML file explicitly enables it, and even then, RPU currently only *reports* what it would change — it does
+not yet add or remove anyone from any GitHub team.
+
+See [docs/rollout-of-github-permissions-sync.md](docs/rollout-of-github-permissions-sync.md) for the staged adoption plan across the 2000+ repos in the org and how GitHub
+API usage is kept bounded as adoption grows.
+
+### Why report-only, and why it's opt-in
+
+The `jenkinsci` organization has 2000+ repositories and ~2600 teams, so a mistake in an automated
+reconciliation could lock maintainers out of their own repositories at scale. To manage that risk:
+
+- A component (or cross-repository team) is only touched by this feature once its YAML file sets
+  `manageGithubPermissions: true` (or, for `teams/*.yml`, `manageGithubTeam: true`). Everything else is left
+  completely alone, so adoption can be gradual.
+- The tool currently only *computes and reports* a diff (who would be added/removed per GitHub team) to
+  `json/github-permissions-diff.json`, published alongside the other index reports. Actually adding/removing
+  GitHub team members is a deferred follow-up, to be enabled only after this report has been reviewed over a
+  bake-in period.
+- Just like Artifactory sync, any live call to the GitHub API for this feature **only happens in the trusted,
+  post-merge run** — never in PR builds. PR builds intentionally run without any credentials (since PRs can
+  come from forks), and there is no GitHub credential that is both genuinely read-only *and* safe to hand to
+  untrusted, credential-free PR builds (a fine-grained PAT or GitHub App key is still a secret; anonymous
+  reads are rate-limited to 60 requests/hour and don't reliably expose private team membership). PR builds
+  only perform static YAML validation (schema/format checks) of the fields below — no network calls.
+
+### The `developers` list
+
+Each entry in `developers` (in both `permissions/*.yml` and `teams/*.yml`) can be either:
+
+- a plain string — a Jenkins community (LDAP) id, exactly as before; used for Artifactory permissions. If a
+  component opts into GitHub permissions management, a plain string entry is also assumed to be that
+  person's GitHub login (true for the vast majority of Jenkins contributors).
+- a mapping with **both** `ldap` and `github` keys — ties that developer's LDAP id to their GitHub login
+  1-to-1, e.g. `{ldap: jglick, github: jglick}`. Use this form when the two ids differ, so the GitHub login
+  used for permissions management is explicit rather than assumed. Both keys are required when using this
+  form. The two forms can be freely mixed in the same list.
+
+### YAML fields
+
+In a component's `permissions/*.yml` file:
+
+```yaml
+developers:
+  - ldap: "jglick"
+    github: "jglick"
+manageGithubPermissions: true    # opt-in: without this, GitHub logins above and the fields below are ignored
+repositoryTeam: "custom-name"    # optional: overrides the default "<repo> Developers" team name
+additionalGithubTeams:            # grants existing cross-repo teams (teams/*.yml) access to this repo
+  - name: "cloudbees-developers"
+    role: "push"                  # one of: pull, triage, push, maintain, admin
+```
+
+In a cross-repository `teams/*.yml` file:
+
+```yaml
+name: "cloudbees-developers"
+developers:
+  - ldap: "existing-ldap-id"
+    github: "existing-github-id"
+manageGithubTeam: true
+```
+
+
+
 Managing Security Process
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -143,25 +143,32 @@ Managing GitHub Permissions (experimental)
 -------------------------------------------
 
 RPU is gaining the ability to also manage GitHub repository/team access as code, in addition to Artifactory
-upload permissions. This is a new, **opt-in, report-only** feature: nothing changes for a component unless its
-YAML file explicitly enables it, and even then, RPU currently only *reports* what it would change — it does
-not yet add or remove anyone from any GitHub team.
+upload permissions. This is a new, **opt-in** feature: nothing changes for a component unless its YAML file
+explicitly enables it.
 
 See [docs/rollout-of-github-permissions-sync.md](docs/rollout-of-github-permissions-sync.md) for the staged adoption plan across the 2000+ repos in the org and how GitHub
 API usage is kept bounded as adoption grows.
 
-### Why report-only, and why it's opt-in
+### Why it's opt-in, and how writes are gated
 
 The `jenkinsci` organization has 2000+ repositories and ~2600 teams, so a mistake in an automated
 reconciliation could lock maintainers out of their own repositories at scale. To manage that risk:
 
 - A component (or cross-repository team) is only touched by this feature once its YAML file sets
-  `manageGithubPermissions: true` (or, for `teams/*.yml`, `manageGithubTeam: true`). Everything else is left
-  completely alone, so adoption can be gradual.
-- The tool currently only *computes and reports* a diff (who would be added/removed per GitHub team) to
-  `json/github-permissions-diff.json`, published alongside the other index reports. Actually adding/removing
-  GitHub team members is a deferred follow-up, to be enabled only after this report has been reviewed over a
-  bake-in period.
+  `manageGitHubPermissions: true` (or, for `teams/*.yml`, `manageGitHubTeam: true`). Everything else is left
+  completely alone, so adoption can be gradual. Setting this flag means RPU actively reconciles that
+  component's/team's GitHub membership to match its `developers` list — it is not merely a reporting toggle.
+- Whether a run actually *applies* those changes, or only computes and logs/reports them, is controlled
+  independently by the `githubPermissionsDryRun` system property (`-DgithubPermissionsDryRun=...`), which
+  **defaults to `true`** (safe/report-only) until explicitly set to `false`. This lets the org run the full
+  read+diff pipeline against real GitHub data for a bake-in period, with zero risk of a write, before
+  anyone deliberately flips the switch to start applying changes. Either way, the computed diff (including
+  whether it was applied) is written to `json/github-permissions-diff.json`, published alongside the other
+  index reports.
+- Removing the last member of a team is allowed and is not treated as a special/blocked case: org owners can
+  always restore access regardless of member count, so there's no lockout risk that needs guarding against.
+- A mutation failure for one login/team (e.g. a login that no longer exists) is logged and recorded in that
+  team's `errors` in the report, but does not abort reconciliation of any other opted-in team in the same run.
 - Just like Artifactory sync, any live call to the GitHub API for this feature **only happens in the trusted,
   post-merge run** — never in PR builds. PR builds intentionally run without any credentials (since PRs can
   come from forks), and there is no GitHub credential that is both genuinely read-only *and* safe to hand to
@@ -189,9 +196,9 @@ In a component's `permissions/*.yml` file:
 developers:
   - ldap: "jglick"
     github: "jglick"
-manageGithubPermissions: true    # opt-in: without this, GitHub logins above and the fields below are ignored
+manageGitHubPermissions: true    # opt-in: without this, GitHub logins above and the fields below are ignored
 repositoryTeam: "custom-name"    # optional: overrides the default "<repo> Developers" team name
-additionalGithubTeams:            # grants existing cross-repo teams (teams/*.yml) access to this repo
+additionalGitHubTeams:            # grants existing cross-repo teams (teams/*.yml) access to this repo
   - name: "cloudbees-developers"
     role: "push"                  # one of: pull, triage, push, maintain, admin
 ```
@@ -203,8 +210,52 @@ name: "cloudbees-developers"
 developers:
   - ldap: "existing-ldap-id"
     github: "existing-github-id"
-manageGithubTeam: true
+manageGitHubTeam: true
 ```
+
+### Testing the diff report locally, for one component
+
+The `github-sync` CLI command computes the same diff `sync` produces, but on its own — it never touches
+Artifactory, so it doesn't need `ARTIFACTORY_TOKEN` at all. This makes it convenient to test
+`manageGitHubPermissions`/`manageGitHubTeam` changes for a single component in isolation:
+
+```shell
+# GITHUB_TOKEN needs read access to the relevant team(s) - e.g. an org member's token with the read:org scope.
+# It additionally needs write (admin:org) access if you disable dry-run below and want to actually apply changes.
+export GITHUB_TOKEN=...
+
+# Point definitionsDir at a directory containing just the file(s) you want to test, e.g.:
+mkdir -p /tmp/rpu-test/permissions /tmp/rpu-test/teams
+cp permissions/plugin-slack.yml /tmp/rpu-test/permissions/
+
+java -DdefinitionsDir=/tmp/rpu-test/permissions \
+     -DteamsDir=/tmp/rpu-test/teams \
+     -DgithubDiffOutput=/tmp/rpu-test/github-permissions-diff.json \
+     -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar \
+     github-sync
+
+cat /tmp/rpu-test/github-permissions-diff.json
+```
+
+By default (`githubPermissionsDryRun` unset, or explicitly `-DgithubPermissionsDryRun=true`), this only
+computes and reports the diff — nothing is added or removed on GitHub. To actually apply the reported
+changes, pass `-DgithubPermissionsDryRun=false`:
+
+```shell
+java -DdefinitionsDir=/tmp/rpu-test/permissions \
+     -DteamsDir=/tmp/rpu-test/teams \
+     -DgithubDiffOutput=/tmp/rpu-test/github-permissions-diff.json \
+     -DgithubPermissionsDryRun=false \
+     -jar target/repository-permissions-updater-*-bin/repository-permissions-updater-*.jar \
+     github-sync
+```
+
+Since the sync only ever considers components/teams that have opted in
+(`manageGitHubPermissions`/`manageGitHubTeam: true`), you don't strictly need to copy files out — running
+`github-sync` directly against the real `permissions`/`teams` directories (the defaults if `-D...Dir` is
+omitted) is equally safe and only reports on whichever components have currently opted in; copying a single
+file out is just a convenient way to be certain you're looking at exactly one component's report while
+testing.
 
 
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,15 @@ Each entry in `developers` (in both `permissions/*.yml` and `teams/*.yml`) can b
 - a mapping with **both** `ldap` and `github` keys — ties that developer's LDAP id to their GitHub login
   1-to-1, e.g. `{ldap: jglick, github: jglick}`. Use this form when the two ids differ, so the GitHub login
   used for permissions management is explicit rather than assumed. Both keys are required when using this
-  form. The two forms can be freely mixed in the same list.
+  form.
+- a mapping with **only** a `github` key, e.g. `{github: someuser}` — a developer with a GitHub login but no
+  Jenkins community (LDAP) account at all. Only relevant for GitHub permissions management (never contributes
+  to Artifactory permissions, since there's no LDAP id to grant them). Useful when backfilling
+  `manageGitHubPermissions`/`manageGitHubTeam` for a component that already has GitHub collaborators/team
+  members with no obvious LDAP mapping: merge the ones you can confidently tie to an LDAP id as `{ldap,
+  github}`, and add everyone else as GitHub-only entries so existing access is preserved without guessing.
+
+All three forms can be freely mixed in the same list.
 
 ### YAML fields
 

--- a/docs/rollout-of-github-permissions-sync.md
+++ b/docs/rollout-of-github-permissions-sync.md
@@ -4,10 +4,58 @@ This document describes how GitHub team/repository permissions management (see t
 Permissions" section of [README.md](README.md)) will actually be rolled out across the `jenkinsci` org
 (2000+ repositories, ~2600 teams), and how the design keeps GitHub API usage bounded as adoption grows.
 
-Everything below builds on what's already merged: an opt-in schema (`manageGithubPermissions` /
-`manageGithubTeam`), static (network-free) YAML validation on every PR, and a **report-only** diff generator
+Everything below builds on what's already merged: an opt-in schema (`manageGitHubPermissions` /
+`manageGitHubTeam`), static (network-free) YAML validation on every PR, and a **report-only** diff generator
 (`GitHubPermissionsSyncer`) that runs once every ~2 hours on trusted.ci and publishes
 `json/github-permissions-diff.json`. No GitHub team membership is mutated today.
+
+## Why not Terraform (or another general-purpose IaC tool)?
+
+Terraform (with the `integrations/github` provider) is the obvious "codify GitHub as infrastructure"
+answer, and jenkins-infra already uses Terraform elsewhere, so it's worth explaining explicitly why this
+project doesn't adopt it for GitHub team/repo permissions. This isn't about credentials/trust boundaries —
+Terraform can follow the same `plan` on PR / `apply` on trusted post-merge split RPU already uses. The
+deciding factor is **performance at this specific scale (2000+ repos, ~2600 teams)**, where Terraform's
+execution model is a poor match:
+
+- **Terraform refreshes its entire managed state before every plan, not just what changed.** By default,
+  `terraform plan`/`apply` re-reads the current state of *every* resource under management to detect drift,
+  regardless of how small the underlying config change is. A single-line YAML edit to one plugin's
+  `developers` list would still trigger a full read of every other opted-in repo/team's current GitHub state
+  in the same run. `-target` can narrow this, but Hashicorp documents it as an exceptional/debugging flag,
+  not something to build a routine CI pipeline on — and computing a safe target list per PR is itself extra
+  engineering with no upstream support. RPU's diff generator, by contrast, only ever reads the specific teams
+  whose YAML is present in `permissions/`/`teams/` — cost scales with the opted-in set, not with "everything
+  Terraform happens to have in state."
+- **The GitHub Terraform provider is REST-based (built on `go-github`), not GraphQL, and doesn't batch.**
+  Resources like team membership are generally one API call per resource (or per team, for set-based
+  membership resources) during refresh — there's no built-in equivalent to the alias-batched GraphQL query
+  this project's `GitHubTeamsAPIImpl` uses to fetch up to 50 teams' full membership in a **single** HTTP
+  request. At full adoption (~2600 teams), that's the difference between roughly 52 requests per run (RPU,
+  see [Scaling](#scaling-to-2000-repos-minimizing-api-calls)) and on the order of thousands of individual
+  REST calls per full-state refresh with the stock provider — a ~50x+ difference in API cost for the same
+  read, before even counting writes.
+- **That refresh cost is paid on every run, including the trusted cron that runs every ~2 hours regardless of
+  whether anything changed.** A few thousand REST calls per refresh, times 12 runs/day, would consume a
+  meaningful fraction of GitHub's primary rate limit purely on drift-detection overhead — compared to RPU's
+  bounded ~52 requests/run (~624/day at full adoption), which leaves over an order of magnitude of headroom
+  with no further optimization needed.
+- **State size and plan/apply wall-clock time grow linearly with total managed resources, not with what
+  changed.** Modelling per-team membership as individual Terraform resources across thousands of repos means
+  the state file, and the time to refresh/diff/serialize it, keeps growing as adoption approaches 100% —
+  even for a run triggered by one small PR. RPU has no persisted state to grow: each run computes a diff
+  transiently from a live GraphQL read and a git-diff of the changed YAML, so its cost is a function of the
+  opted-in set size, not accumulated historical state.
+- **Getting Terraform to batch the way this project needs would mean writing a custom provider/data source
+  anyway** — at which point the actual GraphQL-batching engineering work (the part that makes this scale to
+  2000+ repos) is identical to what's already built in `GitHubTeamsAPIImpl`; Terraform would only be adding a
+  state-management and HCL layer on top of that same code, without a performance benefit to justify it.
+
+This isn't a rejection of Terraform in general — it remains a good fit where jenkins-infra already uses it
+(e.g. provisioning cloud infrastructure, where resource counts don't scale with "one file per external
+contributor" and full-state refreshes are cheap because there simply isn't that much to refresh). It's
+specifically the wrong tool for reconciling thousands of small, high-churn GitHub team-membership resources
+on a tight API budget.
 
 ## Goals for this phase
 
@@ -19,7 +67,7 @@ Everything below builds on what's already merged: an opt-in schema (`manageGithu
 
 ## Stage 0 — Pilot (in progress)
 
-- `permissions/plugin-slack.yml` is opted in (`manageGithubPermissions: true`) as the first pilot.
+- `permissions/plugin-slack.yml` is opted in (`manageGitHubPermissions: true`) as the first pilot.
 - Every trusted run computes and publishes a diff for this one repo/team. No mutations.
 - Hosting team reviews `json/github-permissions-diff.json` manually for a couple of weeks to confirm:
   - the desired vs. actual computation matches reality (spot-check against the GitHub UI),
@@ -44,7 +92,7 @@ Manually editing 2000+ YAML files is not viable. Before broad adoption we need a
 1. Reads `https://reports.jenkins.io/github-jenkinsci-permissions-report.json` (existing GitHub↔LDAP mapping
    report) plus the current `permissions/*.yml`/`teams/*.yml` developer lists.
 2. For each file, proposes:
-   - `manageGithubPermissions: true` (or `manageGithubTeam: true` for `teams/*.yml`),
+   - `manageGitHubPermissions: true` (or `manageGitHubTeam: true` for `teams/*.yml`),
    - upgrading plain-string `developers` entries to `{ldap, github}` mappings only where the report shows a
      GitHub login that **differs** from the LDAP id (leaving matching entries as plain strings, since the
      sync already assumes `ldap == github` by default — see README).
@@ -59,12 +107,19 @@ This is a scripted, supervised, one-time batch job — not something that runs u
 
 Once the diff report has been trustworthy across Stage 1/2 for a sustained period:
 
-1. Implement the write path (`GHTeam#add`/`GHTeam#remove` via the existing kohsuke `github-api` client,
-   reusing the same bot token already used for repo creation/hosting — no new credential).
-2. Ship it **behind a second, separate opt-in flag** (e.g. `syncGithubPermissions: true`, distinct from
-   `manageGithubPermissions`), so every repo that's currently only getting a report must explicitly
-   re-opt-in to writes. This avoids silently turning report-only repos into write-enabled ones the moment the
-   code ships.
+1. **Done.** The write path is implemented: `GitHubTeamsAPIImpl#addTeamMember`/`#removeTeamMember` call the
+   GitHub REST API (`PUT`/`DELETE /orgs/{org}/teams/{team}/memberships/{login}`, always role `member`, never
+   `maintainer`), reusing the existing bot token already used for repo creation/hosting — no new credential.
+2. Rather than a **second** opt-in YAML flag, `manageGitHubPermissions`/`manageGitHubTeam` directly mean
+   "actively manage (i.e. reconcile) this component's/team's GitHub membership" — there is only one YAML
+   opt-in flag. Whether a given trusted run actually *applies* the computed diff, or only computes and
+   reports/logs it, is controlled independently by the `githubPermissionsDryRun` system property passed to
+   the trusted run (`-DgithubPermissionsDryRun=true|false`), which **defaults to `true`** (safe/report-only).
+   This means every currently-opted-in repo can be re-verified end-to-end (real reads, real diff, real
+   report) with zero write risk, right up until the org deliberately flips `githubPermissionsDryRun=false`
+   for the trusted run — at which point *all* currently opted-in repos start being reconciled for real, not
+   just newly-added ones. This is simpler than a second flag and avoids repos silently drifting between
+   "reported on" and "actually managed" states independent of their own YAML.
 3. Safety guards before any write is issued:
    - removing the **last** member of a team is allowed and expected — an adopted/orphaned plugin can
      legitimately end up with zero maintainers (e.g. the previous maintainer stepped away and `developers`
@@ -74,16 +129,23 @@ Once the diff report has been trustworthy across Stage 1/2 for a sustained perio
      derived directly from the YAML in the merged commit, so a large removal simply reflects a large,
      reviewed change to `developers`; there's no separate "unexpected" state to guard against beyond normal
      PR review.
-   - every mutation is logged with before/after state; the diff report remains the audit trail.
-4. Re-run Stage 0/1 style pilot (small set first, e.g. `plugin-slack`) with writes enabled before wider
-   rollout, watching closely for a few cycles.
-5. Roll out to the Stage 2 batch, then broaden opt-in over time as plugin maintainers/hosting team choose to
-   adopt it — this remains **opt-in per repo indefinitely**, there is no planned "flip everyone over" cutover.
+   - a mutation failure for one login/team (e.g. a login that no longer exists, or a team that was deleted)
+     is caught per-mutation, logged, and recorded in that team's `errors` in the JSON report — it does not
+     abort reconciliation of any other opted-in team/login in the same run.
+   - every mutation is logged; the diff report (which also records `dryRun` and any `errors`) remains the
+     audit trail.
+4. Before flipping `githubPermissionsDryRun=false` for the first time, re-review the current diff report for
+   every already-opted-in repo (starting with the Stage 0 pilot, `plugin-slack`) to confirm it still looks
+   as expected, then flip the flag and watch closely for a few cycles.
+5. Broaden opt-in over time as plugin maintainers/hosting team choose to adopt it — this remains **opt-in per
+   repo indefinitely** via `manageGitHubPermissions`/`manageGitHubTeam`; there is no planned "flip everyone
+   over" cutover. `githubPermissionsDryRun`, once disabled, applies to all opted-in repos uniformly — it is a
+   single global switch for the trusted run, not a per-repo setting.
 
 ## Stage 4 — Steady state
 
-- Adoption grows organically as maintainers add `manageGithubPermissions`/`syncGithubPermissions` to their
-  `permissions/*.yml` (new plugins can opt in from day one via the hosting request template).
+- Adoption grows organically as maintainers add `manageGitHubPermissions`/`manageGitHubTeam` to their
+  `permissions/*.yml`/`teams/*.yml` (new plugins can opt in from day one via the hosting request template).
 - Hosting team spot-checks the diff report periodically; alerts (see below) catch anomalies between checks.
 - The manual GitHub-permissions request issue template
   (`.github/ISSUE_TEMPLATE/5-github-permissions.yml`) is updated to point maintainers at self-service YAML
@@ -95,7 +157,7 @@ The design keeps GitHub API usage roughly proportional to the **opted-in set**, 
 each run's call count low even as that set grows:
 
 - **Opt-in scope, not org-wide scans.** `GitHubPermissionsSyncer` only queries teams/repos where
-  `manageGithubPermissions`/`manageGithubTeam` is `true`. A repo that hasn't opted in costs zero GitHub API
+  `manageGitHubPermissions`/`manageGitHubTeam` is `true`. A repo that hasn't opted in costs zero GitHub API
   calls. This is the single biggest lever — the org has ~2600 teams total, but only opted-in teams are ever
   queried.
 - **GraphQL batching via aliased sub-queries.** `GitHubTeamsAPIImpl` doesn't do one REST call per team.
@@ -158,7 +220,7 @@ already accounts for the 2000+ repo scale.
 ## Explicitly out of scope for this rollout
 
 - CLI commands for developer search/removal (jenkins-infra/repository-permissions-updater#4755/#4759) — separate effort.
-- Repo-level (non-team) permission diffing for `additionalGithubTeams` role grants — diff report currently
+- Repo-level (non-team) permission diffing for `additionalGitHubTeams` role grants — diff report currently
   only reconciles team *membership*, not repo-to-team permission-level grants; follow-up once membership
   sync is proven out.
 - Any org-wide, non-opt-in scan or migration — adoption is and remains per-repo opt-in.

--- a/docs/rollout-of-github-permissions-sync.md
+++ b/docs/rollout-of-github-permissions-sync.md
@@ -1,0 +1,164 @@
+# Rollout plan: GitHub permissions management via RPU
+
+This document describes how GitHub team/repository permissions management (see the "Managing GitHub
+Permissions" section of [README.md](README.md)) will actually be rolled out across the `jenkinsci` org
+(2000+ repositories, ~2600 teams), and how the design keeps GitHub API usage bounded as adoption grows.
+
+Everything below builds on what's already merged: an opt-in schema (`manageGithubPermissions` /
+`manageGithubTeam`), static (network-free) YAML validation on every PR, and a **report-only** diff generator
+(`GitHubPermissionsSyncer`) that runs once every ~2 hours on trusted.ci and publishes
+`json/github-permissions-diff.json`. No GitHub team membership is mutated today.
+
+## Goals for this phase
+
+1. Prove the diff report is accurate against real data with zero risk (nothing is written to GitHub).
+2. Get a handful of real plugins opted in and get hosting-team sign-off on the diffs before writing any code
+   that mutates memberships.
+3. Design the eventual write path and the org-wide adoption path so that neither one requires an unbounded
+   number of GitHub API calls as the opted-in set grows toward "all 2000+ repos".
+
+## Stage 0 — Pilot (in progress)
+
+- `permissions/plugin-slack.yml` is opted in (`manageGithubPermissions: true`) as the first pilot.
+- Every trusted run computes and publishes a diff for this one repo/team. No mutations.
+- Hosting team reviews `json/github-permissions-diff.json` manually for a couple of weeks to confirm:
+  - the desired vs. actual computation matches reality (spot-check against the GitHub UI),
+  - the report correctly reflects additions/removals when `plugin-slack.yml` is edited,
+  - GraphQL calls stay cheap and reliable (see [Scaling](#scaling-to-2000-repos-minimizing-api-calls) below).
+- Exit criteria: hosting team explicitly approves moving to Stage 1.
+
+## Stage 1 — Expand opt-in to a small, representative batch (~20-50 repos)
+
+- Ask a handful of plugin maintainers (mix of high-traffic and low-traffic plugins, at least one with a
+  cross-repo `teams/*.yml` team) to opt in via PR.
+- No tooling change needed for this — it's the same schema, just more files setting the flag.
+- Track diff-report stability across a few runs per repo (a "flapping" diff, e.g. members appearing/
+  disappearing between runs, would indicate a bug and must be fixed before Stage 2).
+- Exit criteria: diffs are stable and correct across this batch for at least a week of runs.
+
+## Stage 2 — Bulk opt-in tooling
+
+Manually editing 2000+ YAML files is not viable. Before broad adoption we need a one-off migration helper
+(a script, not part of the production sync path) that:
+
+1. Reads `https://reports.jenkins.io/github-jenkinsci-permissions-report.json` (existing GitHub↔LDAP mapping
+   report) plus the current `permissions/*.yml`/`teams/*.yml` developer lists.
+2. For each file, proposes:
+   - `manageGithubPermissions: true` (or `manageGithubTeam: true` for `teams/*.yml`),
+   - upgrading plain-string `developers` entries to `{ldap, github}` mappings only where the report shows a
+     GitHub login that **differs** from the LDAP id (leaving matching entries as plain strings, since the
+     sync already assumes `ldap == github` by default — see README).
+3. Opens the changes as a small number of batched PRs (e.g. per-letter or per-N-files, not one giant PR),
+   so each is independently reviewable and revertable, and so any one bad diff doesn't block the rest.
+4. Runs **entirely off the existing static report JSON** — it does not call the GitHub API itself, so this
+   step adds no additional GitHub load regardless of how many repos it touches.
+
+This is a scripted, supervised, one-time batch job — not something that runs unattended in CI.
+
+## Stage 3 — Enable mutations (writes), still gated and staged
+
+Once the diff report has been trustworthy across Stage 1/2 for a sustained period:
+
+1. Implement the write path (`GHTeam#add`/`GHTeam#remove` via the existing kohsuke `github-api` client,
+   reusing the same bot token already used for repo creation/hosting — no new credential).
+2. Ship it **behind a second, separate opt-in flag** (e.g. `syncGithubPermissions: true`, distinct from
+   `manageGithubPermissions`), so every repo that's currently only getting a report must explicitly
+   re-opt-in to writes. This avoids silently turning report-only repos into write-enabled ones the moment the
+   code ships.
+3. Safety guards before any write is issued:
+   - removing the **last** member of a team is allowed and expected — an adopted/orphaned plugin can
+     legitimately end up with zero maintainers (e.g. the previous maintainer stepped away and `developers`
+     was correctly emptied), and org owners always retain the ability to restore access to any repo/team
+     regardless of its member count. This is not treated as an error case.
+   - no cap on the number/percentage of removals performed in a single run per team — the diff is always
+     derived directly from the YAML in the merged commit, so a large removal simply reflects a large,
+     reviewed change to `developers`; there's no separate "unexpected" state to guard against beyond normal
+     PR review.
+   - every mutation is logged with before/after state; the diff report remains the audit trail.
+4. Re-run Stage 0/1 style pilot (small set first, e.g. `plugin-slack`) with writes enabled before wider
+   rollout, watching closely for a few cycles.
+5. Roll out to the Stage 2 batch, then broaden opt-in over time as plugin maintainers/hosting team choose to
+   adopt it — this remains **opt-in per repo indefinitely**, there is no planned "flip everyone over" cutover.
+
+## Stage 4 — Steady state
+
+- Adoption grows organically as maintainers add `manageGithubPermissions`/`syncGithubPermissions` to their
+  `permissions/*.yml` (new plugins can opt in from day one via the hosting request template).
+- Hosting team spot-checks the diff report periodically; alerts (see below) catch anomalies between checks.
+- The manual GitHub-permissions request issue template
+  (`.github/ISSUE_TEMPLATE/5-github-permissions.yml`) is updated to point maintainers at self-service YAML
+  instead of a manual hosting-team action, once confidence is high.
+
+## Scaling to 2000+ repos: minimizing API calls
+
+The design keeps GitHub API usage roughly proportional to the **opted-in set**, not the org size, and keeps
+each run's call count low even as that set grows:
+
+- **Opt-in scope, not org-wide scans.** `GitHubPermissionsSyncer` only queries teams/repos where
+  `manageGithubPermissions`/`manageGithubTeam` is `true`. A repo that hasn't opted in costs zero GitHub API
+  calls. This is the single biggest lever — the org has ~2600 teams total, but only opted-in teams are ever
+  queried.
+- **GraphQL batching via aliased sub-queries.** `GitHubTeamsAPIImpl` doesn't do one REST call per team.
+  It builds one GraphQL query containing up to `BATCH_SIZE = 50` aliased `team(slug: ...) { members { ... } }`
+  sub-selections, so 50 teams cost **1 HTTP request**, not 50. At full adoption (2600 teams), that's ~52
+  requests total per run, comfortably inside GitHub's primary rate limit (5000 pts/hr for a GitHub App /
+  authenticated request) and the GraphQL secondary/node-count limits (each request currently asks for at
+  most 50 teams × 100 members = 5000 nodes, well under the 500,000-node ceiling).
+- **Members fetched in the same request as the team lookup.** There's no separate "list teams" call followed
+  by N "list members" calls — membership comes back in the same aliased sub-query, so cost doesn't multiply
+  with team size.
+- **Per-team member cap is a non-issue in practice, not a scaling concern.** `MAX_MEMBERS_PER_TEAM = 100`
+  members are fetched per team per request (no pagination implemented). No team in the org is expected to
+  ever approach 100 members — per-repo "Developers" teams are almost always single digits, and even the
+  largest cross-repo teams (e.g. core-maintainer teams) are nowhere near that size — so this cap is simply
+  headroom, not a real limitation that needs revisiting as part of this rollout.
+- **Bounded batch count regardless of adoption growth.** Request count per run is `ceil(opted_in_teams / 50)`.
+  Even if every one of the ~2600 teams in the org opted in simultaneously, that's ~52 GraphQL requests per
+  run — not 2000+ (one per repo) and not 2600+ (one per team). This is the property that makes "scale to
+  2000+ repos" tractable: the call count scales with `teams / 50`, not with `repos` or `members` directly.
+- **Runs are infrequent and off the hot path.** The sync only runs on the trusted, post-merge cron (every 2
+  hours, see `Jenkinsfile`), not per-PR and not per-webhook. PR builds do zero GitHub-permissions API calls
+  (only static YAML validation), so the 2000+ contributor-facing builds per day never touch this API at all.
+  Only the trusted run touches GitHub, and it does so at most every 2 hours regardless of how many repos are
+  opted in.
+- **Retry/backoff, not busy-polling.** `GitHubTeamsAPIImpl.postGraphQl` retries transient failures (up to 3
+  attempts with a short fixed delay) instead of re-querying eagerly or falling back to slower REST loops, so
+  transient GitHub issues don't multiply call volume.
+- **Failure isolation.** The diff generation is wrapped in try/catch in `ArtifactoryPermissionsUpdater`, so a
+  GitHub API problem (rate limit, outage) fails the diff step only — it doesn't block or retry the
+  Artifactory sync, and doesn't retry-storm GitHub on the next run beyond the normal 2-hour cadence.
+- **When writes are added (Stage 3),** the same batching principle applies: additions/removals should be
+  issued as the minimal set of mutating calls derived from the diff (one `add`/`remove` REST call is
+  unavoidable per membership change — GraphQL has no bulk-mutation for team membership — but the number of
+  mutations per run is bounded by how much actually changed since the last run, which in steady state is
+  small). No polling loops, no re-deriving full state more than once per run.
+
+### Rough capacity math (worst case: 100% adoption)
+
+- Teams to query: ~2600 (all teams, if every repo + cross-repo team opts in).
+- GraphQL requests per run: `ceil(2600 / 50)` = 52.
+- Runs per day: 24h / 2h cadence = 12.
+- GraphQL requests per day at full adoption: 52 × 12 = **624/day**, vs. a 5000-point/hour primary limit
+  (60,000+/day) — over an order of magnitude of headroom even at 100% adoption, without any further
+  optimization.
+
+This means no additional scaling work is required to reach full org adoption; the existing batching design
+already accounts for the 2000+ repo scale.
+
+## Monitoring / guardrails carried into rollout
+
+- `json/github-permissions-diff.json` is published every trusted run (already implemented) — this is the
+  primary visibility mechanism during Stage 0-2.
+- Before Stage 3 (writes), add: a run-over-run diff-size alert (e.g. if the number of planned changes in a
+  single run is anomalously large compared to the previous run, hold and notify rather than auto-apply) —
+  this is the main defense against a schema bug or bad PR silently mass-editing GitHub team membership.
+- Keep the "opt-in per repo" model permanently, even post-Stage 3 — this bounds the blast radius of any bug
+  to the repos that have explicitly adopted the feature, no matter how mature it becomes.
+
+## Explicitly out of scope for this rollout
+
+- CLI commands for developer search/removal (jenkins-infra/repository-permissions-updater#4755/#4759) — separate effort.
+- Repo-level (non-team) permission diffing for `additionalGithubTeams` role grants — diff report currently
+  only reconciles team *membership*, not repo-to-team permission-level grants; follow-up once membership
+  sync is proven out.
+- Any org-wide, non-opt-in scan or migration — adoption is and remains per-repo opt-in.

--- a/permissions/plugin-pipeline-graph-view.yml
+++ b/permissions/plugin-pipeline-graph-view.yml
@@ -6,7 +6,12 @@ paths:
 cd:
   enabled: true
 developers:
-  - "timja"
-  - "janfaracik"
+  - ldap: "timja"
+    github: "timja"
+  - ldap: "janfaracik"
+    github: "janfaracik"
+  - github: "lewisbirks"
 issues:
   - github: *GH
+
+manageGitHubPermissions: true

--- a/permissions/plugin-slack.yml
+++ b/permissions/plugin-slack.yml
@@ -12,4 +12,4 @@ developers:
     github: "timja"
   - ldap: "jetersen"
     github: "jetersen"
-manageGithubPermissions: true
+manageGitHubPermissions: true

--- a/permissions/plugin-slack.yml
+++ b/permissions/plugin-slack.yml
@@ -8,5 +8,8 @@ paths:
 cd:
   enabled: true
 developers:
-  - "timja"
-  - "jetersen"
+  - ldap: "timja"
+    github: "timja"
+  - ldap: "jetersen"
+    github: "jetersen"
+manageGithubPermissions: true

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
@@ -56,20 +56,14 @@ public final class ArtifactoryPermissionsUpdater {
     private static final File ARTIFACTORY_API_DIR = new File(System.getProperty("artifactoryApiTempDir", "./json"));
 
     /**
-     * If enabled, will not send PUT/DELETE requests to Artifactory, only GET (i.e. not modifying).
+     * Whether this instance is running in dry-run mode: if enabled, will not send PUT/DELETE requests to
+     * Artifactory, only GET (i.e. not modifying), and does not generate CD tokens.
      */
-    private static final boolean DRY_RUN_MODE = Boolean.getBoolean("dryRun");
+    private final boolean dryRunMode;
 
-    /**
-     * Independent of {@link #DRY_RUN_MODE}: controls whether GitHub permissions management (for components
-     * that have opted in via {@code manageGitHubPermissions}/{@code manageGitHubTeam}) actually mutates
-     * GitHub team membership, or only computes and logs/reports the diff. Defaults to {@code true} (safe,
-     * report-only) so this stays report-only until deliberately turned off, e.g. via
-     * {@code -DgithubPermissionsDryRun=false}. Has no effect when {@link #DRY_RUN_MODE} is {@code true},
-     * since GitHub permissions sync doesn't run in dry-run/PR builds at all (no credentials).
-     */
-    private static final boolean GITHUB_PERMISSIONS_DRY_RUN =
-            Boolean.parseBoolean(System.getProperty("githubPermissionsDryRun", "true"));
+    public ArtifactoryPermissionsUpdater(boolean dryRunMode) {
+        this.dryRunMode = dryRunMode;
+    }
 
     /**
      * Set to true during development to prevent collisions with production behavior:
@@ -656,7 +650,7 @@ public final class ArtifactoryPermissionsUpdater {
      *
      * @param githubReposForCdIndex JSON file containing a list of GitHub repo names in the format 'orgname/reponame'
      */
-    private static void generateTokens(File githubReposForCdIndex) throws IOException {
+    private void generateTokens(File githubReposForCdIndex) throws IOException {
         JsonArray repos;
         try (BufferedReader br = Files.newBufferedReader(githubReposForCdIndex.toPath())) {
             repos = new Gson().fromJson(br, JsonArray.class);
@@ -672,7 +666,7 @@ public final class ArtifactoryPermissionsUpdater {
 
             String token;
             try {
-                if (DRY_RUN_MODE) {
+                if (dryRunMode) {
                     LOGGER.log(
                             Level.INFO,
                             "Skipped creation of token for GitHub repo: ''{0}'', Artifactory user: ''{1}'', group name: ''{2}'', valid for {3} seconds",
@@ -715,14 +709,14 @@ public final class ArtifactoryPermissionsUpdater {
         }
     }
 
-    public static void syncPermissions() throws IOException {
+    public void syncPermissions() throws IOException {
         for (Handler h : Logger.getLogger("").getHandlers()) {
             if (h instanceof ConsoleHandler) {
                 ((ConsoleHandler) h).setFormatter(new SupportLogFormatter());
             }
         }
 
-        if (DRY_RUN_MODE) {
+        if (dryRunMode) {
             LOGGER.log(Level.INFO, "Running in dry run mode");
         }
         ArtifactoryAPI artifactory = ArtifactoryAPI.getInstance();
@@ -757,27 +751,6 @@ public final class ArtifactoryPermissionsUpdater {
          * For all CD-enabled GitHub repositories, obtain a token from Artifactory and attach it to a GH repo as secret.
          */
         generateTokens(new File(ARTIFACTORY_API_DIR, "cd.index.json"));
-
-        /*
-         * Reconcile GitHub team membership for all opted-in components/teams (manageGitHubPermissions /
-         * manageGitHubTeam), writing a JSON diff report either way. Whether this actually mutates GitHub or
-         * only computes and logs/reports the diff is controlled independently by the
-         * "githubPermissionsDryRun" system property (default true, i.e. safe/report-only until explicitly
-         * turned off) -- see GitHubPermissionsSyncer's class javadoc. Since this requires live, authenticated
-         * GitHub API calls even in dry-run mode (to read current membership), it never runs in dry-run/PR
-         * builds (which run without credentials) -- that's the separate, coarser DRY_RUN_MODE gate below.
-         */
-        if (!DRY_RUN_MODE) {
-            try {
-                GitHubPermissionsSyncer.generateDiffReport(
-                        DEFINITIONS_DIR,
-                        new File("teams/"),
-                        new File(ARTIFACTORY_API_DIR, "github-permissions-diff.json"),
-                        GITHUB_PERMISSIONS_DRY_RUN);
-            } catch (Exception ex) {
-                LOGGER.log(Level.WARNING, "Failed to sync GitHub permissions", ex);
-            }
-        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(ArtifactoryPermissionsUpdater.class.getName());

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
@@ -120,7 +120,7 @@ public final class ArtifactoryPermissionsUpdater {
      * {@code {ldap, github}} mapping entries (not just plain LDAP id strings) survive expansion unchanged.
      */
     private static void expandTeams(Definition definition, Map<String, Set<TeamDefinition>> teamsByName) {
-        Map<String, Object> expandedByLdapId = new TreeMap<>();
+        Map<String, Object> expandedByKey = new TreeMap<>();
 
         for (Object developerEntry : definition.getDevelopers()) {
             if (developerEntry instanceof String developerName && developerName.startsWith("@")) {
@@ -142,14 +142,14 @@ public final class ArtifactoryPermissionsUpdater {
                 });
                 for (TeamDefinition teamDev : teamDevs) {
                     for (Object teamEntry : teamDev.getDevelopers()) {
-                        expandedByLdapId.putIfAbsent(DeveloperEntries.extractLdapId(teamEntry), teamEntry);
+                        expandedByKey.putIfAbsent(DeveloperEntries.extractDedupKey(teamEntry), teamEntry);
                     }
                 }
             } else {
-                expandedByLdapId.putIfAbsent(DeveloperEntries.extractLdapId(developerEntry), developerEntry);
+                expandedByKey.putIfAbsent(DeveloperEntries.extractDedupKey(developerEntry), developerEntry);
             }
         }
-        definition.setDevelopers(expandedByLdapId.values().toArray());
+        definition.setDevelopers(expandedByKey.values().toArray());
     }
 
     /**
@@ -163,11 +163,12 @@ public final class ArtifactoryPermissionsUpdater {
     /**
      * Validates the shape of the polymorphic {@code developers} list, regardless of whether GitHub
      * permissions management is enabled: every entry must be either a plain string (a Jenkins community/LDAP
-     * id) or a mapping with exactly the {@code ldap} and {@code github} keys, both non-blank, the latter
-     * looking like a valid GitHub login. Also rejects a {@code {ldap, github}} mapping entry whose {@code
-     * ldap}/{@code github} duplicates another entry. Plain-string entries are not checked for duplicates
-     * against each other, to preserve the pre-existing (silently deduplicated at {@code @team} expansion
-     * time) tolerance for accidental repeats in legacy data.
+     * id), a mapping with exactly the {@code ldap} and {@code github} keys, or a mapping with only a
+     * {@code github} key (a developer with no Jenkins community/LDAP account, GitHub-only), all non-blank,
+     * GitHub logins format-checked. Also rejects a mapping entry whose {@code ldap}/{@code github}
+     * duplicates another entry. Plain-string entries are not checked for duplicates against each other, to
+     * preserve the pre-existing (silently deduplicated at {@code @team} expansion time) tolerance for
+     * accidental repeats in legacy data.
      */
     private static void validateDeveloperEntries(String fileName, Object[] developers) {
         Set<String> seenLdapIds = new HashSet<>();
@@ -183,22 +184,24 @@ public final class ArtifactoryPermissionsUpdater {
             } else if (entry instanceof Map<?, ?> map) {
                 Set<String> keys = new HashSet<>();
                 map.keySet().forEach(k -> keys.add(String.valueOf(k)));
-                if (!keys.equals(Set.of("ldap", "github"))) {
+                if (!keys.equals(Set.of("ldap", "github")) && !keys.equals(Set.of("github"))) {
                     throw new IllegalArgumentException(
-                            "developers entry using the {ldap, github} mapping form must specify exactly "
-                                    + "both 'ldap' and 'github' in " + fileName + ", but got: " + keys);
+                            "developers entry using the mapping form must specify either both 'ldap' and "
+                                    + "'github', or just 'github' (for a developer with no Jenkins "
+                                    + "community/LDAP account), in " + fileName + ", but got: " + keys);
                 }
-                String ldapId = String.valueOf(map.get("ldap"));
+                boolean hasLdap = keys.contains("ldap");
+                String ldapId = hasLdap ? String.valueOf(map.get("ldap")) : null;
                 String githubLogin = String.valueOf(map.get("github"));
-                if (ldapId.isBlank()) {
+                if (hasLdap && ldapId.isBlank()) {
                     throw new IllegalArgumentException("developers entry has a blank 'ldap' in " + fileName);
                 }
                 if (githubLogin.isBlank()
                         || !GITHUB_USERNAME_PATTERN.matcher(githubLogin).matches()) {
                     throw new IllegalArgumentException("developers entry has an invalid GitHub user name '"
-                            + githubLogin + "' for '" + ldapId + "' in " + fileName);
+                            + githubLogin + "'" + (hasLdap ? " for '" + ldapId + "'" : "") + " in " + fileName);
                 }
-                if (!seenLdapIds.add(ldapId)) {
+                if (hasLdap && !seenLdapIds.add(ldapId)) {
                     throw new IllegalArgumentException("Duplicate developer '" + ldapId + "' in " + fileName);
                 }
                 if (!seenGitHubLogins.add(githubLogin)) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
@@ -35,6 +35,7 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -74,8 +75,15 @@ public final class ArtifactoryPermissionsUpdater {
      * Always returns non null.
      */
     private static Map<String, Set<TeamDefinition>> loadTeams() throws IOException {
+        return loadTeams(new File("teams/"));
+    }
+
+    /**
+     * Loads all teams from the given folder.
+     * Always returns non null.
+     */
+    static Map<String, Set<TeamDefinition>> loadTeams(File teamsDir) throws IOException {
         Yaml yaml = new Yaml(new Constructor(TeamDefinition.class, new LoaderOptions()));
-        File teamsDir = new File("teams/");
 
         Map<String, Set<TeamDefinition>> teams = new HashMap<>();
 
@@ -102,12 +110,15 @@ public final class ArtifactoryPermissionsUpdater {
      * Checks if any developer has its name starting with `@`.
      * In which case, for `@some-team` it will replace it with the developers
      * listed for the team whose name equals `some-team` under the teams/ directory.
+     * <p>
+     * Operates on the raw {@code developers} entries (see {@link Definition#getDevelopers()}) so that any
+     * {@code {ldap, github}} mapping entries (not just plain LDAP id strings) survive expansion unchanged.
      */
     private static void expandTeams(Definition definition, Map<String, Set<TeamDefinition>> teamsByName) {
-        Set<String> expandedDevelopers = new TreeSet<>();
+        Map<String, Object> expandedByLdapId = new TreeMap<>();
 
-        for (String developerName : definition.getDevelopers()) {
-            if (developerName.startsWith("@")) {
+        for (Object developerEntry : definition.getDevelopers()) {
+            if (developerEntry instanceof String developerName && developerName.startsWith("@")) {
                 String teamName = developerName.substring(1);
                 Set<TeamDefinition> teamDevs = teamsByName.get(teamName);
                 if (teamDevs == null) {
@@ -124,12 +135,110 @@ public final class ArtifactoryPermissionsUpdater {
                             .flatMap(Stream::of)
                             .collect(Collectors.toList())
                 });
-                teamDevs.forEach(t -> expandedDevelopers.addAll(List.of(t.getDevelopers())));
+                for (TeamDefinition teamDev : teamDevs) {
+                    for (Object teamEntry : teamDev.getDevelopers()) {
+                        expandedByLdapId.putIfAbsent(DeveloperEntries.extractLdapId(teamEntry), teamEntry);
+                    }
+                }
             } else {
-                expandedDevelopers.add(developerName);
+                expandedByLdapId.putIfAbsent(DeveloperEntries.extractLdapId(developerEntry), developerEntry);
             }
         }
-        definition.setDevelopers(expandedDevelopers.toArray(new String[0]));
+        definition.setDevelopers(expandedByLdapId.values().toArray());
+    }
+
+    /**
+     * The set of GitHub repository permission roles accepted for {@link Definition.AdditionalGitHubTeam#role}.
+     * @see <a href="https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization">GitHub repository roles</a>
+     */
+    private static final Set<String> VALID_GITHUB_ROLES = Set.of("pull", "triage", "push", "maintain", "admin");
+
+    private static final Pattern GITHUB_USERNAME_PATTERN = Pattern.compile("[a-zA-Z0-9-]+");
+
+    /**
+     * Validates the shape of the polymorphic {@code developers} list, regardless of whether GitHub
+     * permissions management is enabled: every entry must be either a plain string (a Jenkins community/LDAP
+     * id) or a mapping with exactly the {@code ldap} and {@code github} keys, both non-blank, the latter
+     * looking like a valid GitHub login. Also rejects a {@code {ldap, github}} mapping entry whose {@code
+     * ldap}/{@code github} duplicates another entry. Plain-string entries are not checked for duplicates
+     * against each other, to preserve the pre-existing (silently deduplicated at {@code @team} expansion
+     * time) tolerance for accidental repeats in legacy data.
+     */
+    private static void validateDeveloperEntries(String fileName, Object[] developers) {
+        Set<String> seenLdapIds = new HashSet<>();
+        Set<String> seenGithubLogins = new HashSet<>();
+        for (Object entry : developers) {
+            if (entry instanceof String ldapId) {
+                if (ldapId.isBlank()) {
+                    throw new IllegalArgumentException("developers entry must not be blank in " + fileName);
+                }
+                if (!ldapId.startsWith("@")) {
+                    seenLdapIds.add(ldapId);
+                }
+            } else if (entry instanceof Map<?, ?> map) {
+                Set<String> keys = new HashSet<>();
+                map.keySet().forEach(k -> keys.add(String.valueOf(k)));
+                if (!keys.equals(Set.of("ldap", "github"))) {
+                    throw new IllegalArgumentException(
+                            "developers entry using the {ldap, github} mapping form must specify exactly "
+                                    + "both 'ldap' and 'github' in " + fileName + ", but got: " + keys);
+                }
+                String ldapId = String.valueOf(map.get("ldap"));
+                String githubLogin = String.valueOf(map.get("github"));
+                if (ldapId.isBlank()) {
+                    throw new IllegalArgumentException("developers entry has a blank 'ldap' in " + fileName);
+                }
+                if (githubLogin.isBlank()
+                        || !GITHUB_USERNAME_PATTERN.matcher(githubLogin).matches()) {
+                    throw new IllegalArgumentException("developers entry has an invalid GitHub user name '"
+                            + githubLogin + "' for '" + ldapId + "' in " + fileName);
+                }
+                if (!seenLdapIds.add(ldapId)) {
+                    throw new IllegalArgumentException("Duplicate developer '" + ldapId + "' in " + fileName);
+                }
+                if (!seenGithubLogins.add(githubLogin)) {
+                    throw new IllegalArgumentException(
+                            "Duplicate GitHub user name '" + githubLogin + "' in " + fileName);
+                }
+            } else {
+                throw new IllegalArgumentException("Invalid developers entry in " + fileName + ": " + entry);
+            }
+        }
+    }
+
+    /**
+     * Performs static (no network access) validation of the GitHub permissions management fields
+     * ({@code repositoryTeam}, {@code additionalGithubTeams}, {@code manageGithubPermissions}) on a
+     * {@link Definition}. Failures here are fatal so PR builds fail fast, mirroring the validation already
+     * performed for the Artifactory-related fields. No GitHub API calls are made from here, so this runs
+     * safely even in credential-free PR/dry-run builds.
+     */
+    private static void validateGithubPermissionsFields(
+            File file, Definition definition, Map<String, Set<TeamDefinition>> teamsByName) {
+        if (!definition.isManageGithubPermissions()) {
+            // Feature is opt-in per component; skip validation of the related (unused) fields entirely.
+            return;
+        }
+
+        if (definition.getGithub() == null) {
+            throw new IllegalArgumentException(
+                    "manageGithubPermissions requires a GitHub repository ('github') in " + file.getName());
+        }
+
+        for (Definition.AdditionalGitHubTeam additionalTeam : definition.getAdditionalGithubTeams()) {
+            if (additionalTeam.name == null || additionalTeam.name.isBlank()) {
+                throw new IllegalArgumentException(
+                        "additionalGithubTeams entry is missing 'name' in " + file.getName());
+            }
+            if (!teamsByName.containsKey(additionalTeam.name)) {
+                throw new IllegalArgumentException("additionalGithubTeams references unknown team '"
+                        + additionalTeam.name + "' (no teams/" + additionalTeam.name + ".yml) in " + file.getName());
+            }
+            if (additionalTeam.role == null || !VALID_GITHUB_ROLES.contains(additionalTeam.role)) {
+                throw new IllegalArgumentException("additionalGithubTeams entry for '" + additionalTeam.name
+                        + "' has invalid 'role' (must be one of " + VALID_GITHUB_ROLES + ") in " + file.getName());
+            }
+        }
     }
 
     /**
@@ -153,6 +262,11 @@ public final class ArtifactoryPermissionsUpdater {
             File yamlSourceDirectory, File apiOutputDir, ArtifactoryAPI artifactoryAPI) throws IOException {
         Yaml yaml = new Yaml(new Constructor(Definition.class, new LoaderOptions()));
         Map<String, Set<TeamDefinition>> teamsByName = loadTeams();
+        for (Set<TeamDefinition> teamDefinitions : teamsByName.values()) {
+            for (TeamDefinition team : teamDefinitions) {
+                validateDeveloperEntries(team.getName() + ".yml", team.getDevelopers());
+            }
+        }
 
         Map<String, Set<String>> pathsByGithub = new TreeMap<>();
         Map<String, List<Map<String, String>>> issueTrackersByPlugin = new TreeMap<>();
@@ -171,7 +285,9 @@ public final class ArtifactoryPermissionsUpdater {
             try (InputStream is = Files.newInputStream(file.toPath())) {
                 definition = yaml.loadAs(is, Definition.class);
 
+                validateDeveloperEntries(file.getName(), definition.getDevelopers());
                 expandTeams(definition, teamsByName);
+                validateGithubPermissionsFields(file, definition, teamsByName);
 
             } catch (Exception e) {
                 throw new IOException("Failed to read " + file.getName(), e);
@@ -188,7 +304,7 @@ public final class ArtifactoryPermissionsUpdater {
                         throw new IllegalArgumentException(
                                 "CD is only supported when the GitHub repository is in @jenkinsci");
                     }
-                    if (definition.getDevelopers().length > 0) {
+                    if (definition.getDeveloperIds().length > 0) {
                         List<Definition> definitions = cdEnabledComponentsByGitHub.get(definition.getGithub());
                         if (definitions == null || definitions.isEmpty()) {
                             definitions = new ArrayList<>();
@@ -294,7 +410,7 @@ public final class ArtifactoryPermissionsUpdater {
             JsonObject usersJson = new JsonObject();
             JsonObject groupsJson = new JsonObject();
 
-            if (definition.getDevelopers().length == 0) {
+            if (definition.getDeveloperIds().length == 0) {
                 if (definition.getCd() != null && definition.getCd().enabled) {
                     LOGGER.log(
                             Level.INFO,
@@ -303,7 +419,7 @@ public final class ArtifactoryPermissionsUpdater {
                 }
             } else {
                 if (definition.getCd() == null || !definition.getCd().exclusive) {
-                    for (String dev : definition.getDevelopers()) {
+                    for (String dev : definition.getDeveloperIds()) {
                         boolean inArtifactory = KnownUsers.existsInArtifactory(dev);
                         boolean inJira = KnownUsers.existsInJira(dev);
 
@@ -350,7 +466,7 @@ public final class ArtifactoryPermissionsUpdater {
                         usersJson.add(dev.toLowerCase(Locale.US), rights);
                     }
                 } else {
-                    for (String dev : definition.getDevelopers()) {
+                    for (String dev : definition.getDeveloperIds()) {
                         if (!KnownUsers.existsInJira(dev)) {
                             reportChecksApiDetails(dev + " needs to log in to Jira", """
                                     %s needs to log in to [Jira](https://issues.jenkins.io/)
@@ -367,7 +483,7 @@ public final class ArtifactoryPermissionsUpdater {
                 }
             }
 
-            if (definition.getCd() != null && definition.getCd().enabled && definition.getDevelopers().length != 0) {
+            if (definition.getCd() != null && definition.getCd().enabled && definition.getDeveloperIds().length != 0) {
                 JsonArray rights = new JsonArray();
                 rights.add("w");
                 rights.add("n");
@@ -445,7 +561,7 @@ public final class ArtifactoryPermissionsUpdater {
         // In practice this will probably not be a problem when path changes here and subsequent release are close
         // enough in time.
         // Alternatively, always keep the old groupId around for a while.
-        maintainersByComponent.computeIfAbsent(key, unused -> List.of(definition.getDevelopers()));
+        maintainersByComponent.computeIfAbsent(key, unused -> List.of(definition.getDeveloperIds()));
     }
 
     /**
@@ -630,6 +746,24 @@ public final class ArtifactoryPermissionsUpdater {
          * For all CD-enabled GitHub repositories, obtain a token from Artifactory and attach it to a GH repo as secret.
          */
         generateTokens(new File(ARTIFACTORY_API_DIR, "cd.index.json"));
+
+        /*
+         * Report-only: compute the diff between desired GitHub team membership (opted-in components/teams
+         * only) and actual GitHub team membership, and write it to a JSON report. No GitHub team membership
+         * is added or removed by this step; it exists purely to let the hosting team review the effect of
+         * managing GitHub permissions before any reconciliation is implemented. Since this requires live,
+         * authenticated GitHub API calls, it never runs in dry-run/PR builds (which run without credentials).
+         */
+        if (!DRY_RUN_MODE) {
+            try {
+                GitHubPermissionsSyncer.generateDiffReport(
+                        DEFINITIONS_DIR,
+                        new File("teams/"),
+                        new File(ARTIFACTORY_API_DIR, "github-permissions-diff.json"));
+            } catch (Exception ex) {
+                LOGGER.log(Level.WARNING, "Failed to generate GitHub permissions diff report", ex);
+            }
+        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(ArtifactoryPermissionsUpdater.class.getName());

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/ArtifactoryPermissionsUpdater.java
@@ -61,6 +61,17 @@ public final class ArtifactoryPermissionsUpdater {
     private static final boolean DRY_RUN_MODE = Boolean.getBoolean("dryRun");
 
     /**
+     * Independent of {@link #DRY_RUN_MODE}: controls whether GitHub permissions management (for components
+     * that have opted in via {@code manageGitHubPermissions}/{@code manageGitHubTeam}) actually mutates
+     * GitHub team membership, or only computes and logs/reports the diff. Defaults to {@code true} (safe,
+     * report-only) so this stays report-only until deliberately turned off, e.g. via
+     * {@code -DgithubPermissionsDryRun=false}. Has no effect when {@link #DRY_RUN_MODE} is {@code true},
+     * since GitHub permissions sync doesn't run in dry-run/PR builds at all (no credentials).
+     */
+    private static final boolean GITHUB_PERMISSIONS_DRY_RUN =
+            Boolean.parseBoolean(System.getProperty("githubPermissionsDryRun", "true"));
+
+    /**
      * Set to true during development to prevent collisions with production behavior:
      *
      * - Different prefixes for groups and permission targets in {@link ArtifactoryAPI}.
@@ -166,7 +177,7 @@ public final class ArtifactoryPermissionsUpdater {
      */
     private static void validateDeveloperEntries(String fileName, Object[] developers) {
         Set<String> seenLdapIds = new HashSet<>();
-        Set<String> seenGithubLogins = new HashSet<>();
+        Set<String> seenGitHubLogins = new HashSet<>();
         for (Object entry : developers) {
             if (entry instanceof String ldapId) {
                 if (ldapId.isBlank()) {
@@ -196,7 +207,7 @@ public final class ArtifactoryPermissionsUpdater {
                 if (!seenLdapIds.add(ldapId)) {
                     throw new IllegalArgumentException("Duplicate developer '" + ldapId + "' in " + fileName);
                 }
-                if (!seenGithubLogins.add(githubLogin)) {
+                if (!seenGitHubLogins.add(githubLogin)) {
                     throw new IllegalArgumentException(
                             "Duplicate GitHub user name '" + githubLogin + "' in " + fileName);
                 }
@@ -208,34 +219,34 @@ public final class ArtifactoryPermissionsUpdater {
 
     /**
      * Performs static (no network access) validation of the GitHub permissions management fields
-     * ({@code repositoryTeam}, {@code additionalGithubTeams}, {@code manageGithubPermissions}) on a
+     * ({@code repositoryTeam}, {@code additionalGitHubTeams}, {@code manageGitHubPermissions}) on a
      * {@link Definition}. Failures here are fatal so PR builds fail fast, mirroring the validation already
      * performed for the Artifactory-related fields. No GitHub API calls are made from here, so this runs
      * safely even in credential-free PR/dry-run builds.
      */
-    private static void validateGithubPermissionsFields(
+    private static void validateGitHubPermissionsFields(
             File file, Definition definition, Map<String, Set<TeamDefinition>> teamsByName) {
-        if (!definition.isManageGithubPermissions()) {
+        if (!definition.isManageGitHubPermissions()) {
             // Feature is opt-in per component; skip validation of the related (unused) fields entirely.
             return;
         }
 
         if (definition.getGithub() == null) {
             throw new IllegalArgumentException(
-                    "manageGithubPermissions requires a GitHub repository ('github') in " + file.getName());
+                    "manageGitHubPermissions requires a GitHub repository ('github') in " + file.getName());
         }
 
-        for (Definition.AdditionalGitHubTeam additionalTeam : definition.getAdditionalGithubTeams()) {
+        for (Definition.AdditionalGitHubTeam additionalTeam : definition.getAdditionalGitHubTeams()) {
             if (additionalTeam.name == null || additionalTeam.name.isBlank()) {
                 throw new IllegalArgumentException(
-                        "additionalGithubTeams entry is missing 'name' in " + file.getName());
+                        "additionalGitHubTeams entry is missing 'name' in " + file.getName());
             }
             if (!teamsByName.containsKey(additionalTeam.name)) {
-                throw new IllegalArgumentException("additionalGithubTeams references unknown team '"
+                throw new IllegalArgumentException("additionalGitHubTeams references unknown team '"
                         + additionalTeam.name + "' (no teams/" + additionalTeam.name + ".yml) in " + file.getName());
             }
             if (additionalTeam.role == null || !VALID_GITHUB_ROLES.contains(additionalTeam.role)) {
-                throw new IllegalArgumentException("additionalGithubTeams entry for '" + additionalTeam.name
+                throw new IllegalArgumentException("additionalGitHubTeams entry for '" + additionalTeam.name
                         + "' has invalid 'role' (must be one of " + VALID_GITHUB_ROLES + ") in " + file.getName());
             }
         }
@@ -268,7 +279,7 @@ public final class ArtifactoryPermissionsUpdater {
             }
         }
 
-        Map<String, Set<String>> pathsByGithub = new TreeMap<>();
+        Map<String, Set<String>> pathsByGitHub = new TreeMap<>();
         Map<String, List<Map<String, String>>> issueTrackersByPlugin = new TreeMap<>();
         Map<String, List<Definition>> cdEnabledComponentsByGitHub = new TreeMap<>();
         Map<String, List<String>> maintainersByComponent = new HashMap<>();
@@ -287,7 +298,7 @@ public final class ArtifactoryPermissionsUpdater {
 
                 validateDeveloperEntries(file.getName(), definition.getDevelopers());
                 expandTeams(definition, teamsByName);
-                validateGithubPermissionsFields(file, definition, teamsByName);
+                validateGitHubPermissionsFields(file, definition, teamsByName);
 
             } catch (Exception e) {
                 throw new IOException("Failed to read " + file.getName(), e);
@@ -296,7 +307,7 @@ public final class ArtifactoryPermissionsUpdater {
             if (definition.getGithub() != null) {
                 if (!definition.isReleaseBlocked()) {
                     Set<String> paths =
-                            pathsByGithub.computeIfAbsent(definition.getGithub(), unused -> new TreeSet<>());
+                            pathsByGitHub.computeIfAbsent(definition.getGithub(), unused -> new TreeSet<>());
                     paths.addAll(List.of(definition.getPaths()));
                 }
                 if (definition.getCd() != null && definition.getCd().enabled) {
@@ -519,7 +530,7 @@ public final class ArtifactoryPermissionsUpdater {
             }
         }
 
-        writePrettyJson(apiOutputDir.toPath().resolve("github.index.json"), pathsByGithub, gson);
+        writePrettyJson(apiOutputDir.toPath().resolve("github.index.json"), pathsByGitHub, gson);
         writePrettyJson(apiOutputDir.toPath().resolve("issues.index.json"), issueTrackersByPlugin, gson);
         writePrettyJson(
                 apiOutputDir.toPath().resolve("cd.index.json"),
@@ -748,20 +759,23 @@ public final class ArtifactoryPermissionsUpdater {
         generateTokens(new File(ARTIFACTORY_API_DIR, "cd.index.json"));
 
         /*
-         * Report-only: compute the diff between desired GitHub team membership (opted-in components/teams
-         * only) and actual GitHub team membership, and write it to a JSON report. No GitHub team membership
-         * is added or removed by this step; it exists purely to let the hosting team review the effect of
-         * managing GitHub permissions before any reconciliation is implemented. Since this requires live,
-         * authenticated GitHub API calls, it never runs in dry-run/PR builds (which run without credentials).
+         * Reconcile GitHub team membership for all opted-in components/teams (manageGitHubPermissions /
+         * manageGitHubTeam), writing a JSON diff report either way. Whether this actually mutates GitHub or
+         * only computes and logs/reports the diff is controlled independently by the
+         * "githubPermissionsDryRun" system property (default true, i.e. safe/report-only until explicitly
+         * turned off) -- see GitHubPermissionsSyncer's class javadoc. Since this requires live, authenticated
+         * GitHub API calls even in dry-run mode (to read current membership), it never runs in dry-run/PR
+         * builds (which run without credentials) -- that's the separate, coarser DRY_RUN_MODE gate below.
          */
         if (!DRY_RUN_MODE) {
             try {
                 GitHubPermissionsSyncer.generateDiffReport(
                         DEFINITIONS_DIR,
                         new File("teams/"),
-                        new File(ARTIFACTORY_API_DIR, "github-permissions-diff.json"));
+                        new File(ARTIFACTORY_API_DIR, "github-permissions-diff.json"),
+                        GITHUB_PERMISSIONS_DRY_RUN);
             } catch (Exception ex) {
-                LOGGER.log(Level.WARNING, "Failed to generate GitHub permissions diff report", ex);
+                LOGGER.log(Level.WARNING, "Failed to sync GitHub permissions", ex);
             }
         }
     }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -135,7 +135,7 @@ public class Definition {
      * Each entry is either a plain string (legacy format: a Jenkins community/LDAP id, used for Artifactory
      * permissions), or a mapping with both {@code ldap} and {@code github} keys (new format: ties an LDAP id
      * to a GitHub login 1-to-1, e.g. {@code {ldap: jglick, github: jglick}}), so the two can differ when
-     * needed. See {@link #getDeveloperIds()} and {@link #getGithubUsernames()}.
+     * needed. See {@link #getDeveloperIds()} and {@link #getGitHubUsernames()}.
      */
     private Object[] developers = new Object[0];
 
@@ -148,11 +148,11 @@ public class Definition {
 
     /**
      * Opt-in flag: if {@code true}, RPU will reconcile GitHub team membership for this component's
-     * repository, using {@link #developers} (see {@link #getGithubUsernames()} for how GitHub logins are
-     * resolved) plus {@link #additionalGithubTeams}. Defaults to {@code false} so existing components are
+     * repository, using {@link #developers} (see {@link #getGitHubUsernames()} for how GitHub logins are
+     * resolved) plus {@link #additionalGitHubTeams}. Defaults to {@code false} so existing components are
      * unaffected until they explicitly opt in.
      */
-    private boolean manageGithubPermissions;
+    private boolean manageGitHubPermissions;
 
     /**
      * Overrides the default GitHub team name (otherwise derived as {@code "<repo> Developers"}) used to
@@ -164,7 +164,7 @@ public class Definition {
      * Additional, cross-repository GitHub teams (defined in {@code teams/*.yml}) to grant access to this
      * component's repository, and at what role.
      */
-    private AdditionalGitHubTeam[] additionalGithubTeams = new AdditionalGitHubTeam[0];
+    private AdditionalGitHubTeam[] additionalGitHubTeams = new AdditionalGitHubTeam[0];
 
     public CD getCd() {
         return cd;
@@ -231,12 +231,12 @@ public class Definition {
         this.github = github;
     }
 
-    public boolean isManageGithubPermissions() {
-        return manageGithubPermissions;
+    public boolean isManageGitHubPermissions() {
+        return manageGitHubPermissions;
     }
 
-    public void setManageGithubPermissions(boolean manageGithubPermissions) {
-        this.manageGithubPermissions = manageGithubPermissions;
+    public void setManageGitHubPermissions(boolean manageGitHubPermissions) {
+        this.manageGitHubPermissions = manageGitHubPermissions;
     }
 
     /**
@@ -244,8 +244,8 @@ public class Definition {
      * {@code {ldap, github}} mapping form, keyed by that entry's LDAP id. Entries declared as a plain string
      * are not included here -- callers should treat the LDAP id itself as the GitHub login for those.
      */
-    public Map<String, String> getGithubUsernames() {
-        return DeveloperEntries.extractGithubUsernames(developers);
+    public Map<String, String> getGitHubUsernames() {
+        return DeveloperEntries.extractGitHubUsernames(developers);
     }
 
     @CheckForNull
@@ -257,12 +257,12 @@ public class Definition {
         this.repositoryTeam = repositoryTeam;
     }
 
-    public AdditionalGitHubTeam[] getAdditionalGithubTeams() {
-        return additionalGithubTeams.clone();
+    public AdditionalGitHubTeam[] getAdditionalGitHubTeams() {
+        return additionalGitHubTeams.clone();
     }
 
-    public void setAdditionalGithubTeams(AdditionalGitHubTeam[] additionalGithubTeams) {
-        this.additionalGithubTeams = additionalGithubTeams.clone();
+    public void setAdditionalGitHubTeams(AdditionalGitHubTeam[] additionalGitHubTeams) {
+        this.additionalGitHubTeams = additionalGitHubTeams.clone();
     }
 
     public void setSecurity(Security security) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -3,6 +3,7 @@ package io.jenkins.infra.repository_permissions_updater;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -133,9 +134,11 @@ public class Definition {
 
     /**
      * Each entry is either a plain string (legacy format: a Jenkins community/LDAP id, used for Artifactory
-     * permissions), or a mapping with both {@code ldap} and {@code github} keys (new format: ties an LDAP id
-     * to a GitHub login 1-to-1, e.g. {@code {ldap: jglick, github: jglick}}), so the two can differ when
-     * needed. See {@link #getDeveloperIds()} and {@link #getGitHubUsernames()}.
+     * permissions), a mapping with both {@code ldap} and {@code github} keys (ties an LDAP id to a GitHub
+     * login 1-to-1, e.g. {@code {ldap: jglick, github: jglick}}, so the two can differ when needed), or a
+     * mapping with only a {@code github} key (a developer with a GitHub login but no Jenkins community/LDAP
+     * account, e.g. {@code {github: someuser}} -- GitHub permissions management only, useful for backfill).
+     * See {@link #getDeveloperIds()}, {@link #getGitHubUsernames()}, and {@link #getGitHubOnlyUsernames()}.
      */
     private Object[] developers = new Object[0];
 
@@ -246,6 +249,16 @@ public class Definition {
      */
     public Map<String, String> getGitHubUsernames() {
         return DeveloperEntries.extractGitHubUsernames(developers);
+    }
+
+    /**
+     * Returns the GitHub login for each {@link #developers} entry declared using the GitHub-only mapping
+     * form ({@code {github: ...}}, no {@code ldap} key) -- developers with a GitHub login but no Jenkins
+     * community (LDAP) account, so they never appear in {@link #getDeveloperIds()}. Useful for backfilling
+     * existing GitHub team membership that hasn't yet been (or won't be) tied to an LDAP account.
+     */
+    public Set<String> getGitHubOnlyUsernames() {
+        return DeveloperEntries.extractGitHubOnlyLogins(developers);
     }
 
     @CheckForNull

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/Definition.java
@@ -1,10 +1,12 @@
 package io.jenkins.infra.repository_permissions_updater;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@SuppressFBWarnings("UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD")
+@SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
 public class Definition {
 
     public static class CD {
@@ -14,6 +16,15 @@ public class Definition {
 
     public static class Security {
         public SecurityContacts contacts;
+    }
+
+    /**
+     * Grants an existing cross-repository GitHub team (as defined in {@code teams/*.yml}) access to this
+     * component's GitHub repository, at the specified GitHub permission role.
+     */
+    public static class AdditionalGitHubTeam {
+        public String name;
+        public String role;
     }
 
     public static class SecurityContacts {
@@ -119,13 +130,41 @@ public class Definition {
 
     private String name = "";
     private String[] paths = new String[0];
-    private String[] developers = new String[0];
+
+    /**
+     * Each entry is either a plain string (legacy format: a Jenkins community/LDAP id, used for Artifactory
+     * permissions), or a mapping with both {@code ldap} and {@code github} keys (new format: ties an LDAP id
+     * to a GitHub login 1-to-1, e.g. {@code {ldap: jglick, github: jglick}}), so the two can differ when
+     * needed. See {@link #getDeveloperIds()} and {@link #getGithubUsernames()}.
+     */
+    private Object[] developers = new Object[0];
+
     private IssueTracker[] issues = new IssueTracker[0];
     private String[] extraNames = new String[0];
     private boolean releaseBlocked;
     private boolean communityPluginMaintainers;
 
     private String github;
+
+    /**
+     * Opt-in flag: if {@code true}, RPU will reconcile GitHub team membership for this component's
+     * repository, using {@link #developers} (see {@link #getGithubUsernames()} for how GitHub logins are
+     * resolved) plus {@link #additionalGithubTeams}. Defaults to {@code false} so existing components are
+     * unaffected until they explicitly opt in.
+     */
+    private boolean manageGithubPermissions;
+
+    /**
+     * Overrides the default GitHub team name (otherwise derived as {@code "<repo> Developers"}) used to
+     * grant {@link #developers} access to this component's repository.
+     */
+    private String repositoryTeam;
+
+    /**
+     * Additional, cross-repository GitHub teams (defined in {@code teams/*.yml}) to grant access to this
+     * component's repository, and at what role.
+     */
+    private AdditionalGitHubTeam[] additionalGithubTeams = new AdditionalGitHubTeam[0];
 
     public CD getCd() {
         return cd;
@@ -170,16 +209,60 @@ public class Definition {
         this.issues = paths.clone();
     }
 
-    public String[] getDevelopers() {
+    public Object[] getDevelopers() {
         return developers.clone();
     }
 
-    public void setDevelopers(String[] developers) {
+    public void setDevelopers(Object[] developers) {
         this.developers = developers.clone();
+    }
+
+    /**
+     * Returns the Jenkins community (LDAP) id for every {@link #developers} entry, in order: a plain string
+     * entry (legacy format) is returned as-is, and a {@code {ldap, github}} mapping entry (new format)
+     * contributes its {@code ldap} value. Most Artifactory-related code should use this rather than
+     * {@link #getDevelopers()}.
+     */
+    public String[] getDeveloperIds() {
+        return DeveloperEntries.toLdapIds(developers);
     }
 
     public void setGithub(String github) {
         this.github = github;
+    }
+
+    public boolean isManageGithubPermissions() {
+        return manageGithubPermissions;
+    }
+
+    public void setManageGithubPermissions(boolean manageGithubPermissions) {
+        this.manageGithubPermissions = manageGithubPermissions;
+    }
+
+    /**
+     * Returns the GitHub login to use for each {@link #developers} entry declared using the
+     * {@code {ldap, github}} mapping form, keyed by that entry's LDAP id. Entries declared as a plain string
+     * are not included here -- callers should treat the LDAP id itself as the GitHub login for those.
+     */
+    public Map<String, String> getGithubUsernames() {
+        return DeveloperEntries.extractGithubUsernames(developers);
+    }
+
+    @CheckForNull
+    public String getRepositoryTeam() {
+        return repositoryTeam;
+    }
+
+    public void setRepositoryTeam(String repositoryTeam) {
+        this.repositoryTeam = repositoryTeam;
+    }
+
+    public AdditionalGitHubTeam[] getAdditionalGithubTeams() {
+        return additionalGithubTeams.clone();
+    }
+
+    public void setAdditionalGithubTeams(AdditionalGitHubTeam[] additionalGithubTeams) {
+        this.additionalGithubTeams = additionalGithubTeams.clone();
     }
 
     public void setSecurity(Security security) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntries.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntries.java
@@ -1,0 +1,68 @@
+package io.jenkins.infra.repository_permissions_updater;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Shared helpers for interpreting the polymorphic {@code developers} YAML list used by both
+ * {@link Definition} and {@link TeamDefinition}. Each entry may be either:
+ * <ul>
+ *     <li>a plain string (legacy format): just a Jenkins community (LDAP) id, used for Artifactory
+ *     permissions only; or</li>
+ *     <li>a mapping with both {@code ldap} and {@code github} keys (new format): ties a developer's LDAP id
+ *     to their GitHub login 1-to-1, so the same entry can be used for both Artifactory permissions and the
+ *     (opt-in) GitHub permissions management feature.</li>
+ * </ul>
+ */
+final class DeveloperEntries {
+
+    private DeveloperEntries() {}
+
+    /**
+     * Extracts the Jenkins community (LDAP) id from a single {@code developers} entry.
+     */
+    static String extractLdapId(Object entry) {
+        if (entry instanceof String s) {
+            return s;
+        }
+        if (entry instanceof Map<?, ?> map) {
+            Object ldap = map.get("ldap");
+            if (ldap != null) {
+                return ldap.toString();
+            }
+        }
+        throw new IllegalArgumentException(
+                "Invalid 'developers' entry, expected a plain string or a {ldap, github} mapping, but got: " + entry);
+    }
+
+    /**
+     * Extracts the LDAP id for every entry in {@code developers}, in order.
+     */
+    static String[] toLdapIds(Object[] developers) {
+        String[] ids = new String[developers.length];
+        for (int i = 0; i < developers.length; i++) {
+            ids[i] = extractLdapId(developers[i]);
+        }
+        return ids;
+    }
+
+    /**
+     * Builds an LDAP id -&gt; GitHub login map from every {@code {ldap, github}} mapping entry in
+     * {@code developers}. Plain string entries contribute nothing here; callers that need a GitHub login for
+     * every developer should fall back to treating the LDAP id as the GitHub login when it's absent from this
+     * map.
+     */
+    static Map<String, String> extractGithubUsernames(Object[] developers) {
+        Map<String, String> logins = new LinkedHashMap<>();
+        for (Object entry : developers) {
+            if (entry instanceof Map<?, ?> map) {
+                Object ldap = map.get("ldap");
+                Object github = map.get("github");
+                if (ldap != null && github != null) {
+                    logins.put(ldap.toString(), github.toString());
+                }
+            }
+        }
+        return logins;
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntries.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntries.java
@@ -1,7 +1,9 @@
 package io.jenkins.infra.repository_permissions_updater;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Shared helpers for interpreting the polymorphic {@code developers} YAML list used by both
@@ -11,7 +13,10 @@ import java.util.Map;
  *     permissions only; or</li>
  *     <li>a mapping with both {@code ldap} and {@code github} keys (new format): ties a developer's LDAP id
  *     to their GitHub login 1-to-1, so the same entry can be used for both Artifactory permissions and the
- *     (opt-in) GitHub permissions management feature.</li>
+ *     (opt-in) GitHub permissions management feature; or</li>
+ *     <li>a mapping with only a {@code github} key (no {@code ldap}): a developer with a GitHub login but no
+ *     Jenkins community (LDAP) account, used for GitHub permissions management only. Useful for backfilling
+ *     existing GitHub team membership that hasn't yet been (or never will be) tied to an LDAP account.</li>
  * </ul>
  */
 final class DeveloperEntries {
@@ -19,7 +24,8 @@ final class DeveloperEntries {
     private DeveloperEntries() {}
 
     /**
-     * Extracts the Jenkins community (LDAP) id from a single {@code developers} entry.
+     * Extracts the Jenkins community (LDAP) id from a single {@code developers} entry, or {@code null} if
+     * the entry is a GitHub-only mapping (has a {@code github} key but no {@code ldap} key).
      */
     static String extractLdapId(Object entry) {
         if (entry instanceof String s) {
@@ -30,27 +36,56 @@ final class DeveloperEntries {
             if (ldap != null) {
                 return ldap.toString();
             }
+            if (map.get("github") != null) {
+                return null;
+            }
         }
         throw new IllegalArgumentException(
-                "Invalid 'developers' entry, expected a plain string or a {ldap, github} mapping, but got: " + entry);
+                "Invalid 'developers' entry, expected a plain string, a {ldap, github} mapping, or a "
+                        + "{github} mapping, but got: " + entry);
     }
 
     /**
-     * Extracts the LDAP id for every entry in {@code developers}, in order.
+     * Extracts a stable dedup key for a single {@code developers} entry: the LDAP id when present, otherwise
+     * (for a GitHub-only mapping entry) a key derived from its GitHub login. Used where entries need to be
+     * deduplicated (e.g. {@code @team} expansion) even though GitHub-only entries have no LDAP id to key on.
+     */
+    static String extractDedupKey(Object entry) {
+        String ldapId = extractLdapId(entry);
+        if (ldapId != null) {
+            return ldapId;
+        }
+        Map<?, ?> map = (Map<?, ?>) entry;
+        return "github:" + map.get("github");
+    }
+
+    /**
+     * Extracts the LDAP id for every entry in {@code developers} that has one, in order. GitHub-only mapping
+     * entries (no {@code ldap} key) are skipped -- they have no Jenkins community account and so are not
+     * relevant to Artifactory permissions or any other LDAP-id-keyed logic.
      */
     static String[] toLdapIds(Object[] developers) {
         String[] ids = new String[developers.length];
-        for (int i = 0; i < developers.length; i++) {
-            ids[i] = extractLdapId(developers[i]);
+        int count = 0;
+        for (Object developer : developers) {
+            String ldapId = extractLdapId(developer);
+            if (ldapId != null) {
+                ids[count++] = ldapId;
+            }
         }
-        return ids;
+        if (count == ids.length) {
+            return ids;
+        }
+        String[] trimmed = new String[count];
+        System.arraycopy(ids, 0, trimmed, 0, count);
+        return trimmed;
     }
 
     /**
      * Builds an LDAP id -&gt; GitHub login map from every {@code {ldap, github}} mapping entry in
-     * {@code developers}. Plain string entries contribute nothing here; callers that need a GitHub login for
-     * every developer should fall back to treating the LDAP id as the GitHub login when it's absent from this
-     * map.
+     * {@code developers}. Plain string entries and GitHub-only mapping entries contribute nothing here;
+     * callers that need a GitHub login for every developer should fall back to treating the LDAP id as the
+     * GitHub login when it's absent from this map.
      */
     static Map<String, String> extractGitHubUsernames(Object[] developers) {
         Map<String, String> logins = new LinkedHashMap<>();
@@ -61,6 +96,22 @@ final class DeveloperEntries {
                 if (ldap != null && github != null) {
                     logins.put(ldap.toString(), github.toString());
                 }
+            }
+        }
+        return logins;
+    }
+
+    /**
+     * Extracts the GitHub login from every GitHub-only mapping entry ({@code {github: ...}}, no
+     * {@code ldap} key) in {@code developers}. These are developers with no Jenkins community (LDAP)
+     * account, so they only ever show up here, never in {@link #toLdapIds(Object[])} or
+     * {@link #extractGitHubUsernames(Object[])}.
+     */
+    static Set<String> extractGitHubOnlyLogins(Object[] developers) {
+        Set<String> logins = new LinkedHashSet<>();
+        for (Object entry : developers) {
+            if (entry instanceof Map<?, ?> map && map.get("ldap") == null && map.get("github") != null) {
+                logins.add(map.get("github").toString());
             }
         }
         return logins;

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntries.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntries.java
@@ -52,7 +52,7 @@ final class DeveloperEntries {
      * every developer should fall back to treating the LDAP id as the GitHub login when it's absent from this
      * map.
      */
-    static Map<String, String> extractGithubUsernames(Object[] developers) {
+    static Map<String, String> extractGitHubUsernames(Object[] developers) {
         Map<String, String> logins = new LinkedHashMap<>();
         for (Object entry : developers) {
             if (entry instanceof Map<?, ?> map) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
@@ -29,15 +29,16 @@ import org.yaml.snakeyaml.constructor.Constructor;
 /**
  * Computes the difference between the desired GitHub team membership (declared in YAML, for components that
  * have opted in via {@code manageGitHubPermissions}/{@code manageGitHubTeam}) and the actual membership
- * currently on GitHub, writes it to a JSON report, and -- unless running in dry-run mode -- applies it by
- * adding/removing the affected members.
+ * currently on GitHub, writes it to a JSON report, and -- unless this instance is running in dry-run mode --
+ * applies it by adding/removing the affected members.
  * <p>
- * Dry-run is controlled independently of the opt-in YAML flag, via the {@code dryRun} parameter (wired to
- * the {@code githubPermissionsDryRun} system property by callers): {@code manageGitHubPermissions: true} /
- * {@code manageGitHubTeam: true} means "this component/team's GitHub membership should be managed by RPU",
- * while the dry-run flag independently controls whether that management actually mutates GitHub or only
- * computes and logs/reports what it would do. This lets the trusted run exercise the real read+diff+apply
- * code path safely (with real credentials, against real teams) before switching dry-run off.
+ * Dry-run is controlled independently of the opt-in YAML flag, via the {@code dryRunMode} constructor
+ * parameter (wired to the {@code githubPermissionsDryRun} system property by callers): {@code
+ * manageGitHubPermissions: true} / {@code manageGitHubTeam: true} means "this component/team's GitHub
+ * membership should be managed by RPU", while the dry-run flag independently controls whether that
+ * management actually mutates GitHub or only computes and logs/reports what it would do. This lets the
+ * trusted run exercise the real read+diff+apply code path safely (with real credentials, against real
+ * teams) before switching dry-run off.
  * <p>
  * Only ever executes in the trusted, post-merge run -- see the project README for why PR/dry-run builds
  * cannot safely make any live GitHub API calls for this feature at all (a distinct, coarser gate than the
@@ -53,7 +54,15 @@ public final class GitHubPermissionsSyncer {
      */
     private static final String DEFAULT_ORGANIZATION = "jenkinsci";
 
-    private GitHubPermissionsSyncer() {}
+    /**
+     * Whether this instance only computes and logs/reports the diff ({@code true}), or also applies it by
+     * adding/removing the affected members on GitHub ({@code false}).
+     */
+    private final boolean dryRunMode;
+
+    public GitHubPermissionsSyncer(boolean dryRunMode) {
+        this.dryRunMode = dryRunMode;
+    }
 
     /**
      * One managed team's desired state: which GitHub organization it lives in, and which logins should be
@@ -70,30 +79,34 @@ public final class GitHubPermissionsSyncer {
 
     /**
      * Computes the desired vs. actual GitHub team membership diff for all opted-in components and teams,
-     * and writes it as JSON to {@code reportFile}. Equivalent to {@code generateDiffReport(definitionsDir,
-     * teamsDir, reportFile, true)} -- i.e. dry-run, never mutates anything. Kept for callers/tests that only
-     * ever want the report-only behavior.
+     * writes it as JSON to {@code reportFile}, and, unless this instance is in dry-run mode, applies it by
+     * adding/removing the affected members on GitHub. Equivalent to {@code sync(definitionsDir, teamsDir,
+     * reportFile, true)}.
      *
      * @param definitionsDir directory containing component YAML definitions (see {@link Definition})
      * @param teamsDir directory containing cross-repository team YAML definitions (see {@link TeamDefinition})
      * @param reportFile file to write the JSON diff report to
      */
-    public static void generateDiffReport(File definitionsDir, File teamsDir, File reportFile) throws IOException {
-        generateDiffReport(definitionsDir, teamsDir, reportFile, true);
+    public void sync(File definitionsDir, File teamsDir, File reportFile) throws IOException {
+        sync(definitionsDir, teamsDir, reportFile, true);
     }
 
     /**
-     * Computes the desired vs. actual GitHub team membership diff for all opted-in components and teams,
-     * writes it as JSON to {@code reportFile}, and, unless {@code dryRun} is {@code true}, applies it by
-     * adding/removing the affected members on GitHub.
+     * Computes the desired vs. actual GitHub team membership diff for all opted-in components and teams
+     * and, unless this instance is in dry-run mode, applies it by adding/removing the affected members on
+     * GitHub. {@code dryRunMode} (fixed for the lifetime of this instance, set via the constructor) and
+     * {@code writeReport} are independent: {@code dryRunMode} controls whether GitHub is actually mutated,
+     * while {@code writeReport} controls only whether the JSON diff report is written to {@code reportFile}
+     * -- the diff is always computed (and, in dry-run, logged) regardless of {@code writeReport}.
      *
      * @param definitionsDir directory containing component YAML definitions (see {@link Definition})
      * @param teamsDir directory containing cross-repository team YAML definitions (see {@link TeamDefinition})
-     * @param reportFile file to write the JSON diff report to
-     * @param dryRun if {@code true}, only compute and report/log the diff; if {@code false}, also apply it
+     * @param reportFile file to write the JSON diff report to; may be {@code null} if {@code writeReport} is
+     *     {@code false}
+     * @param writeReport if {@code true}, write the JSON diff report to {@code reportFile}; if {@code false},
+     *     skip writing it (e.g. for callers that only care about the applied/logged result)
      */
-    public static void generateDiffReport(File definitionsDir, File teamsDir, File reportFile, boolean dryRun)
-            throws IOException {
+    public void sync(File definitionsDir, File teamsDir, File reportFile, boolean writeReport) throws IOException {
         Map<String, Set<TeamDefinition>> teamsByName = ArtifactoryPermissionsUpdater.loadTeams(teamsDir);
         Map<String, DesiredTeam> desiredByTeamSlug = computeDesiredState(definitionsDir, teamsByName);
 
@@ -102,7 +115,9 @@ public final class GitHubPermissionsSyncer {
                     Level.INFO,
                     "No components have opted into GitHub permissions management "
                             + "(manageGitHubPermissions/manageGitHubTeam); nothing to do");
-            writeReport(reportFile, Map.of(), dryRun);
+            if (writeReport) {
+                writeReport(reportFile, Map.of());
+            }
             return;
         }
 
@@ -132,20 +147,22 @@ public final class GitHubPermissionsSyncer {
             diffsBySlug.put(slug, new TeamDiff(desired.organization, toAdd, toRemove));
         }
 
-        if (dryRun) {
+        if (dryRunMode) {
             logDryRun(diffsBySlug);
         } else {
             applyDiffs(diffsBySlug);
         }
 
-        writeReport(reportFile, diffsBySlug, dryRun);
+        if (writeReport) {
+            writeReport(reportFile, diffsBySlug);
+        }
     }
 
     /**
-     * Logs a summary of what would be changed, without touching GitHub. Used when {@code dryRun} is
+     * Logs a summary of what would be changed, without touching GitHub. Used when {@link #dryRunMode} is
      * {@code true}, so the trusted run's read+diff logic can be exercised safely before enabling apply.
      */
-    private static void logDryRun(Map<String, TeamDiff> diffsBySlug) {
+    private void logDryRun(Map<String, TeamDiff> diffsBySlug) {
         int toAdd = diffsBySlug.values().stream()
                 .mapToInt(diff -> diff.toAdd().size())
                 .sum();
@@ -168,7 +185,7 @@ public final class GitHubPermissionsSyncer {
      * they show up in the JSON report), but do not stop the run -- one bad membership change (e.g. a login
      * that no longer exists) shouldn't block reconciling every other opted-in team.
      */
-    private static void applyDiffs(Map<String, TeamDiff> diffsBySlug) {
+    private void applyDiffs(Map<String, TeamDiff> diffsBySlug) {
         GitHubTeamsAPI api = GitHubTeamsAPI.getInstance();
         int added = 0;
         int removed = 0;
@@ -311,15 +328,14 @@ public final class GitHubPermissionsSyncer {
         }
     }
 
-    private static void writeReport(File reportFile, Map<String, TeamDiff> diffsBySlug, boolean dryRun)
-            throws IOException {
+    private void writeReport(File reportFile, Map<String, TeamDiff> diffsBySlug) throws IOException {
         Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
         JsonObject root = new JsonObject();
         for (Map.Entry<String, TeamDiff> entry : diffsBySlug.entrySet()) {
             TeamDiff diff = entry.getValue();
             JsonObject teamJson = new JsonObject();
             teamJson.addProperty("organization", diff.organization());
-            teamJson.addProperty("dryRun", dryRun);
+            teamJson.addProperty("dryRun", dryRunMode);
             teamJson.add("toAdd", toJsonArray(diff.toAdd()));
             teamJson.add("toRemove", toJsonArray(diff.toRemove()));
             if (!diff.errors().isEmpty()) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
@@ -10,7 +10,10 @@ import java.io.InputStream;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -25,16 +28,20 @@ import org.yaml.snakeyaml.constructor.Constructor;
 
 /**
  * Computes the difference between the desired GitHub team membership (declared in YAML, for components that
- * have opted in via {@code manageGithubPermissions}/{@code manageGithubTeam}) and the actual membership
- * currently on GitHub, and writes it to a JSON report.
+ * have opted in via {@code manageGitHubPermissions}/{@code manageGitHubTeam}) and the actual membership
+ * currently on GitHub, writes it to a JSON report, and -- unless running in dry-run mode -- applies it by
+ * adding/removing the affected members.
  * <p>
- * This is deliberately <b>report-only</b>: no GitHub team membership is ever added or removed by this class.
- * The report is meant to be reviewed by the hosting team during a bake-in period before any reconciliation
- * (actual add/remove of members) is implemented as a follow-up.
+ * Dry-run is controlled independently of the opt-in YAML flag, via the {@code dryRun} parameter (wired to
+ * the {@code githubPermissionsDryRun} system property by callers): {@code manageGitHubPermissions: true} /
+ * {@code manageGitHubTeam: true} means "this component/team's GitHub membership should be managed by RPU",
+ * while the dry-run flag independently controls whether that management actually mutates GitHub or only
+ * computes and logs/reports what it would do. This lets the trusted run exercise the real read+diff+apply
+ * code path safely (with real credentials, against real teams) before switching dry-run off.
  * <p>
- * Only runs against the opt-in managed set (never the whole org), and only ever executes in the trusted,
- * post-merge run -- see the project README for why PR/dry-run builds cannot safely make any live GitHub API
- * calls for this feature.
+ * Only ever executes in the trusted, post-merge run -- see the project README for why PR/dry-run builds
+ * cannot safely make any live GitHub API calls for this feature at all (a distinct, coarser gate than the
+ * dry-run flag described above, which only matters once already inside the trusted run).
  */
 public final class GitHubPermissionsSyncer {
 
@@ -63,13 +70,30 @@ public final class GitHubPermissionsSyncer {
 
     /**
      * Computes the desired vs. actual GitHub team membership diff for all opted-in components and teams,
-     * and writes it as JSON to {@code reportFile}.
+     * and writes it as JSON to {@code reportFile}. Equivalent to {@code generateDiffReport(definitionsDir,
+     * teamsDir, reportFile, true)} -- i.e. dry-run, never mutates anything. Kept for callers/tests that only
+     * ever want the report-only behavior.
      *
      * @param definitionsDir directory containing component YAML definitions (see {@link Definition})
      * @param teamsDir directory containing cross-repository team YAML definitions (see {@link TeamDefinition})
      * @param reportFile file to write the JSON diff report to
      */
     public static void generateDiffReport(File definitionsDir, File teamsDir, File reportFile) throws IOException {
+        generateDiffReport(definitionsDir, teamsDir, reportFile, true);
+    }
+
+    /**
+     * Computes the desired vs. actual GitHub team membership diff for all opted-in components and teams,
+     * writes it as JSON to {@code reportFile}, and, unless {@code dryRun} is {@code true}, applies it by
+     * adding/removing the affected members on GitHub.
+     *
+     * @param definitionsDir directory containing component YAML definitions (see {@link Definition})
+     * @param teamsDir directory containing cross-repository team YAML definitions (see {@link TeamDefinition})
+     * @param reportFile file to write the JSON diff report to
+     * @param dryRun if {@code true}, only compute and report/log the diff; if {@code false}, also apply it
+     */
+    public static void generateDiffReport(File definitionsDir, File teamsDir, File reportFile, boolean dryRun)
+            throws IOException {
         Map<String, Set<TeamDefinition>> teamsByName = ArtifactoryPermissionsUpdater.loadTeams(teamsDir);
         Map<String, DesiredTeam> desiredByTeamSlug = computeDesiredState(definitionsDir, teamsByName);
 
@@ -77,8 +101,8 @@ public final class GitHubPermissionsSyncer {
             LOGGER.log(
                     Level.INFO,
                     "No components have opted into GitHub permissions management "
-                            + "(manageGithubPermissions/manageGithubTeam); nothing to report");
-            writeReport(reportFile, Map.of());
+                            + "(manageGitHubPermissions/manageGitHubTeam); nothing to do");
+            writeReport(reportFile, Map.of(), dryRun);
             return;
         }
 
@@ -108,7 +132,77 @@ public final class GitHubPermissionsSyncer {
             diffsBySlug.put(slug, new TeamDiff(desired.organization, toAdd, toRemove));
         }
 
-        writeReport(reportFile, diffsBySlug);
+        if (dryRun) {
+            logDryRun(diffsBySlug);
+        } else {
+            applyDiffs(diffsBySlug);
+        }
+
+        writeReport(reportFile, diffsBySlug, dryRun);
+    }
+
+    /**
+     * Logs a summary of what would be changed, without touching GitHub. Used when {@code dryRun} is
+     * {@code true}, so the trusted run's read+diff logic can be exercised safely before enabling apply.
+     */
+    private static void logDryRun(Map<String, TeamDiff> diffsBySlug) {
+        int toAdd = diffsBySlug.values().stream()
+                .mapToInt(diff -> diff.toAdd().size())
+                .sum();
+        int toRemove = diffsBySlug.values().stream()
+                .mapToInt(diff -> diff.toRemove().size())
+                .sum();
+        if (toAdd == 0 && toRemove == 0) {
+            return;
+        }
+        LOGGER.log(
+                Level.INFO,
+                "GitHub permissions sync dry-run: would add {0} and remove {1} membership(s) across {2}"
+                        + " team(s); no changes applied (set githubPermissionsDryRun=false to apply)",
+                new Object[] {toAdd, toRemove, diffsBySlug.size()});
+    }
+
+    /**
+     * Applies the computed diff: adds/removes the affected members via {@link GitHubTeamsAPI}. Failures for
+     * an individual membership change are logged and recorded on that team's {@link TeamDiff#errors()} (so
+     * they show up in the JSON report), but do not stop the run -- one bad membership change (e.g. a login
+     * that no longer exists) shouldn't block reconciling every other opted-in team.
+     */
+    private static void applyDiffs(Map<String, TeamDiff> diffsBySlug) {
+        GitHubTeamsAPI api = GitHubTeamsAPI.getInstance();
+        int added = 0;
+        int removed = 0;
+        int failures = 0;
+        for (Map.Entry<String, TeamDiff> entry : diffsBySlug.entrySet()) {
+            String slug = entry.getKey();
+            TeamDiff diff = entry.getValue();
+            for (String login : diff.toAdd()) {
+                try {
+                    api.addTeamMember(diff.organization(), slug, login);
+                    added++;
+                } catch (IOException e) {
+                    failures++;
+                    String message = "Failed to add " + login + " to " + diff.organization() + "/" + slug;
+                    diff.errors().add(message + ": " + e.getMessage());
+                    LOGGER.log(Level.WARNING, message, e);
+                }
+            }
+            for (String login : diff.toRemove()) {
+                try {
+                    api.removeTeamMember(diff.organization(), slug, login);
+                    removed++;
+                } catch (IOException e) {
+                    failures++;
+                    String message = "Failed to remove " + login + " from " + diff.organization() + "/" + slug;
+                    diff.errors().add(message + ": " + e.getMessage());
+                    LOGGER.log(Level.WARNING, message, e);
+                }
+            }
+        }
+        LOGGER.log(
+                Level.INFO,
+                "GitHub permissions sync: added {0}, removed {1} membership(s) across {2} team(s), {3}" + " failure(s)",
+                new Object[] {added, removed, diffsBySlug.size(), failures});
     }
 
     private static Map<String, DesiredTeam> computeDesiredState(
@@ -118,10 +212,10 @@ public final class GitHubPermissionsSyncer {
         // Cross-repository teams (teams/*.yml) that have opted in.
         for (Set<TeamDefinition> definitions : teamsByName.values()) {
             for (TeamDefinition team : definitions) {
-                if (!team.isManageGithubTeam()) {
+                if (!team.isManageGitHubTeam()) {
                     continue;
                 }
-                Set<String> logins = resolveGithubLogins(team.getDeveloperIds(), team.getGithubUsernames());
+                Set<String> logins = resolveGitHubLogins(team.getDeveloperIds(), team.getGitHubUsernames());
                 if (logins.isEmpty()) {
                     continue;
                 }
@@ -145,7 +239,7 @@ public final class GitHubPermissionsSyncer {
                 continue;
             }
 
-            if (!definition.isManageGithubPermissions()) {
+            if (!definition.isManageGitHubPermissions()) {
                 continue;
             }
             String repo = definition.getGithub();
@@ -153,7 +247,7 @@ public final class GitHubPermissionsSyncer {
                 // Already rejected by ArtifactoryPermissionsUpdater's static validation; be defensive here too.
                 LOGGER.log(
                         Level.WARNING,
-                        "Skipping {0}: manageGithubPermissions requires a GitHub repository",
+                        "Skipping {0}: manageGitHubPermissions requires a GitHub repository",
                         file.getName());
                 continue;
             }
@@ -162,7 +256,7 @@ public final class GitHubPermissionsSyncer {
             String repositoryTeam = definition.getRepositoryTeam();
             String teamName = repositoryTeam != null ? repositoryTeam : repoName + " Developers";
 
-            Set<String> logins = resolveGithubLogins(definition.getDeveloperIds(), definition.getGithubUsernames());
+            Set<String> logins = resolveGitHubLogins(definition.getDeveloperIds(), definition.getGitHubUsernames());
             mergeDesired(desiredByTeamSlug, slugify(teamName), organization, logins);
         }
 
@@ -178,10 +272,10 @@ public final class GitHubPermissionsSyncer {
     /**
      * Resolves the desired GitHub login for each entry in {@code developers}: by default, a developer's
      * Jenkins community (LDAP) id is assumed to also be their GitHub login; {@code githubUsernameOverrides}
-     * (an LDAP id -&gt; GitHub login map, see {@link Definition#getGithubUsernames()}/
-     * {@link TeamDefinition#getGithubUsernames()}) can override this for the rare case where they differ.
+     * (an LDAP id -&gt; GitHub login map, see {@link Definition#getGitHubUsernames()}/
+     * {@link TeamDefinition#getGitHubUsernames()}) can override this for the rare case where they differ.
      */
-    static Set<String> resolveGithubLogins(String[] developers, Map<String, String> githubUsernameOverrides) {
+    static Set<String> resolveGitHubLogins(String[] developers, Map<String, String> githubUsernameOverrides) {
         Set<String> logins = new TreeSet<>();
         for (String developer : developers) {
             if (developer == null || developer.isBlank()) {
@@ -205,17 +299,32 @@ public final class GitHubPermissionsSyncer {
         return slug.replaceAll("^-+|-+$", "");
     }
 
-    private record TeamDiff(String organization, Set<String> toAdd, Set<String> toRemove) {}
+    /**
+     * One team's diff for this run: which logins should be added/removed to reconcile desired vs. actual
+     * state, and (populated only when applying, i.e. not dry-run) any per-membership-change errors
+     * encountered -- kept mutable (a plain {@link ArrayList}) so {@link #applyDiffs(Map)} can record
+     * failures against the same {@code TeamDiff} instance that gets serialized into the report.
+     */
+    private record TeamDiff(String organization, Set<String> toAdd, Set<String> toRemove, List<String> errors) {
+        TeamDiff(String organization, Set<String> toAdd, Set<String> toRemove) {
+            this(organization, toAdd, toRemove, new ArrayList<>());
+        }
+    }
 
-    private static void writeReport(File reportFile, Map<String, TeamDiff> diffsBySlug) throws IOException {
+    private static void writeReport(File reportFile, Map<String, TeamDiff> diffsBySlug, boolean dryRun)
+            throws IOException {
         Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
         JsonObject root = new JsonObject();
         for (Map.Entry<String, TeamDiff> entry : diffsBySlug.entrySet()) {
             TeamDiff diff = entry.getValue();
             JsonObject teamJson = new JsonObject();
             teamJson.addProperty("organization", diff.organization());
+            teamJson.addProperty("dryRun", dryRun);
             teamJson.add("toAdd", toJsonArray(diff.toAdd()));
             teamJson.add("toRemove", toJsonArray(diff.toRemove()));
+            if (!diff.errors().isEmpty()) {
+                teamJson.add("errors", toJsonArray(diff.errors()));
+            }
             root.add(entry.getKey(), teamJson);
         }
 
@@ -230,7 +339,7 @@ public final class GitHubPermissionsSyncer {
         });
     }
 
-    private static JsonArray toJsonArray(Set<String> values) {
+    private static JsonArray toJsonArray(Collection<String> values) {
         JsonArray array = new JsonArray();
         values.forEach(array::add);
         return array;

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
@@ -193,10 +193,13 @@ public final class GitHubPermissionsSyncer {
         for (Map.Entry<String, TeamDiff> entry : diffsBySlug.entrySet()) {
             String slug = entry.getKey();
             TeamDiff diff = entry.getValue();
+            List<String> addedLogins = new ArrayList<>();
+            List<String> removedLogins = new ArrayList<>();
             for (String login : diff.toAdd()) {
                 try {
                     api.addTeamMember(diff.organization(), slug, login);
                     added++;
+                    addedLogins.add(login);
                 } catch (IOException e) {
                     failures++;
                     String message = "Failed to add " + login + " to " + diff.organization() + "/" + slug;
@@ -208,12 +211,18 @@ public final class GitHubPermissionsSyncer {
                 try {
                     api.removeTeamMember(diff.organization(), slug, login);
                     removed++;
+                    removedLogins.add(login);
                 } catch (IOException e) {
                     failures++;
                     String message = "Failed to remove " + login + " from " + diff.organization() + "/" + slug;
                     diff.errors().add(message + ": " + e.getMessage());
                     LOGGER.log(Level.WARNING, message, e);
                 }
+            }
+            if (!addedLogins.isEmpty() || !removedLogins.isEmpty()) {
+                LOGGER.log(Level.INFO, "GitHub permissions sync: {0}/{1}: added {2}, removed {3}", new Object[] {
+                    diff.organization(), slug, addedLogins, removedLogins
+                });
             }
         }
         LOGGER.log(
@@ -233,6 +242,7 @@ public final class GitHubPermissionsSyncer {
                     continue;
                 }
                 Set<String> logins = resolveGitHubLogins(team.getDeveloperIds(), team.getGitHubUsernames());
+                logins.addAll(team.getGitHubOnlyUsernames());
                 if (logins.isEmpty()) {
                     continue;
                 }
@@ -274,6 +284,7 @@ public final class GitHubPermissionsSyncer {
             String teamName = repositoryTeam != null ? repositoryTeam : repoName + " Developers";
 
             Set<String> logins = resolveGitHubLogins(definition.getDeveloperIds(), definition.getGitHubUsernames());
+            logins.addAll(definition.getGitHubOnlyUsernames());
             mergeDesired(desiredByTeamSlug, slugify(teamName), organization, logins);
         }
 

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncer.java
@@ -1,0 +1,238 @@
+package io.jenkins.infra.repository_permissions_updater;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+/**
+ * Computes the difference between the desired GitHub team membership (declared in YAML, for components that
+ * have opted in via {@code manageGithubPermissions}/{@code manageGithubTeam}) and the actual membership
+ * currently on GitHub, and writes it to a JSON report.
+ * <p>
+ * This is deliberately <b>report-only</b>: no GitHub team membership is ever added or removed by this class.
+ * The report is meant to be reviewed by the hosting team during a bake-in period before any reconciliation
+ * (actual add/remove of members) is implemented as a follow-up.
+ * <p>
+ * Only runs against the opt-in managed set (never the whole org), and only ever executes in the trusted,
+ * post-merge run -- see the project README for why PR/dry-run builds cannot safely make any live GitHub API
+ * calls for this feature.
+ */
+public final class GitHubPermissionsSyncer {
+
+    private static final Logger LOGGER = Logger.getLogger(GitHubPermissionsSyncer.class.getName());
+
+    /**
+     * Default GitHub organization assumed for cross-repository teams (teams/*.yml), which aren't themselves
+     * tied to a single component's {@code github:} repository.
+     */
+    private static final String DEFAULT_ORGANIZATION = "jenkinsci";
+
+    private GitHubPermissionsSyncer() {}
+
+    /**
+     * One managed team's desired state: which GitHub organization it lives in, and which logins should be
+     * members.
+     */
+    private static final class DesiredTeam {
+        final String organization;
+        final Set<String> logins = new TreeSet<>();
+
+        DesiredTeam(String organization) {
+            this.organization = organization;
+        }
+    }
+
+    /**
+     * Computes the desired vs. actual GitHub team membership diff for all opted-in components and teams,
+     * and writes it as JSON to {@code reportFile}.
+     *
+     * @param definitionsDir directory containing component YAML definitions (see {@link Definition})
+     * @param teamsDir directory containing cross-repository team YAML definitions (see {@link TeamDefinition})
+     * @param reportFile file to write the JSON diff report to
+     */
+    public static void generateDiffReport(File definitionsDir, File teamsDir, File reportFile) throws IOException {
+        Map<String, Set<TeamDefinition>> teamsByName = ArtifactoryPermissionsUpdater.loadTeams(teamsDir);
+        Map<String, DesiredTeam> desiredByTeamSlug = computeDesiredState(definitionsDir, teamsByName);
+
+        if (desiredByTeamSlug.isEmpty()) {
+            LOGGER.log(
+                    Level.INFO,
+                    "No components have opted into GitHub permissions management "
+                            + "(manageGithubPermissions/manageGithubTeam); nothing to report");
+            writeReport(reportFile, Map.of());
+            return;
+        }
+
+        Map<String, Set<String>> slugsByOrganization = new TreeMap<>();
+        for (Map.Entry<String, DesiredTeam> entry : desiredByTeamSlug.entrySet()) {
+            slugsByOrganization
+                    .computeIfAbsent(entry.getValue().organization, unused -> new TreeSet<>())
+                    .add(entry.getKey());
+        }
+
+        Map<String, Set<String>> actualBySlug = new HashMap<>();
+        for (Map.Entry<String, Set<String>> entry : slugsByOrganization.entrySet()) {
+            actualBySlug.putAll(GitHubTeamsAPI.getInstance().fetchTeamMembers(entry.getKey(), entry.getValue()));
+        }
+
+        Map<String, TeamDiff> diffsBySlug = new TreeMap<>();
+        for (Map.Entry<String, DesiredTeam> entry : desiredByTeamSlug.entrySet()) {
+            String slug = entry.getKey();
+            DesiredTeam desired = entry.getValue();
+            Set<String> actual = actualBySlug.getOrDefault(slug, Set.of());
+
+            Set<String> toAdd = new TreeSet<>(desired.logins);
+            toAdd.removeAll(actual);
+            Set<String> toRemove = new TreeSet<>(actual);
+            toRemove.removeAll(desired.logins);
+
+            diffsBySlug.put(slug, new TeamDiff(desired.organization, toAdd, toRemove));
+        }
+
+        writeReport(reportFile, diffsBySlug);
+    }
+
+    private static Map<String, DesiredTeam> computeDesiredState(
+            File definitionsDir, Map<String, Set<TeamDefinition>> teamsByName) throws IOException {
+        Map<String, DesiredTeam> desiredByTeamSlug = new TreeMap<>();
+
+        // Cross-repository teams (teams/*.yml) that have opted in.
+        for (Set<TeamDefinition> definitions : teamsByName.values()) {
+            for (TeamDefinition team : definitions) {
+                if (!team.isManageGithubTeam()) {
+                    continue;
+                }
+                Set<String> logins = resolveGithubLogins(team.getDeveloperIds(), team.getGithubUsernames());
+                if (logins.isEmpty()) {
+                    continue;
+                }
+                mergeDesired(desiredByTeamSlug, slugify(team.getName()), DEFAULT_ORGANIZATION, logins);
+            }
+        }
+
+        // Per-component repository teams that have opted in.
+        Yaml yaml = new Yaml(new Constructor(Definition.class, new LoaderOptions()));
+        for (File file : Objects.requireNonNull(definitionsDir.listFiles())) {
+            if (!file.getName().endsWith(".yml")) {
+                continue;
+            }
+            Definition definition;
+            try (InputStream is = Files.newInputStream(file.toPath())) {
+                definition = yaml.loadAs(is, Definition.class);
+            } catch (Exception e) {
+                throw new IOException("Failed to read " + file.getName(), e);
+            }
+            if (definition == null) {
+                continue;
+            }
+
+            if (!definition.isManageGithubPermissions()) {
+                continue;
+            }
+            String repo = definition.getGithub();
+            if (repo == null) {
+                // Already rejected by ArtifactoryPermissionsUpdater's static validation; be defensive here too.
+                LOGGER.log(
+                        Level.WARNING,
+                        "Skipping {0}: manageGithubPermissions requires a GitHub repository",
+                        file.getName());
+                continue;
+            }
+            String organization = repo.substring(0, repo.indexOf('/'));
+            String repoName = repo.substring(repo.indexOf('/') + 1);
+            String repositoryTeam = definition.getRepositoryTeam();
+            String teamName = repositoryTeam != null ? repositoryTeam : repoName + " Developers";
+
+            Set<String> logins = resolveGithubLogins(definition.getDeveloperIds(), definition.getGithubUsernames());
+            mergeDesired(desiredByTeamSlug, slugify(teamName), organization, logins);
+        }
+
+        return desiredByTeamSlug;
+    }
+
+    private static void mergeDesired(
+            Map<String, DesiredTeam> desiredByTeamSlug, String slug, String organization, Set<String> logins) {
+        DesiredTeam team = desiredByTeamSlug.computeIfAbsent(slug, unused -> new DesiredTeam(organization));
+        team.logins.addAll(logins);
+    }
+
+    /**
+     * Resolves the desired GitHub login for each entry in {@code developers}: by default, a developer's
+     * Jenkins community (LDAP) id is assumed to also be their GitHub login; {@code githubUsernameOverrides}
+     * (an LDAP id -&gt; GitHub login map, see {@link Definition#getGithubUsernames()}/
+     * {@link TeamDefinition#getGithubUsernames()}) can override this for the rare case where they differ.
+     */
+    static Set<String> resolveGithubLogins(String[] developers, Map<String, String> githubUsernameOverrides) {
+        Set<String> logins = new TreeSet<>();
+        for (String developer : developers) {
+            if (developer == null || developer.isBlank()) {
+                continue;
+            }
+            String login = githubUsernameOverrides.getOrDefault(developer, developer);
+            if (login != null && !login.isBlank()) {
+                logins.add(login);
+            }
+        }
+        return logins;
+    }
+
+    /**
+     * Converts a GitHub team display name (e.g. {@code "example-plugin Developers"}) into the slug GitHub
+     * derives for it (e.g. {@code "example-plugin-developers"}): lower-cased, with runs of whitespace and
+     * other non-alphanumeric characters collapsed to single hyphens.
+     */
+    static String slugify(String teamName) {
+        String slug = teamName.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "-");
+        return slug.replaceAll("^-+|-+$", "");
+    }
+
+    private record TeamDiff(String organization, Set<String> toAdd, Set<String> toRemove) {}
+
+    private static void writeReport(File reportFile, Map<String, TeamDiff> diffsBySlug) throws IOException {
+        Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+        JsonObject root = new JsonObject();
+        for (Map.Entry<String, TeamDiff> entry : diffsBySlug.entrySet()) {
+            TeamDiff diff = entry.getValue();
+            JsonObject teamJson = new JsonObject();
+            teamJson.addProperty("organization", diff.organization());
+            teamJson.add("toAdd", toJsonArray(diff.toAdd()));
+            teamJson.add("toRemove", toJsonArray(diff.toRemove()));
+            root.add(entry.getKey(), teamJson);
+        }
+
+        if (reportFile.getParentFile() != null) {
+            Files.createDirectories(reportFile.getParentFile().toPath());
+        }
+        try (Writer writer = Files.newBufferedWriter(reportFile.toPath(), StandardCharsets.UTF_8)) {
+            gson.toJson(root, writer);
+        }
+        LOGGER.log(Level.INFO, "Wrote GitHub permissions diff report for {0} team(s) to {1}", new Object[] {
+            diffsBySlug.size(), reportFile
+        });
+    }
+
+    private static JsonArray toJsonArray(Set<String> values) {
+        JsonArray array = new JsonArray();
+        values.forEach(array::add);
+        return array;
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPI.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPI.java
@@ -6,11 +6,12 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Read-only access to current GitHub team membership, used to compute the diff between the desired state
- * (declared in YAML) and the actual state (on GitHub), for the GitHub permissions report.
+ * Access to current GitHub team membership -- reads to compute the diff between the desired state
+ * (declared in YAML) and the actual state (on GitHub), and, when not running in dry-run mode, the mutating
+ * calls used to reconcile that diff (add/remove team members).
  * <p>
- * This is intentionally read-only: see the README/plan for why GitHub permission reconciliation (including
- * these reads) only ever runs in the trusted, post-merge execution, never in credential-free PR builds.
+ * All of this, reads and writes alike, only ever runs in the trusted, post-merge execution, never in
+ * credential-free PR builds -- see the project README for why.
  */
 public abstract class GitHubTeamsAPI {
 
@@ -30,6 +31,29 @@ public abstract class GitHubTeamsAPI {
     @NonNull
     public abstract Map<String, Set<String>> fetchTeamMembers(
             @NonNull String organization, @NonNull Set<String> teamSlugs) throws IOException;
+
+    /**
+     * Adds a user to a team, with the default {@code member} role (never {@code maintainer} -- this project
+     * never grants GitHub team maintainer/admin rights, only membership).
+     *
+     * @param organization the GitHub organization login (e.g. {@code "jenkinsci"})
+     * @param teamSlug the team slug to add the member to
+     * @param login the GitHub login to add
+     */
+    public abstract void addTeamMember(@NonNull String organization, @NonNull String teamSlug, @NonNull String login)
+            throws IOException;
+
+    /**
+     * Removes a user from a team. Removing the last member of a team is allowed and is not treated as an
+     * error -- org owners always retain the ability to restore access to any repo/team regardless of its
+     * member count.
+     *
+     * @param organization the GitHub organization login (e.g. {@code "jenkinsci"})
+     * @param teamSlug the team slug to remove the member from
+     * @param login the GitHub login to remove
+     */
+    public abstract void removeTeamMember(@NonNull String organization, @NonNull String teamSlug, @NonNull String login)
+            throws IOException;
 
     static synchronized GitHubTeamsAPI getInstance() {
         if (INSTANCE == null) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPI.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPI.java
@@ -1,0 +1,40 @@
+package io.jenkins.infra.repository_permissions_updater;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Read-only access to current GitHub team membership, used to compute the diff between the desired state
+ * (declared in YAML) and the actual state (on GitHub), for the GitHub permissions report.
+ * <p>
+ * This is intentionally read-only: see the README/plan for why GitHub permission reconciliation (including
+ * these reads) only ever runs in the trusted, post-merge execution, never in credential-free PR builds.
+ */
+public abstract class GitHubTeamsAPI {
+
+    static GitHubTeamsAPI INSTANCE = null;
+
+    /**
+     * Fetches the current members (GitHub login names) of the given teams within an organization.
+     * Implementations should batch this into as few HTTP requests as possible, since the managed set can
+     * span thousands of teams.
+     *
+     * @param organization the GitHub organization login (e.g. {@code "jenkinsci"})
+     * @param teamSlugs the team slugs to fetch membership for; teams not found are simply absent from the result
+     * @return a map from team slug to the set of member logins; teams with no members or that don't exist
+     *         are mapped to an empty set rather than omitted, so callers can distinguish "no members" from
+     *         "not queried"
+     */
+    @NonNull
+    public abstract Map<String, Set<String>> fetchTeamMembers(
+            @NonNull String organization, @NonNull Set<String> teamSlugs) throws IOException;
+
+    static synchronized GitHubTeamsAPI getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new GitHubTeamsAPIImpl();
+        }
+        return INSTANCE;
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPIImpl.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPIImpl.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -24,15 +25,17 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
- * Fetches current GitHub team membership using the GraphQL API, batching many teams into as few requests as
+ * Reads current GitHub team membership using the GraphQL API, batching many teams into as few requests as
  * possible (via query aliases) to stay well within rate limits even when the managed set grows into the
- * thousands of teams. Based on the bulk-query approach prototyped at
- * https://gist.github.com/halkeye/c1e8348c8ac4cf8d476376b43df2bf6e
+ * thousands of teams (based on the bulk-query approach prototyped at
+ * https://gist.github.com/halkeye/c1e8348c8ac4cf8d476376b43df2bf6e), and applies membership changes
+ * (add/remove) via the REST API, which is what GitHub exposes for team membership mutations.
  */
 class GitHubTeamsAPIImpl extends GitHubTeamsAPI {
     private static final Logger LOGGER = Logger.getLogger(GitHubTeamsAPIImpl.class.getName());
 
     private static final String GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+    private static final String GITHUB_REST_URL = "https://api.github.com";
     private static final String GITHUB_TOKEN = System.getenv("GITHUB_TOKEN");
 
     /** Number of teams queried (via aliased sub-queries) per GraphQL request. */
@@ -59,6 +62,25 @@ class GitHubTeamsAPIImpl extends GitHubTeamsAPI {
             result.putIfAbsent(slug, Set.of());
         }
         return result;
+    }
+
+    @Override
+    public void addTeamMember(@NonNull String organization, @NonNull String teamSlug, @NonNull String login)
+            throws IOException {
+        JsonObject body = new JsonObject();
+        // Always "member", never "maintainer" - this project only ever manages membership, not team admin rights.
+        body.addProperty("role", "member");
+        restRequest("PUT", membershipUrl(organization, teamSlug, login), body.toString());
+    }
+
+    @Override
+    public void removeTeamMember(@NonNull String organization, @NonNull String teamSlug, @NonNull String login)
+            throws IOException {
+        restRequest("DELETE", membershipUrl(organization, teamSlug, login), null);
+    }
+
+    private static String membershipUrl(String organization, String teamSlug, String login) {
+        return GITHUB_REST_URL + "/orgs/" + organization + "/teams/" + teamSlug + "/memberships/" + login;
     }
 
     private Map<String, Set<String>> fetchBatch(String organization, List<String> slugs) throws IOException {
@@ -158,6 +180,57 @@ class GitHubTeamsAPIImpl extends GitHubTeamsAPI {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IOException("Interrupted while retrying GitHub GraphQL request", e);
+            }
+        }
+        throw lastError;
+    }
+
+    /**
+     * Issues a REST API request (used for team membership mutations, which GitHub does not expose via
+     * GraphQL), retrying transient failures the same way {@link #postGraphQl(String)} does.
+     *
+     * @param method HTTP method, e.g. {@code "PUT"}/{@code "DELETE"}
+     * @param url full request URL
+     * @param jsonBody request body to send, or {@code null} for a request with no body (e.g. DELETE)
+     */
+    @SuppressFBWarnings(
+            value = "URLCONNECTION_SSRF_FD",
+            justification = "url is built from the constant GitHub REST API host plus already-validated"
+                    + " organization/teamSlug/login segments, not arbitrary user input.")
+    private void restRequest(String method, String url, String jsonBody) throws IOException {
+        int attemptNumber = 1;
+        int maxAttempts = 3;
+        IOException lastError = null;
+        while (attemptNumber <= maxAttempts) {
+            HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+            conn.setRequestProperty("Authorization", "Bearer " + GITHUB_TOKEN);
+            conn.setRequestProperty("Accept", "application/vnd.github+json");
+            conn.setRequestMethod(method);
+
+            if (jsonBody != null) {
+                conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+                conn.setDoOutput(true);
+                try (OutputStreamWriter osw = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8)) {
+                    osw.write(jsonBody);
+                }
+            }
+
+            int responseCode = conn.getResponseCode();
+            if (responseCode >= 200 && responseCode < 300) {
+                conn.disconnect();
+                return;
+            }
+
+            lastError = new IOException(method + " " + url + " failed with response code " + responseCode);
+            LOGGER.log(Level.WARNING, "Attempt {0}/{1} of {2} {3} failed with code {4}", new Object[] {
+                attemptNumber, maxAttempts, method, url, responseCode
+            });
+            attemptNumber++;
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while retrying GitHub REST request", e);
             }
         }
         throw lastError;

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPIImpl.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/GitHubTeamsAPIImpl.java
@@ -1,0 +1,171 @@
+package io.jenkins.infra.repository_permissions_updater;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * Fetches current GitHub team membership using the GraphQL API, batching many teams into as few requests as
+ * possible (via query aliases) to stay well within rate limits even when the managed set grows into the
+ * thousands of teams. Based on the bulk-query approach prototyped at
+ * https://gist.github.com/halkeye/c1e8348c8ac4cf8d476376b43df2bf6e
+ */
+class GitHubTeamsAPIImpl extends GitHubTeamsAPI {
+    private static final Logger LOGGER = Logger.getLogger(GitHubTeamsAPIImpl.class.getName());
+
+    private static final String GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+    private static final String GITHUB_TOKEN = System.getenv("GITHUB_TOKEN");
+
+    /** Number of teams queried (via aliased sub-queries) per GraphQL request. */
+    private static final int BATCH_SIZE = 50;
+
+    /** Max team members fetched per team; teams with more members would need pagination (not yet implemented). */
+    private static final int MAX_MEMBERS_PER_TEAM = 100;
+
+    @NonNull
+    @Override
+    public Map<String, Set<String>> fetchTeamMembers(@NonNull String organization, @NonNull Set<String> teamSlugs)
+            throws IOException {
+        Map<String, Set<String>> result = new HashMap<>();
+        List<String> slugs = new ArrayList<>(teamSlugs);
+
+        for (int start = 0; start < slugs.size(); start += BATCH_SIZE) {
+            List<String> batch = slugs.subList(start, Math.min(start + BATCH_SIZE, slugs.size()));
+            result.putAll(fetchBatch(organization, batch));
+        }
+
+        // Teams that don't exist (or have no members) on GitHub yet are reported as empty, not omitted, so
+        // that callers can compute "everyone in the desired set needs to be added" diffs correctly.
+        for (String slug : teamSlugs) {
+            result.putIfAbsent(slug, Set.of());
+        }
+        return result;
+    }
+
+    private Map<String, Set<String>> fetchBatch(String organization, List<String> slugs) throws IOException {
+        Map<String, String> aliasToSlug = new HashMap<>();
+        StringBuilder subQueries = new StringBuilder();
+        int i = 0;
+        for (String slug : slugs) {
+            String alias = "t" + (i++);
+            aliasToSlug.put(alias, slug);
+            subQueries
+                    .append(alias)
+                    .append(": team(slug: ")
+                    .append(gsonString(slug))
+                    .append(") { slug members(first: ")
+                    .append(MAX_MEMBERS_PER_TEAM)
+                    .append(") { totalCount nodes { login } } }\n");
+        }
+
+        String query = "query { organization(login: " + gsonString(organization) + ") {\n" + subQueries + "} }";
+
+        JsonObject response = postGraphQl(query);
+        Map<String, Set<String>> membersBySlug = new HashMap<>();
+
+        JsonObject data = response.getAsJsonObject("data");
+        JsonObject org = data == null ? null : data.getAsJsonObject("organization");
+        if (org == null) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "GraphQL response for organization ''{0}'' had no data, skipping batch",
+                    organization);
+            return membersBySlug;
+        }
+
+        for (Map.Entry<String, String> entry : aliasToSlug.entrySet()) {
+            JsonElement teamElement = org.get(entry.getKey());
+            if (teamElement == null || teamElement.isJsonNull()) {
+                // Team doesn't exist (yet) on GitHub - treated as empty by the caller.
+                continue;
+            }
+            JsonObject team = teamElement.getAsJsonObject();
+            JsonObject membersObj = team.getAsJsonObject("members");
+            int totalCount = membersObj.get("totalCount").getAsInt();
+            if (totalCount > MAX_MEMBERS_PER_TEAM) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Team ''{0}'' has {1} members, exceeding the {2} fetched per request; pagination not yet"
+                                + " implemented, diff for this team may be incomplete",
+                        new Object[] {entry.getValue(), totalCount, MAX_MEMBERS_PER_TEAM});
+            }
+            JsonArray nodes = membersObj.getAsJsonArray("nodes");
+            Set<String> logins = new TreeSet<>();
+            for (JsonElement node : nodes) {
+                logins.add(node.getAsJsonObject().get("login").getAsString());
+            }
+            membersBySlug.put(entry.getValue(), logins);
+        }
+        return membersBySlug;
+    }
+
+    private JsonObject postGraphQl(String query) throws IOException {
+        JsonObject body = new JsonObject();
+        body.addProperty("query", query);
+
+        int responseCode;
+        int attemptNumber = 1;
+        int maxAttempts = 3;
+        IOException lastError = null;
+        while (attemptNumber <= maxAttempts) {
+            URL url = URI.create(GITHUB_GRAPHQL_URL).toURL();
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Authorization", "Bearer " + GITHUB_TOKEN);
+            conn.setRequestProperty("Accept", "application/vnd.github+json");
+            conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+
+            try (OutputStreamWriter osw = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8)) {
+                osw.write(body.toString());
+            }
+
+            responseCode = conn.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                try (BufferedReader reader =
+                        new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                    String text = reader.lines().collect(Collectors.joining());
+                    return JsonParser.parseString(text).getAsJsonObject();
+                }
+            }
+
+            lastError = new IOException("GraphQL request failed with response code " + responseCode);
+            LOGGER.log(Level.WARNING, "Attempt {0}/{1} to query GitHub GraphQL API failed with code {2}", new Object[] {
+                attemptNumber, maxAttempts, responseCode
+            });
+            attemptNumber++;
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while retrying GitHub GraphQL request", e);
+            }
+        }
+        throw lastError;
+    }
+
+    private static String gsonString(String value) {
+        JsonArray tmp = new JsonArray();
+        tmp.add(value);
+        return tmp.get(0).toString();
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/TeamDefinition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/TeamDefinition.java
@@ -1,9 +1,26 @@
 package io.jenkins.infra.repository_permissions_updater;
 
+import java.util.Map;
+
 public class TeamDefinition {
 
     private String name = "";
-    private String[] developers = new String[0];
+
+    /**
+     * Each entry is either a plain string (legacy format: a Jenkins community/LDAP id, used for Artifactory
+     * permissions), or a mapping with both {@code ldap} and {@code github} keys (new format: ties an LDAP id
+     * to a GitHub login 1-to-1), so the two can differ when needed. See {@link #getDevelopers()} and
+     * {@link #getGithubUsernames()}.
+     */
+    private Object[] developers = new Object[0];
+
+    /**
+     * Opt-in flag: if {@code true}, RPU will reconcile GitHub team membership for this cross-repository
+     * team, using {@link #developers} (see {@link #getGithubUsernames()} for how GitHub logins are
+     * resolved), when granted to a repository via {@link Definition.AdditionalGitHubTeam}. Defaults to
+     * {@code false}.
+     */
+    private boolean manageGithubTeam;
 
     public String getName() {
         return name;
@@ -13,11 +30,36 @@ public class TeamDefinition {
         this.name = name;
     }
 
-    public String[] getDevelopers() {
+    public Object[] getDevelopers() {
         return developers.clone();
     }
 
-    public void setDevelopers(String[] developers) {
+    public void setDevelopers(Object[] developers) {
         this.developers = developers.clone();
+    }
+
+    /**
+     * Returns the Jenkins community (LDAP) id for every {@link #developers} entry (see
+     * {@link Definition#getDeveloperIds()} for details).
+     */
+    public String[] getDeveloperIds() {
+        return DeveloperEntries.toLdapIds(developers);
+    }
+
+    public boolean isManageGithubTeam() {
+        return manageGithubTeam;
+    }
+
+    public void setManageGithubTeam(boolean manageGithubTeam) {
+        this.manageGithubTeam = manageGithubTeam;
+    }
+
+    /**
+     * Returns the GitHub login to use for each {@link #developers} entry declared using the
+     * {@code {ldap, github}} mapping form, keyed by that entry's LDAP id. Entries declared as a plain string
+     * are not included here -- callers should treat the LDAP id itself as the GitHub login for those.
+     */
+    public Map<String, String> getGithubUsernames() {
+        return DeveloperEntries.extractGithubUsernames(developers);
     }
 }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/TeamDefinition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/TeamDefinition.java
@@ -1,6 +1,7 @@
 package io.jenkins.infra.repository_permissions_updater;
 
 import java.util.Map;
+import java.util.Set;
 
 public class TeamDefinition {
 
@@ -8,9 +9,11 @@ public class TeamDefinition {
 
     /**
      * Each entry is either a plain string (legacy format: a Jenkins community/LDAP id, used for Artifactory
-     * permissions), or a mapping with both {@code ldap} and {@code github} keys (new format: ties an LDAP id
-     * to a GitHub login 1-to-1), so the two can differ when needed. See {@link #getDevelopers()} and
-     * {@link #getGitHubUsernames()}.
+     * permissions), a mapping with both {@code ldap} and {@code github} keys (ties an LDAP id to a GitHub
+     * login 1-to-1, so the two can differ when needed), or a mapping with only a {@code github} key (a
+     * developer with a GitHub login but no Jenkins community/LDAP account -- GitHub permissions management
+     * only, useful for backfill). See {@link #getDevelopers()}, {@link #getGitHubUsernames()}, and
+     * {@link #getGitHubOnlyUsernames()}.
      */
     private Object[] developers = new Object[0];
 
@@ -61,5 +64,14 @@ public class TeamDefinition {
      */
     public Map<String, String> getGitHubUsernames() {
         return DeveloperEntries.extractGitHubUsernames(developers);
+    }
+
+    /**
+     * Returns the GitHub login for each {@link #developers} entry declared using the GitHub-only mapping
+     * form ({@code {github: ...}}, no {@code ldap} key) -- developers with a GitHub login but no Jenkins
+     * community (LDAP) account, so they never appear in {@link #getDeveloperIds()}.
+     */
+    public Set<String> getGitHubOnlyUsernames() {
+        return DeveloperEntries.extractGitHubOnlyLogins(developers);
     }
 }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/TeamDefinition.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/TeamDefinition.java
@@ -10,17 +10,17 @@ public class TeamDefinition {
      * Each entry is either a plain string (legacy format: a Jenkins community/LDAP id, used for Artifactory
      * permissions), or a mapping with both {@code ldap} and {@code github} keys (new format: ties an LDAP id
      * to a GitHub login 1-to-1), so the two can differ when needed. See {@link #getDevelopers()} and
-     * {@link #getGithubUsernames()}.
+     * {@link #getGitHubUsernames()}.
      */
     private Object[] developers = new Object[0];
 
     /**
      * Opt-in flag: if {@code true}, RPU will reconcile GitHub team membership for this cross-repository
-     * team, using {@link #developers} (see {@link #getGithubUsernames()} for how GitHub logins are
+     * team, using {@link #developers} (see {@link #getGitHubUsernames()} for how GitHub logins are
      * resolved), when granted to a repository via {@link Definition.AdditionalGitHubTeam}. Defaults to
      * {@code false}.
      */
-    private boolean manageGithubTeam;
+    private boolean manageGitHubTeam;
 
     public String getName() {
         return name;
@@ -46,12 +46,12 @@ public class TeamDefinition {
         return DeveloperEntries.toLdapIds(developers);
     }
 
-    public boolean isManageGithubTeam() {
-        return manageGithubTeam;
+    public boolean isManageGitHubTeam() {
+        return manageGitHubTeam;
     }
 
-    public void setManageGithubTeam(boolean manageGithubTeam) {
-        this.manageGithubTeam = manageGithubTeam;
+    public void setManageGitHubTeam(boolean manageGitHubTeam) {
+        this.manageGitHubTeam = manageGitHubTeam;
     }
 
     /**
@@ -59,7 +59,7 @@ public class TeamDefinition {
      * {@code {ldap, github}} mapping form, keyed by that entry's LDAP id. Entries declared as a plain string
      * are not included here -- callers should treat the LDAP id itself as the GitHub login for those.
      */
-    public Map<String, String> getGithubUsernames() {
-        return DeveloperEntries.extractGithubUsernames(developers);
+    public Map<String, String> getGitHubUsernames() {
+        return DeveloperEntries.extractGitHubUsernames(developers);
     }
 }

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/RepositoryPermissionsUpdaterCLI.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/RepositoryPermissionsUpdaterCLI.java
@@ -1,6 +1,7 @@
 package io.jenkins.infra.repository_permissions_updater.cli;
 
 import io.jenkins.infra.repository_permissions_updater.cli.commands.CheckHostingCommand;
+import io.jenkins.infra.repository_permissions_updater.cli.commands.GitHubSyncCommand;
 import io.jenkins.infra.repository_permissions_updater.cli.commands.HostCommand;
 import io.jenkins.infra.repository_permissions_updater.cli.commands.SyncCommand;
 import picocli.CommandLine;
@@ -15,7 +16,7 @@ import picocli.CommandLine.Command;
         description = "Repository Permissions Updater - Manage Jenkins plugin permissions",
         mixinStandardHelpOptions = true,
         version = "1.0-SNAPSHOT",
-        subcommands = {SyncCommand.class, CheckHostingCommand.class, HostCommand.class})
+        subcommands = {SyncCommand.class, CheckHostingCommand.class, HostCommand.class, GitHubSyncCommand.class})
 public class RepositoryPermissionsUpdaterCLI implements Runnable {
 
     public static void main(String[] args) {

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/GitHubSyncCommand.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/GitHubSyncCommand.java
@@ -1,0 +1,56 @@
+package io.jenkins.infra.repository_permissions_updater.cli.commands;
+
+import io.jenkins.infra.repository_permissions_updater.GitHubPermissionsSyncer;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+/**
+ * Computes the GitHub permissions diff (desired vs. actual team membership for opted-in components/teams),
+ * and either reports it or applies it, without touching Artifactory at all. Useful for testing
+ * {@code manageGitHubPermissions}/{@code manageGitHubTeam} changes for one or a few components in isolation,
+ * e.g. against a checkout containing only {@code permissions/plugin-slack.yml}.
+ * <p>
+ * Requires a {@code GITHUB_TOKEN} environment variable with enough access to read (and, if not running in
+ * dry-run mode, write) membership of the teams involved (an org member's token with {@code read:org} scope
+ * at minimum for reads; adding/removing members requires the token's owner to be a maintainer of those teams
+ * or an org owner).
+ * <p>
+ * Configuration is via system properties (see Jenkinsfile for examples of the same properties used by the
+ * {@code sync} command):
+ * <ul>
+ *   <li>{@code definitionsDir} (default {@code ./permissions})</li>
+ *   <li>{@code teamsDir} (default {@code ./teams})</li>
+ *   <li>{@code githubDiffOutput} (default {@code ./json/github-permissions-diff.json})</li>
+ *   <li>{@code githubPermissionsDryRun} (default {@code true}): when {@code true}, only computes and
+ *       logs/reports the diff; when {@code false}, also applies it (adds/removes the affected GitHub team
+ *       members). Defaults to {@code true} so running this command is safe by default -- pass
+ *       {@code -DgithubPermissionsDryRun=false} deliberately to actually mutate GitHub.</li>
+ * </ul>
+ */
+@Command(
+        name = "github-sync",
+        description = "Compute (and optionally apply) the GitHub permissions diff for opted-in components/teams"
+                + " (no Artifactory calls)",
+        mixinStandardHelpOptions = true)
+public class GitHubSyncCommand implements Callable<Integer> {
+
+    @Override
+    public Integer call() throws Exception {
+        File definitionsDir = new File(System.getProperty("definitionsDir", "./permissions"));
+        File teamsDir = new File(System.getProperty("teamsDir", "./teams"));
+        File reportFile = new File(System.getProperty("githubDiffOutput", "./json/github-permissions-diff.json"));
+        boolean dryRun = Boolean.parseBoolean(System.getProperty("githubPermissionsDryRun", "true"));
+
+        File parent = reportFile.getParentFile();
+        if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
+            throw new IOException("Failed to create output directory " + parent.getPath());
+        }
+
+        GitHubPermissionsSyncer.generateDiffReport(definitionsDir, teamsDir, reportFile, dryRun);
+        System.out.println("Wrote GitHub permissions diff report to " + reportFile.getPath()
+                + (dryRun ? " (dry-run, nothing applied)" : " (applied changes to GitHub)"));
+        return 0;
+    }
+}

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/GitHubSyncCommand.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/GitHubSyncCommand.java
@@ -48,7 +48,7 @@ public class GitHubSyncCommand implements Callable<Integer> {
             throw new IOException("Failed to create output directory " + parent.getPath());
         }
 
-        GitHubPermissionsSyncer.generateDiffReport(definitionsDir, teamsDir, reportFile, dryRun);
+        new GitHubPermissionsSyncer(dryRun).sync(definitionsDir, teamsDir, reportFile);
         System.out.println("Wrote GitHub permissions diff report to " + reportFile.getPath()
                 + (dryRun ? " (dry-run, nothing applied)" : " (applied changes to GitHub)"));
         return 0;

--- a/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/SyncCommand.java
+++ b/src/main/java/io/jenkins/infra/repository_permissions_updater/cli/commands/SyncCommand.java
@@ -1,11 +1,16 @@
 package io.jenkins.infra.repository_permissions_updater.cli.commands;
 
 import io.jenkins.infra.repository_permissions_updater.ArtifactoryPermissionsUpdater;
+import io.jenkins.infra.repository_permissions_updater.GitHubPermissionsSyncer;
+import java.io.File;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import picocli.CommandLine.Command;
 
 /**
- * Command to sync permissions to Artifactory.
+ * Command to sync permissions to Artifactory, and (independently) reconcile GitHub team membership for all
+ * opted-in components/teams ({@code manageGitHubPermissions}/{@code manageGitHubTeam}).
  * Configuration is via system properties (see Jenkinsfile for examples).
  */
 @Command(
@@ -14,9 +19,49 @@ import picocli.CommandLine.Command;
         mixinStandardHelpOptions = true)
 public class SyncCommand implements Callable<Integer> {
 
+    private static final Logger LOGGER = Logger.getLogger(SyncCommand.class.getName());
+
+    /**
+     * Independent of the {@code dryRun} flag (read once in {@link #call()} and passed to
+     * {@link ArtifactoryPermissionsUpdater}'s constructor, rather than each class re-reading the system
+     * property itself): controls whether GitHub permissions management (for components that have opted in
+     * via {@code manageGitHubPermissions}/{@code manageGitHubTeam}) actually mutates GitHub team membership,
+     * or only computes and logs/reports the diff. Defaults to {@code true} (safe, report-only) so this stays
+     * report-only until deliberately turned off, e.g. via {@code -DgithubPermissionsDryRun=false}. Has no
+     * effect when {@code dryRun} is {@code true}, since GitHub permissions sync doesn't run in dry-run/PR
+     * builds at all (no credentials).
+     */
+    private static final boolean GITHUB_PERMISSIONS_DRY_RUN =
+            Boolean.parseBoolean(System.getProperty("githubPermissionsDryRun", "true"));
+
     @Override
     public Integer call() throws Exception {
-        ArtifactoryPermissionsUpdater.syncPermissions();
+        boolean dryRun = Boolean.getBoolean("dryRun");
+
+        new ArtifactoryPermissionsUpdater(dryRun).syncPermissions();
+
+        /*
+         * Reconcile GitHub team membership for all opted-in components/teams (manageGitHubPermissions /
+         * manageGitHubTeam), writing a JSON diff report either way. Whether this actually mutates GitHub or
+         * only computes and logs/reports the diff is controlled independently by the
+         * "githubPermissionsDryRun" system property -- see GitHubPermissionsSyncer's class javadoc. Wrapped
+         * in try/catch so a GitHub-sync failure doesn't fail the whole command after Artifactory sync has
+         * already succeeded.
+         */
+        if (!dryRun) {
+            try {
+                File definitionsDir = new File(System.getProperty("definitionsDir", "./permissions"));
+                File artifactoryApiDir = new File(System.getProperty("artifactoryApiTempDir", "./json"));
+                new GitHubPermissionsSyncer(GITHUB_PERMISSIONS_DRY_RUN)
+                        .sync(
+                                definitionsDir,
+                                new File("teams/"),
+                                new File(artifactoryApiDir, "github-permissions-diff.json"));
+            } catch (Exception ex) {
+                LOGGER.log(Level.WARNING, "Failed to sync GitHub permissions", ex);
+            }
+        }
+
         return 0;
     }
 }

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntriesTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/DeveloperEntriesTest.java
@@ -1,0 +1,57 @@
+package io.jenkins.infra.repository_permissions_updater;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DeveloperEntriesTest {
+
+    @Test
+    void extractLdapIdReturnsNullForGitHubOnlyEntry() {
+        assertNull(DeveloperEntries.extractLdapId(Map.of("github", "someuser")));
+    }
+
+    @Test
+    void extractLdapIdReturnsLdapForPlainStringAndMappingEntries() {
+        assertEquals("alice", DeveloperEntries.extractLdapId("alice"));
+        assertEquals("bob", DeveloperEntries.extractLdapId(Map.of("ldap", "bob", "github", "bob-gh")));
+    }
+
+    @Test
+    void toLdapIdsSkipsGitHubOnlyEntries() {
+        Object[] developers = {
+            "alice", Map.of("ldap", "bob", "github", "bob-gh"), Map.of("github", "no-ldap-user"),
+        };
+
+        assertArrayEquals(new String[] {"alice", "bob"}, DeveloperEntries.toLdapIds(developers));
+    }
+
+    @Test
+    void extractGitHubOnlyLoginsReturnsOnlyGitHubOnlyEntries() {
+        Object[] developers = {
+            "alice", Map.of("ldap", "bob", "github", "bob-gh"), Map.of("github", "no-ldap-user"),
+        };
+
+        assertEquals(Set.of("no-ldap-user"), DeveloperEntries.extractGitHubOnlyLogins(developers));
+    }
+
+    @Test
+    void extractGitHubUsernamesDoesNotIncludeGitHubOnlyEntries() {
+        Object[] developers = {
+            "alice", Map.of("ldap", "bob", "github", "bob-gh"), Map.of("github", "no-ldap-user"),
+        };
+
+        assertEquals(Map.of("bob", "bob-gh"), DeveloperEntries.extractGitHubUsernames(developers));
+    }
+
+    @Test
+    void extractDedupKeyUsesGitHubLoginWhenNoLdapIsPresent() {
+        assertEquals("github:no-ldap-user", DeveloperEntries.extractDedupKey(Map.of("github", "no-ldap-user")));
+        assertEquals("bob", DeveloperEntries.extractDedupKey(Map.of("ldap", "bob", "github", "bob-gh")));
+        assertEquals("alice", DeveloperEntries.extractDedupKey("alice"));
+    }
+}

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
@@ -49,7 +49,7 @@ class GitHubPermissionsSyncerTest {
         GitHubTeamsAPI.INSTANCE = stub;
 
         File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
-        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report);
+        new GitHubPermissionsSyncer(true).sync(permissions, teams, report);
 
         assertEquals("jenkinsci", stub.lastOrganization);
         assertEquals(Set.of("example-plugin-developers"), stub.lastTeamSlugs);
@@ -82,7 +82,7 @@ class GitHubPermissionsSyncerTest {
         GitHubTeamsAPI.INSTANCE = stub;
 
         File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
-        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report);
+        new GitHubPermissionsSyncer(true).sync(permissions, teams, report);
 
         JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
         JsonObject team = json.getAsJsonObject("example-plugin-developers");
@@ -107,7 +107,7 @@ class GitHubPermissionsSyncerTest {
         GitHubTeamsAPI.INSTANCE = stub;
 
         File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
-        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report);
+        new GitHubPermissionsSyncer(true).sync(permissions, teams, report);
 
         assertTrue(stub.fetchCalls == 0, "Should not call the GitHub API when nothing has opted in");
         JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
@@ -134,7 +134,7 @@ class GitHubPermissionsSyncerTest {
         GitHubTeamsAPI.INSTANCE = stub;
 
         File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
-        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report, true);
+        new GitHubPermissionsSyncer(true).sync(permissions, teams, report);
 
         assertTrue(stub.added.isEmpty(), "Dry-run must not add anyone");
         assertTrue(stub.removed.isEmpty(), "Dry-run must not remove anyone");
@@ -166,7 +166,7 @@ class GitHubPermissionsSyncerTest {
         GitHubTeamsAPI.INSTANCE = stub;
 
         File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
-        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report, false);
+        new GitHubPermissionsSyncer(false).sync(permissions, teams, report);
 
         assertEquals(List.of("example-plugin-developers:alice"), stub.added);
         assertEquals(List.of("example-plugin-developers:carol"), stub.removed);
@@ -199,7 +199,7 @@ class GitHubPermissionsSyncerTest {
         GitHubTeamsAPI.INSTANCE = stub;
 
         File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
-        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report, false);
+        new GitHubPermissionsSyncer(false).sync(permissions, teams, report);
 
         // "alice" (add) and "carol" (remove) fail; "dave" (remove) still succeeds despite those failures.
         assertTrue(stub.added.isEmpty());
@@ -208,6 +208,57 @@ class GitHubPermissionsSyncerTest {
         JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
         JsonObject team = json.getAsJsonObject("example-plugin-developers");
         assertEquals(2, team.getAsJsonArray("errors").size());
+    }
+
+    @Test
+    void writeReportFalseSkipsReportButStillApplies() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - "bob"
+                manageGitHubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of("bob", "carol")));
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        // No report file is passed (and none should be needed) since writeReport is false.
+        new GitHubPermissionsSyncer(false).sync(permissions, teams, null, false);
+
+        assertEquals(List.of("example-plugin-developers:alice"), stub.added);
+        assertEquals(List.of("example-plugin-developers:carol"), stub.removed);
+    }
+
+    @Test
+    void writeReportFalseSkipsReportInDryRunToo() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - "bob"
+                manageGitHubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of("bob", "carol")));
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        new GitHubPermissionsSyncer(true).sync(permissions, teams, null, false);
+
+        assertTrue(stub.added.isEmpty(), "Dry-run must not add anyone even when the report is skipped");
+        assertTrue(stub.removed.isEmpty(), "Dry-run must not remove anyone even when the report is skipped");
     }
 
     @Test

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.infra.repository_permissions_updater;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
@@ -9,14 +10,17 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests the report-only GitHub permissions diff generation: desired state (from opted-in YAML) vs. actual
- * state (mocked GitHub API), with no live network access and no mutation of any kind.
+ * Tests GitHub permissions diff generation and application: desired state (from opted-in YAML) vs. actual
+ * state (mocked GitHub API), with no live network access. Covers both dry-run (report-only, no mutation) and
+ * apply (dryRun=false, mutates via the mocked API) modes.
  */
 class GitHubPermissionsSyncerTest {
 
@@ -36,7 +40,7 @@ class GitHubPermissionsSyncerTest {
                 developers:
                   - "alice"
                   - "bob"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """);
         File teams = Files.createTempDirectory("teams").toFile();
         teams.deleteOnExit();
@@ -58,7 +62,7 @@ class GitHubPermissionsSyncerTest {
     }
 
     @Test
-    void ldapGithubMappingEntryAppliesToDesiredState() throws IOException {
+    void ldapGitHubMappingEntryAppliesToDesiredState() throws IOException {
         File permissions = Files.createTempDirectory("permissions").toFile();
         permissions.deleteOnExit();
         Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
@@ -69,7 +73,7 @@ class GitHubPermissionsSyncerTest {
                   - "alice"
                   - ldap: "someldapid"
                     github: "bob-gh"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """);
         File teams = Files.createTempDirectory("teams").toFile();
         teams.deleteOnExit();
@@ -111,7 +115,103 @@ class GitHubPermissionsSyncerTest {
     }
 
     @Test
-    void slugifyMatchesGithubTeamSlugConvention() {
+    void dryRunDoesNotMutateAnything() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - "bob"
+                manageGitHubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of("bob", "carol")));
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
+        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report, true);
+
+        assertTrue(stub.added.isEmpty(), "Dry-run must not add anyone");
+        assertTrue(stub.removed.isEmpty(), "Dry-run must not remove anyone");
+
+        JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
+        JsonObject team = json.getAsJsonObject("example-plugin-developers");
+        assertTrue(team.get("dryRun").getAsBoolean());
+        assertEquals("[\"alice\"]", team.getAsJsonArray("toAdd").toString());
+        assertEquals("[\"carol\"]", team.getAsJsonArray("toRemove").toString());
+    }
+
+    @Test
+    void applyingDiffAddsAndRemovesMembersViaApi() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - "bob"
+                manageGitHubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of("bob", "carol")));
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
+        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report, false);
+
+        assertEquals(List.of("example-plugin-developers:alice"), stub.added);
+        assertEquals(List.of("example-plugin-developers:carol"), stub.removed);
+
+        JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
+        JsonObject team = json.getAsJsonObject("example-plugin-developers");
+        assertFalse(team.get("dryRun").getAsBoolean());
+        assertFalse(team.has("errors"), "No errors expected when every mutation succeeds");
+    }
+
+    @Test
+    void applyFailuresAreLoggedInReportButDoNotStopOtherMutations() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - "bob"
+                manageGitHubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub =
+                new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of("bob", "carol", "dave")));
+        stub.loginsToFailOn = Set.of("alice", "carol");
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
+        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report, false);
+
+        // "alice" (add) and "carol" (remove) fail; "dave" (remove) still succeeds despite those failures.
+        assertTrue(stub.added.isEmpty());
+        assertEquals(List.of("example-plugin-developers:dave"), stub.removed);
+
+        JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
+        JsonObject team = json.getAsJsonObject("example-plugin-developers");
+        assertEquals(2, team.getAsJsonArray("errors").size());
+    }
+
+    @Test
+    void slugifyMatchesGitHubTeamSlugConvention() {
         assertEquals("example-plugin-developers", GitHubPermissionsSyncer.slugify("example-plugin Developers"));
         assertEquals("core", GitHubPermissionsSyncer.slugify("core"));
     }
@@ -121,6 +221,9 @@ class GitHubPermissionsSyncerTest {
         String lastOrganization;
         Set<String> lastTeamSlugs;
         int fetchCalls;
+        final List<String> added = new ArrayList<>();
+        final List<String> removed = new ArrayList<>();
+        Set<String> loginsToFailOn = Set.of();
 
         StubGitHubTeamsAPI(Map<String, Set<String>> membersBySlug) {
             this.membersBySlug = membersBySlug;
@@ -133,6 +236,24 @@ class GitHubPermissionsSyncerTest {
             lastOrganization = organization;
             lastTeamSlugs = teamSlugs;
             return membersBySlug;
+        }
+
+        @Override
+        public void addTeamMember(@NonNull String organization, @NonNull String teamSlug, @NonNull String login)
+                throws IOException {
+            if (loginsToFailOn.contains(login)) {
+                throw new IOException("simulated failure adding " + login);
+            }
+            added.add(teamSlug + ":" + login);
+        }
+
+        @Override
+        public void removeTeamMember(@NonNull String organization, @NonNull String teamSlug, @NonNull String login)
+                throws IOException {
+            if (loginsToFailOn.contains(login)) {
+                throw new IOException("simulated failure removing " + login);
+            }
+            removed.add(teamSlug + ":" + login);
         }
     }
 }

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
@@ -90,6 +90,34 @@ class GitHubPermissionsSyncerTest {
     }
 
     @Test
+    void gitHubOnlyEntryAppliesToDesiredStateWithoutAnLdapId() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - github: "no-ldap-user"
+                manageGitHubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of()));
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
+        new GitHubPermissionsSyncer(true).sync(permissions, teams, report);
+
+        JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
+        JsonObject team = json.getAsJsonObject("example-plugin-developers");
+        assertEquals(
+                "[\"alice\",\"no-ldap-user\"]", team.getAsJsonArray("toAdd").toString());
+    }
+
+    @Test
     void unmanagedComponentIsNotIncludedInReport() throws IOException {
         File permissions = Files.createTempDirectory("permissions").toFile();
         permissions.deleteOnExit();

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsSyncerTest.java
@@ -1,0 +1,138 @@
+package io.jenkins.infra.repository_permissions_updater;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the report-only GitHub permissions diff generation: desired state (from opted-in YAML) vs. actual
+ * state (mocked GitHub API), with no live network access and no mutation of any kind.
+ */
+class GitHubPermissionsSyncerTest {
+
+    @AfterEach
+    void resetGitHubTeamsApi() {
+        GitHubTeamsAPI.INSTANCE = null;
+    }
+
+    @Test
+    void computesAddAndRemoveDiffForOptedInComponent() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - "bob"
+                manageGithubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of("bob", "carol")));
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
+        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report);
+
+        assertEquals("jenkinsci", stub.lastOrganization);
+        assertEquals(Set.of("example-plugin-developers"), stub.lastTeamSlugs);
+
+        JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
+        JsonObject team = json.getAsJsonObject("example-plugin-developers");
+        assertEquals("jenkinsci", team.get("organization").getAsString());
+        assertEquals("[\"alice\"]", team.getAsJsonArray("toAdd").toString());
+        assertEquals("[\"carol\"]", team.getAsJsonArray("toRemove").toString());
+    }
+
+    @Test
+    void ldapGithubMappingEntryAppliesToDesiredState() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "alice"
+                  - ldap: "someldapid"
+                    github: "bob-gh"
+                manageGithubPermissions: true
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of("example-plugin-developers", Set.of()));
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
+        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report);
+
+        JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
+        JsonObject team = json.getAsJsonObject("example-plugin-developers");
+        assertEquals("[\"alice\",\"bob-gh\"]", team.getAsJsonArray("toAdd").toString());
+    }
+
+    @Test
+    void unmanagedComponentIsNotIncludedInReport() throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        Files.writeString(new File(permissions, "plugin-example.yml").toPath(), """
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "someuser"
+                """);
+        File teams = Files.createTempDirectory("teams").toFile();
+        teams.deleteOnExit();
+
+        StubGitHubTeamsAPI stub = new StubGitHubTeamsAPI(Map.of());
+        GitHubTeamsAPI.INSTANCE = stub;
+
+        File report = new File(Files.createTempDirectory("json").toFile(), "github-permissions-diff.json");
+        GitHubPermissionsSyncer.generateDiffReport(permissions, teams, report);
+
+        assertTrue(stub.fetchCalls == 0, "Should not call the GitHub API when nothing has opted in");
+        JsonObject json = new Gson().fromJson(Files.readString(report.toPath()), JsonObject.class);
+        assertEquals(0, json.entrySet().size());
+    }
+
+    @Test
+    void slugifyMatchesGithubTeamSlugConvention() {
+        assertEquals("example-plugin-developers", GitHubPermissionsSyncer.slugify("example-plugin Developers"));
+        assertEquals("core", GitHubPermissionsSyncer.slugify("core"));
+    }
+
+    private static class StubGitHubTeamsAPI extends GitHubTeamsAPI {
+        private final Map<String, Set<String>> membersBySlug;
+        String lastOrganization;
+        Set<String> lastTeamSlugs;
+        int fetchCalls;
+
+        StubGitHubTeamsAPI(Map<String, Set<String>> membersBySlug) {
+            this.membersBySlug = membersBySlug;
+        }
+
+        @NonNull
+        @Override
+        public Map<String, Set<String>> fetchTeamMembers(@NonNull String organization, @NonNull Set<String> teamSlugs) {
+            fetchCalls++;
+            lastOrganization = organization;
+            lastTeamSlugs = teamSlugs;
+            return membersBySlug;
+        }
+    }
+}

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsValidationTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsValidationTest.java
@@ -15,11 +15,11 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the static (network-free) validation of the {@code developers} list's polymorphic entry shapes
  * (plain LDAP id strings, or {@code {ldap, github}} mappings) as well as the GitHub permissions management
- * fields ({@code manageGithubPermissions}, {@code repositoryTeam}, {@code additionalGithubTeams}). These
+ * fields ({@code manageGitHubPermissions}, {@code repositoryTeam}, {@code additionalGitHubTeams}). These
  * fields are opt-in and must not affect components that don't use them, and validation must not require any
  * GitHub API access so it stays safe for credential-free PR builds.
  */
-class GithubPermissionsValidationTest {
+class GitHubPermissionsValidationTest {
 
     private static File writeDefinition(String yaml) throws IOException {
         File permissions = Files.createTempDirectory("permissions").toFile();
@@ -37,7 +37,7 @@ class GithubPermissionsValidationTest {
     }
 
     @Test
-    void unmanagedComponentIgnoresGithubFields() {
+    void unmanagedComponentIgnoresGitHubFields() {
         assertDoesNotThrow(() -> generate("""
                 ---
                 name: "example"
@@ -45,11 +45,11 @@ class GithubPermissionsValidationTest {
     }
 
     @Test
-    void managedComponentRequiresGithubRepo() {
+    void managedComponentRequiresGitHubRepo() {
         IOException ex = assertThrows(IOException.class, () -> generate("""
                 ---
                 name: "example"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
         assertContainsCause(ex, "requires a GitHub repository");
     }
@@ -63,27 +63,27 @@ class GithubPermissionsValidationTest {
                 developers:
                   - ldap: "timja"
                     github: "timja-gh"
-                manageGithubPermissions: true
-                additionalGithubTeams:
+                manageGitHubPermissions: true
+                additionalGitHubTeams:
                   - name: "core"
                     role: "push"
                 """));
     }
 
     @Test
-    void legacyPlainStringDevelopersAreUsedAsGithubLoginsByDefault() {
+    void legacyPlainStringDevelopersAreUsedAsGitHubLoginsByDefault() {
         assertDoesNotThrow(() -> generate("""
                 ---
                 name: "example"
                 github: "jenkinsci/example-plugin"
                 developers:
                   - "timja"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
     }
 
     @Test
-    void mixOfLegacyStringsAndLdapGithubMappingsIsAllowed() {
+    void mixOfLegacyStringsAndLdapGitHubMappingsIsAllowed() {
         assertDoesNotThrow(() -> generate("""
                 ---
                 name: "example"
@@ -92,19 +92,19 @@ class GithubPermissionsValidationTest {
                   - "timja"
                   - ldap: "jetersen"
                     github: "jetersen"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
     }
 
     @Test
-    void developerMappingMustSpecifyBothLdapAndGithub() {
+    void developerMappingMustSpecifyBothLdapAndGitHub() {
         IOException ex = assertThrows(IOException.class, () -> generate("""
                 ---
                 name: "example"
                 github: "jenkinsci/example-plugin"
                 developers:
                   - ldap: "timja"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
         assertContainsCause(ex, "must specify exactly both 'ldap' and 'github'");
     }
@@ -119,7 +119,7 @@ class GithubPermissionsValidationTest {
                   - ldap: "timja"
                     github: "timja"
                     extra: "nope"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
         assertContainsCause(ex, "must specify exactly both 'ldap' and 'github'");
     }
@@ -134,13 +134,13 @@ class GithubPermissionsValidationTest {
                   - "timja"
                   - ldap: "timja"
                     github: "timja"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
         assertContainsCause(ex, "Duplicate developer");
     }
 
     @Test
-    void duplicateGithubLoginsAreRejected() {
+    void duplicateGitHubLoginsAreRejected() {
         IOException ex = assertThrows(IOException.class, () -> generate("""
                 ---
                 name: "example"
@@ -150,13 +150,13 @@ class GithubPermissionsValidationTest {
                     github: "shared-gh"
                   - ldap: "userb"
                     github: "shared-gh"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
         assertContainsCause(ex, "Duplicate GitHub user name");
     }
 
     @Test
-    void invalidGithubUsernameIsRejected() {
+    void invalidGitHubUsernameIsRejected() {
         IOException ex = assertThrows(IOException.class, () -> generate("""
                 ---
                 name: "example"
@@ -164,7 +164,7 @@ class GithubPermissionsValidationTest {
                 developers:
                   - ldap: "timja"
                     github: "not a valid name!"
-                manageGithubPermissions: true
+                manageGitHubPermissions: true
                 """));
         assertContainsCause(ex, "invalid GitHub user name");
     }
@@ -175,8 +175,8 @@ class GithubPermissionsValidationTest {
                 ---
                 name: "example"
                 github: "jenkinsci/example-plugin"
-                manageGithubPermissions: true
-                additionalGithubTeams:
+                manageGitHubPermissions: true
+                additionalGitHubTeams:
                   - name: "does-not-exist"
                     role: "push"
                 """));
@@ -189,8 +189,8 @@ class GithubPermissionsValidationTest {
                 ---
                 name: "example"
                 github: "jenkinsci/example-plugin"
-                manageGithubPermissions: true
-                additionalGithubTeams:
+                manageGitHubPermissions: true
+                additionalGitHubTeams:
                   - name: "core"
                     role: "owner"
                 """));

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsValidationTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/GitHubPermissionsValidationTest.java
@@ -106,7 +106,7 @@ class GitHubPermissionsValidationTest {
                   - ldap: "timja"
                 manageGitHubPermissions: true
                 """));
-        assertContainsCause(ex, "must specify exactly both 'ldap' and 'github'");
+        assertContainsCause(ex, "must specify either both 'ldap' and 'github'");
     }
 
     @Test
@@ -121,7 +121,20 @@ class GitHubPermissionsValidationTest {
                     extra: "nope"
                 manageGitHubPermissions: true
                 """));
-        assertContainsCause(ex, "must specify exactly both 'ldap' and 'github'");
+        assertContainsCause(ex, "must specify either both 'ldap' and 'github'");
+    }
+
+    @Test
+    void gitHubOnlyDeveloperEntryIsAccepted() throws IOException {
+        generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "timja"
+                  - github: "someuser-with-no-ldap"
+                manageGitHubPermissions: true
+                """);
     }
 
     @Test

--- a/src/test/java/io/jenkins/infra/repository_permissions_updater/GithubPermissionsValidationTest.java
+++ b/src/test/java/io/jenkins/infra/repository_permissions_updater/GithubPermissionsValidationTest.java
@@ -1,0 +1,237 @@
+package io.jenkins.infra.repository_permissions_updater;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the static (network-free) validation of the {@code developers} list's polymorphic entry shapes
+ * (plain LDAP id strings, or {@code {ldap, github}} mappings) as well as the GitHub permissions management
+ * fields ({@code manageGithubPermissions}, {@code repositoryTeam}, {@code additionalGithubTeams}). These
+ * fields are opt-in and must not affect components that don't use them, and validation must not require any
+ * GitHub API access so it stays safe for credential-free PR builds.
+ */
+class GithubPermissionsValidationTest {
+
+    private static File writeDefinition(String yaml) throws IOException {
+        File permissions = Files.createTempDirectory("permissions").toFile();
+        permissions.deleteOnExit();
+        File file = new File(permissions, "plugin-example.yml");
+        Files.writeString(file.toPath(), yaml);
+        return permissions;
+    }
+
+    private static void generate(String yaml) throws IOException {
+        File permissions = writeDefinition(yaml);
+        File payloads = Files.createTempDirectory("json").toFile();
+        payloads.deleteOnExit();
+        ArtifactoryPermissionsUpdater.doGenerateApiPayloads(permissions, payloads, new NoopArtifactoryAPI());
+    }
+
+    @Test
+    void unmanagedComponentIgnoresGithubFields() {
+        assertDoesNotThrow(() -> generate("""
+                ---
+                name: "example"
+                """));
+    }
+
+    @Test
+    void managedComponentRequiresGithubRepo() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                manageGithubPermissions: true
+                """));
+        assertContainsCause(ex, "requires a GitHub repository");
+    }
+
+    @Test
+    void validManagedComponentPasses() {
+        assertDoesNotThrow(() -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - ldap: "timja"
+                    github: "timja-gh"
+                manageGithubPermissions: true
+                additionalGithubTeams:
+                  - name: "core"
+                    role: "push"
+                """));
+    }
+
+    @Test
+    void legacyPlainStringDevelopersAreUsedAsGithubLoginsByDefault() {
+        assertDoesNotThrow(() -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "timja"
+                manageGithubPermissions: true
+                """));
+    }
+
+    @Test
+    void mixOfLegacyStringsAndLdapGithubMappingsIsAllowed() {
+        assertDoesNotThrow(() -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "timja"
+                  - ldap: "jetersen"
+                    github: "jetersen"
+                manageGithubPermissions: true
+                """));
+    }
+
+    @Test
+    void developerMappingMustSpecifyBothLdapAndGithub() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - ldap: "timja"
+                manageGithubPermissions: true
+                """));
+        assertContainsCause(ex, "must specify exactly both 'ldap' and 'github'");
+    }
+
+    @Test
+    void developerMappingRejectsUnknownKeys() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - ldap: "timja"
+                    github: "timja"
+                    extra: "nope"
+                manageGithubPermissions: true
+                """));
+        assertContainsCause(ex, "must specify exactly both 'ldap' and 'github'");
+    }
+
+    @Test
+    void duplicateLdapIdsAreRejected() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - "timja"
+                  - ldap: "timja"
+                    github: "timja"
+                manageGithubPermissions: true
+                """));
+        assertContainsCause(ex, "Duplicate developer");
+    }
+
+    @Test
+    void duplicateGithubLoginsAreRejected() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - ldap: "usera"
+                    github: "shared-gh"
+                  - ldap: "userb"
+                    github: "shared-gh"
+                manageGithubPermissions: true
+                """));
+        assertContainsCause(ex, "Duplicate GitHub user name");
+    }
+
+    @Test
+    void invalidGithubUsernameIsRejected() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                developers:
+                  - ldap: "timja"
+                    github: "not a valid name!"
+                manageGithubPermissions: true
+                """));
+        assertContainsCause(ex, "invalid GitHub user name");
+    }
+
+    @Test
+    void unknownAdditionalTeamIsRejected() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                manageGithubPermissions: true
+                additionalGithubTeams:
+                  - name: "does-not-exist"
+                    role: "push"
+                """));
+        assertContainsCause(ex, "references unknown team");
+    }
+
+    @Test
+    void invalidRoleIsRejected() {
+        IOException ex = assertThrows(IOException.class, () -> generate("""
+                ---
+                name: "example"
+                github: "jenkinsci/example-plugin"
+                manageGithubPermissions: true
+                additionalGithubTeams:
+                  - name: "core"
+                    role: "owner"
+                """));
+        assertContainsCause(ex, "invalid 'role'");
+    }
+
+    private static void assertContainsCause(IOException ex, String expected) {
+        Throwable cause = ex.getCause();
+        assertNotNull(cause);
+        assertTrue(
+                cause.getMessage() != null && cause.getMessage().contains(expected),
+                "Expected cause message to contain '" + expected + "' but was: " + cause.getMessage());
+    }
+
+    private static class NoopArtifactoryAPI extends ArtifactoryAPI {
+        @Override
+        public List<String> listGeneratedPermissionTargets() {
+            return List.of();
+        }
+
+        @Override
+        public void createOrReplacePermissionTarget(@NonNull String name, @NonNull File payloadFile) {}
+
+        @Override
+        public void deletePermissionTarget(@NonNull String target) {}
+
+        @NonNull
+        @Override
+        public List<String> listGeneratedGroups() {
+            return List.of();
+        }
+
+        @Override
+        public void createOrReplaceGroup(String name, File payloadFile) {}
+
+        @Override
+        public void deleteGroup(String group) {}
+
+        @Override
+        public String generateTokenForGroup(String username, String group, long expiresInSeconds) {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
AI assisted needs more review and testing.

Plan is:
* [x] Incremental roll-out of diff mode - tested on slack and pipeline-graph-view
* [x] Start applying a few
* [x] Test trusted.ci on this branch and make sure it runs fine permission wise
* Migration tool to backfill all permission entries - there's also an option to just use this going forwards and incrementally change it, I've updated the PR template entry to require adapting on each change.
* Diff those and ensure removals are as expected
* Mailing list post
* Enable apply in batches - enabled on slack and pipeline-graph-view so far.
* Once fully applied monitor performance
  * AI seems to think it should. be fine as GraphQL batching is used which will fetch 50 teams at once 

TODO (follow-up potentially)
* Fully implement `additionalGitHubTeams`

## Why not terraform

 1. **Full-state refresh on every plan** — Terraform re-reads every managed resource by default, not just what changed;  -target  is documented as exceptional, not for routine CI.
 2. **No GraphQL batching** — the GitHub Terraform provider is REST-based ( go-github ), issuing roughly one call per resource/team, vs. this project's custom alias-batched GraphQL (~52 requests for all 2600 teams) — a 50x+ difference in API cost for the same read.
 3. **That cost repeats every ~2-hour** cron run regardless of what changed, eating meaningfully into the rate-limit budget compared to RPU's bounded ~624 requests/day at full adoption.
 4. **State size/plan time scale with total managed resources**, not with what changed in a given PR — growing worse as adoption approaches 2000+ repos, whereas RPU has no persisted state at all.

## Testing done

* Dry-run of slack and pipeline-graph-view
  * Required adding 1 maintainer to pipeline-graph-view who I think only has GitHub, there will be quite a few of these and it will make backfill a lot easier not requiring a 1-to-1 mapping during the migration so added support for separate ldap and GitHub entries
* Apply of both above using my timja-bot account
* Teams (specifically with core)
* Duplicate entries both ldap and GitHub
* Mixed case is normalised to lowercase
