### PR TITLE
Enable CD for http-request-plugin

### DIFF
--- a/permissions/plugin-http_request.yml
+++ b/permissions/plugin-http_request.yml
@@ -5,6 +5,8 @@ issues:
   - github: *gh
 paths:
   - "org/jenkins-ci/plugins/http_request"
+cd:
+  enabled: true
 developers:
   - "janario"
   - "markewaite"


### PR DESCRIPTION
Enables JEP-229 continuous delivery for http-request-plugin per https://www.jenkins.io/doc/developer/publishing/releasing-cd/#enable-cd-permissions.

Plugin-side PR with all the necessary changes: jenkinsci/http-request-plugin#344 (cd.yaml workflow, CD versioning, release-drafter removal). A first CD release (1.657.vd86ed302a_a_55) was published with temporarily manually-configured secrets, so the infra-provisioned MAVEN_USERNAME/MAVEN_TOKEN secrets will replace those.

Context: plugin adopted 2026-09-08 (RPU #5273, issue jenkinsci/http-request-plugin#342).